### PR TITLE
Refactor Transaction to be POJO + add strict server response checks

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -5,7 +5,7 @@ import {Logger} from '../utils/logging'
 import {CONFIG} from '../config'
 import {NotConnectedError, ApiError} from './errors'
 import assert from '../utils/assert'
-import {facadeTransaction} from './facade'
+import {checkAndFacadeTransactionAsync} from './facade'
 
 import type {Moment} from 'moment'
 import type {Transaction, RawUtxo} from '../types/HistoryTransaction'
@@ -75,8 +75,11 @@ export const fetchNewTxHistory = async (
     dateFrom: dateFrom.toISOString(),
   })
 
+  const transactions = await Promise.all(
+    response.map(checkAndFacadeTransactionAsync),
+  )
   return {
-    transactions: response.map(facadeTransaction),
+    transactions,
     isLast: response.length <= CONFIG.API.TX_HISTORY_RESPONSE_LIMIT,
   }
 }

--- a/src/api/facade.js
+++ b/src/api/facade.js
@@ -1,9 +1,10 @@
 // @flow
-import assert from '../utils/assert'
-import {TRANSACTION_STATUS} from '../types/HistoryTransaction'
 import moment from 'moment'
 import _ from 'lodash'
-import BigNumber from 'bignumber.js'
+
+import assert from '../utils/assert'
+import {TRANSACTION_STATUS} from '../types/HistoryTransaction'
+import {isValidAddress} from '../crypto/util'
 
 import type {Transaction, TransactionStatus} from '../types/HistoryTransaction'
 
@@ -21,48 +22,121 @@ type RawTransaction = {|
   best_block_num: string,
 |}
 
-const facadeStatus = (status: string): TransactionStatus => {
+const checkAndFacadeStatus = (status: string): TransactionStatus => {
   const mapping = {
     Successful: TRANSACTION_STATUS.SUCCESSFUL,
     Pending: TRANSACTION_STATUS.PENDING,
     Failed: TRANSACTION_STATUS.FAILED,
   }
-  assert.assert(mapping[status] != null)
+  assert.assert(mapping[status], 'Invalid status', status)
   return mapping[status]
 }
 
-export const facadeTransaction = (tx: RawTransaction): Transaction => {
+export const checkNonNegativeInt = (data: string) => {
+  // rest of the code does not catch negative values
+  const regex = /^\d+/
+  if (!regex.test(data)) return false
+
+  const parsed = parseInt(data, 10)
+  return data === parsed.toString()
+}
+
+export const checkISO8601Date = (data: string) => {
+  // ISO8601 format we want to check is exactly following
+  // "2018-11-07T17:10:21.774Z"
+  const regex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/
+  if (!regex.test(data)) return false
+  if (!moment(data).isValid()) return false
+  return data === moment(data).toISOString()
+}
+
+export const checkValidHash = (data: string) => {
+  const regex = /^[0-9a-f]{64}$/
+  return regex.test(data)
+}
+
+export const checkAndFacadeTransactionAsync = async (
+  tx: RawTransaction,
+): Promise<Transaction> => {
   assert.assert(
     tx.inputs_address.length === tx.inputs_amount.length,
     'Invalid data from server (inputs mismatch)',
+    tx.inputs_address,
+    tx.inputs_amount,
   )
   assert.assert(
     tx.outputs_address.length === tx.outputs_amount.length,
     'Invalid data from server (outputs mismatch)',
+    tx.outputs_address,
+    tx.outputs_amount,
+  )
+
+  assert.assert(
+    checkNonNegativeInt(tx.best_block_num),
+    'Invalid best_block_num',
+    tx.best_block_num,
+  )
+  const bestBlockNum = parseInt(tx.best_block_num, 10)
+
+  assert.assert(
+    tx.tx_state !== 'Successful' || checkNonNegativeInt(tx.block_num),
+    'Invalid block_num',
+    tx.block_num,
   )
 
   const blockNum = tx.block_num ? parseInt(tx.block_num, 10) : null
-  assert.assert(
-    tx.block_num ? blockNum : true,
-    `Invalid data from server (block num ${tx.block_num})`,
+
+  tx.inputs_amount.forEach((amount) => {
+    assert.assert(checkNonNegativeInt(amount), 'Invalid input amount', amount)
+  })
+
+  tx.outputs_amount.forEach((amount) => {
+    assert.assert(checkNonNegativeInt(amount), 'Invalid output amount', amount)
+  })
+
+  await Promise.all(
+    tx.inputs_address.map(async (address) => {
+      assert.assert(
+        await isValidAddress(address),
+        'Invalid input address',
+        address,
+      )
+    }),
   )
 
-  const bestBlockNum = parseInt(tx.best_block_num, 10)
-  assert.assert(bestBlockNum, 'Invalid data from server (best block num)')
+  await Promise.all(
+    tx.outputs_address.map(async (address) => {
+      assert.assert(
+        await isValidAddress(address),
+        'Invalid output address',
+        address,
+      )
+    }),
+  )
+
+  assert.assert(checkISO8601Date(tx.time), 'Invalid time', tx.time)
+
+  assert.assert(
+    checkISO8601Date(tx.last_update),
+    'Invalid last_update',
+    tx.last_update,
+  )
+
+  assert.assert(checkValidHash(tx.hash), 'Invalid hash', tx.hash)
 
   const mapAddressAmount = ([address, amount]) => ({
     address,
-    amount: new BigNumber(amount, 10),
+    amount,
   })
 
   return {
     id: tx.hash,
-    status: facadeStatus(tx.tx_state),
+    status: checkAndFacadeStatus(tx.tx_state),
     inputs: _.zip(tx.inputs_address, tx.inputs_amount).map(mapAddressAmount),
     outputs: _.zip(tx.outputs_address, tx.outputs_amount).map(mapAddressAmount),
     blockNum,
-    submittedAt: moment(tx.time),
-    lastUpdatedAt: moment(tx.last_update),
+    submittedAt: tx.time,
+    lastUpdatedAt: tx.last_update,
     bestBlockNum,
   }
 }

--- a/src/api/facade.test.js
+++ b/src/api/facade.test.js
@@ -1,0 +1,53 @@
+import jestSetup from '../jestSetup'
+
+import {checkNonNegativeInt, checkISO8601Date} from './facade'
+
+jestSetup.setup()
+
+describe('checkNonNegativeInt', () => {
+  it('can validate positive integers', () => {
+    expect(checkNonNegativeInt('0')).toBe(true)
+    expect(checkNonNegativeInt('1')).toBe(true)
+    expect(checkNonNegativeInt('9')).toBe(true)
+    expect(checkNonNegativeInt('10')).toBe(true)
+    expect(checkNonNegativeInt('1234567890')).toBe(true)
+  })
+
+  it('does not validate leading zeros', () => {
+    expect(checkNonNegativeInt('00')).toBe(false)
+    expect(checkNonNegativeInt('01')).toBe(false)
+    expect(checkNonNegativeInt('09')).toBe(false)
+  })
+
+  it('does not validate negative', () => {
+    expect(checkNonNegativeInt('-1')).toBe(false)
+  })
+
+  it('does not validate float', () => {
+    expect(checkNonNegativeInt('1.27')).toBe(false)
+  })
+
+  it('does not validate empty', () => {
+    expect(checkNonNegativeInt('')).toBe(false)
+  })
+})
+
+describe('checkISO8601Date', () => {
+  it('does validate', () => {
+    expect(checkISO8601Date('2018-11-07T17:10:21.774Z')).toBe(true)
+    expect(checkISO8601Date('2018-11-07T17:10:21.000Z')).toBe(true)
+  })
+
+  it('does not validate different format', () => {
+    expect(checkISO8601Date('2018-11-07T17:10:21Z')).toBe(false)
+  })
+
+  it('does not validate bad dates', () => {
+    expect(checkISO8601Date('2018-13-07T00:00:00.000Z')).toBe(false)
+    expect(checkISO8601Date('2018-00-00T00:00:00.000Z')).toBe(false)
+    expect(checkISO8601Date('2018-01-32T00:00:00.000Z')).toBe(false)
+    expect(checkISO8601Date('2018-01-01T25:00:00.000Z')).toBe(false)
+    expect(checkISO8601Date('2018-01-01T00:61:00.000Z')).toBe(false)
+    expect(checkISO8601Date('2018-01-01T00:00:61.000Z')).toBe(false)
+  })
+})

--- a/src/crypto/chain.js
+++ b/src/crypto/chain.js
@@ -130,20 +130,35 @@ export class AddressChain {
   _getLastBlock() {
     this._selfCheck()
     const block = _.takeRight(this.addresses, this._blockSize)
-    assert.assert(block.length === this._blockSize)
+    assert.assert(
+      block.length === this._blockSize,
+      'AddressChain::_getLastBlock(): block length',
+    )
     return block
   }
 
   async initialize() {
-    assert.assert(!this._isInitialized)
+    assert.assert(
+      !this._isInitialized,
+      'AddressChain::initialize(): !isInitialized',
+    )
     await this._discoverNewBlock()
-    assert.assert(!this._isInitialized, 'Concurrent modification')
+    assert.assert(
+      !this._isInitialized,
+      'AddressChain::initialized(): Concurrent modification',
+    )
     this._isInitialized = true
   }
 
   _selfCheck() {
-    assert.assert(this._isInitialized)
-    assert.assert(this._addresses.length % this._blockSize === 0)
+    assert.assert(
+      this._isInitialized,
+      'AddressChain::_selfCheck(): isInitialized',
+    )
+    assert.assert(
+      this._addresses.length % this._blockSize === 0,
+      'AddressChain::_selfCheck(): lengths',
+    )
   }
 
   async sync(filterFn: AsyncAddressFilter) {

--- a/src/crypto/transactionUtils.js
+++ b/src/crypto/transactionUtils.js
@@ -1,5 +1,5 @@
 // @flow
-
+import moment from 'moment'
 import {BigNumber} from 'bignumber.js'
 
 import {
@@ -13,7 +13,6 @@ import type {TransactionInfo, Transaction} from '../types/HistoryTransaction'
 
 type TransactionAssurance = 'PENDING' | 'FAILED' | 'LOW' | 'MEDIUM' | 'HIGH'
 
-// TODO(ppershing): create Flow type for this
 export const getTransactionAssurance = (
   status: $Values<typeof TRANSACTION_STATUS>,
   confirmations: number,
@@ -31,8 +30,11 @@ export const getTransactionAssurance = (
   return 'HIGH'
 }
 
-const _sum = (a: Array<{address: string, amount: BigNumber}>): BigNumber =>
-  a.reduce((acc: BigNumber, x) => acc.plus(x.amount), new BigNumber(0))
+const _sum = (a: Array<{address: string, amount: string}>): BigNumber =>
+  a.reduce(
+    (acc: BigNumber, x) => acc.plus(new BigNumber(x.amount, 10)),
+    new BigNumber(0),
+  )
 
 const _multiPartyWarningCache = {}
 
@@ -132,8 +134,8 @@ export const processTxHistoryData = (
     fee,
     confirmations,
     direction,
-    submittedAt: tx.submittedAt,
-    lastUpdatedAt: tx.lastUpdatedAt,
+    submittedAt: moment(tx.submittedAt),
+    lastUpdatedAt: moment(tx.lastUpdatedAt),
     status: tx.status,
     assurance,
   }

--- a/src/types/HistoryTransaction.js
+++ b/src/types/HistoryTransaction.js
@@ -44,12 +44,12 @@ export type TransactionInfo = {|
 export type Transaction = {|
   id: string,
   status: TransactionStatus,
-  inputs: Array<{address: string, amount: BigNumber}>,
-  outputs: Array<{address: string, amount: BigNumber}>,
+  inputs: Array<{address: string, amount: string}>,
+  outputs: Array<{address: string, amount: string}>,
   blockNum: ?number,
   bestBlockNum: number,
-  submittedAt: Moment,
-  lastUpdatedAt: Moment,
+  submittedAt: string,
+  lastUpdatedAt: string,
 |}
 
 export type RawUtxo = {|

--- a/src/utils/assert.js
+++ b/src/utils/assert.js
@@ -5,19 +5,17 @@ import {Logger} from './logging'
 
 export class AssertionFailed extends ExtendableError {}
 
-const _assert = (value: any, message: ?string) => {
+const _assert = (value: any, message: string, ...args: any) => {
   if (value) return
-  // Note(ppershing): Works in V8 (Node/jest)
-  const tmp = new Error()
-  const location = (tmp.stack || '').split('\n')[3] || ''
-  throw new AssertionFailed(message || `Assertion failed ${location}`)
+  Logger.error('Assertion failed', message, ...args)
+  throw new AssertionFailed(message)
 }
 
-export const assertTrue = (value: any, message: ?string) => {
-  _assert(value, message)
+export const assertTrue = (value: any, message: string, ...args: any) => {
+  _assert(value, message, ...args)
 }
 
-export const assertFalse = (value: any, message: ?string) => {
+export const assertFalse = (value: any, message: string) => {
   _assert(!value, message)
 }
 
@@ -29,8 +27,12 @@ export const checkIsFalse = (value: any, ...args: any) => {
   if (!value) Logger.error('Check failed', ...args)
 }
 
-export const preconditionIsTrue = (value: any, message: string) => {
-  _assert(value, `Precondition check failed: ${message}`)
+export const preconditionIsTrue = (
+  value: any,
+  message: string,
+  ...args: any
+) => {
+  _assert(value, `Precondition check failed: ${message}`, ...args)
 }
 
 export default {

--- a/src/utils/assert.test.js
+++ b/src/utils/assert.test.js
@@ -1,10 +1,13 @@
-import {assertTrue} from './assert'
+import assert from './assert'
+import {Logger, LogLevel} from './logging'
+
+Logger.setLogLevel(LogLevel.Nothing)
 
 function tryAssert() {
-  assertTrue(false)
+  assert.assert(false, 'tryAssert')
 }
 
-test('assert shows correct location', () => {
+test('assert shows correct message', () => {
   expect.assertions(1)
   try {
     tryAssert()

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -5,6 +5,7 @@ export const LogLevel = {
   Info: 1,
   Warn: 2,
   Error: 3,
+  Nothing: 4,
 }
 
 let logLevel = LogLevel.Debug


### PR DESCRIPTION
I decided to switch back to strings for following reasons:

1) We can then skip serialization/deserialization during save
2) moment and Bignumber totally clutter console logs
3) We did not really use them that much; as far as transactionCachce is concerned, it never needs to use parsed version
4) This unifies way how do we compare things (e.g., _.equals would work out of the box)

I also added some quite heavy checks on validaty of server's response -- better be strict and learn about potentially breaking API changes quickly.

Finally, I am also considering converting TransactionInfo and other selectors to produce strings. This would be beneficial for checking in shouldComponentUpdate when we start optimizing unnecessary redraws