### PR TITLE
Fix QR code reader on IOS

### DIFF
--- a/ios/emurgo/Info.plist
+++ b/ios/emurgo/Info.plist
@@ -53,5 +53,7 @@
 	<false/>
 	<key>NSFaceIDUsageDescription</key>
 	<string>Enabling Face ID allows you quick and secure access to your account.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Enabling camera allows you to scan QR codes.</string>
 </dict>
 </plist>


### PR DESCRIPTION
Request camera permission on first qr code scan.