### PR TITLE
Explicitly turn off section list sticky headers

### DIFF
--- a/src/components/TxHistory/TxHistoryList.js
+++ b/src/components/TxHistory/TxHistoryList.js
@@ -47,6 +47,7 @@ const TxHistoryList = ({transactions, navigation, refreshing, onRefresh}) => {
         )}
         sections={groupedTransactions}
         keyExtractor={(item) => item.id}
+        stickySectionHeadersEnabled={false}
       />
     </View>
   )


### PR DESCRIPTION
Sticky headers caused delayed transaction list item rendering, e.g. transactions that user already scrolled out off were still rerendered.

Fixes #560 