### PR TITLE
updates README instructions for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,12 @@ rustup target add wasm32-unknown-unknown --toolchain nightly
 
 ```
 node_modules/react-native/scripts/ios-install-third-party.sh
+node_modules/react-native/scripts/ios-configure-glog.sh
+yarn start
+> Update Signing Team in Xcode
+> Compile in Xcode (will error)
 node_modules/react-native/third-party/glog-0.3.5/configure
+> Compile in Xcode (will work now)
 ```
 
 ### android

--- a/ios/emurgo.xcodeproj/xcshareddata/xcschemes/emurgo.xcscheme
+++ b/ios/emurgo.xcodeproj/xcshareddata/xcschemes/emurgo.xcscheme
@@ -99,6 +99,13 @@
             ReferencedContainer = "container:emurgo.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/ios/emurgo/emurgo.entitlements
+++ b/ios/emurgo/emurgo.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.default-data-protection</key>
+	<string>NSFileProtectionComplete</string>
+</dict>
+</plist>


### PR DESCRIPTION
Updates the README instructions so you can compile in iOS. 

Enabled the setting related to the usage of Biometrics, which adds the library for TouchID.

Also added a setting in the App scheme so the Xcode log is not full of non-useful information.
https://stackoverflow.com/questions/37800790/hide-strange-unwanted-xcode-logs