### PR TITLE
Fix balance after transaction on send screen

### DIFF
--- a/src/components/Send/SendScreen.js
+++ b/src/components/Send/SendScreen.js
@@ -298,6 +298,8 @@ class SendScreen extends Component<Props, State> {
       text = translations.calculatingFee
     } else if (!availableAmount) {
       text = formatAda(new BigNumber(0))
+    } else if (!amount) {
+      text = formatAda(availableAmount)
     } else {
       text = formatAda(
         availableAmount.minus(formatAda(new BigNumber(amount))).minus(fee),


### PR DESCRIPTION
Fixes #398.

Balance after transaction now shows available amount when amount field is empty