### PR TITLE
Fix nasty bug when integral part of amount was incorrectly rounded

### DIFF
--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -11,7 +11,7 @@ export const formatAda = (amount: BigNumber) => {
 }
 
 export const formatAdaInteger = (amount: BigNumber) => {
-  const num = amount.dividedBy(MICRO)
+  const num = amount.dividedToIntegerBy(MICRO)
   return num.toFormat(0)
 }
 


### PR DESCRIPTION
It was tricky to locate because were showing "2.700000" instead of "1.7000000" only on TransactionListItem, other places seemed to have the correct value...