### PR TITLE
Fix android missing lib in maven

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,6 +37,15 @@ allprojects {
     }
 }
 
+subprojects {project ->
+    if ('react-native-svg' == project.name) {
+            buildscript {
+                repositories {
+                maven { url "https://dl.bintray.com/android/android-tools/"  }
+            }    
+        }
+    }
+}
 
 task wrapper(type: Wrapper) {
     gradleVersion = '4.4'


### PR DESCRIPTION
There is a bug on current master which prevent fresh android studio installation from successfully build app.

The build process will end with:
```
A problem occurred configuring project ':react-native-svg'.
> Could not resolve all artifacts for configuration ':react-native-svg:classpath'.
   > Could not find com.android.tools.build:gradle:2.2.3.
```

If the app was previously build it will not error because you will have that jar file cached in your gradle cache.

On linux you should be able to reproduce this issue by deleting ~/.gradle/caches

It looks like there was some change in maven repositories and the "old" packages could not resolve their dependencies correctly anymore