### PR TITLE
Missing button translation on Receive screen

### DIFF
--- a/src/l10n/en.js
+++ b/src/l10n/en.js
@@ -232,7 +232,7 @@ your wallets first',
       'Share this address to receive payments. ' +
       'To protect your privacy, new address are ' +
       'generated automatically once you use them.',
-    generateButton: 'Generate another address',
+    generate: 'Generate another address',
     cannotGenerate: 'You have to use some of your addresses',
 
     addressesList: {


### PR DESCRIPTION
We used invalid translation key on Receive screen, which caused app crashes when user navigated to Receive screen and could generate new addresses.