### PR TITLE
Set log level based on environment

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,5 @@
 // @flow
+import {LogLevel} from './utils/logging'
 
 const IS_DEBUG = __DEV__
 // debugging flags
@@ -30,6 +31,8 @@ export const ASSURANCE_LEVELS = {
 }
 
 const CARDANO = IS_DEBUG ? CARDANO_CONFIG.TESTNET : CARDANO_CONFIG.MAINNET
+
+const LOG_LEVEL = IS_DEBUG ? LogLevel.Debug : LogLevel.Warn
 
 export const CONFIG = {
   DEBUG: {
@@ -75,4 +78,5 @@ export const CONFIG = {
   APP_LOCK_TIMEOUT: 3000,
   START_WITH_INDEX_SCREEN: SHOW_INIT_DEBUG_SCREEN,
   ALLOW_SHORT_PASSWORD: false,
+  LOG_LEVEL,
 }

--- a/src/index.js
+++ b/src/index.js
@@ -6,8 +6,12 @@ import {name as appName} from './app.json'
 import {Provider} from 'react-redux'
 import getConfiguredStore from './helpers/configureStore'
 import {setupHooks, handleGeneralError} from './actions'
+import {setLogLevel} from './utils/logging'
+import {CONFIG} from './config'
 
 import bluebird from 'bluebird'
+
+setLogLevel(CONFIG.LOG_LEVEL)
 
 bluebird.config({
   longStackTraces: true,


### PR DESCRIPTION
We want to use higher (Warn) log level in release build, because `console.*` statements cause performance bottlenecks in bundled apps, especially on iOS.