### PR TITLE
Fix ios instalation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ gem install cocoapods
 cd ios && pod install
 ```
 
-*Optional*: Copy your `GoogleService-Info.plist` to `ios/emurgo/` to enable Crashlytics.
+Copy your `GoogleService-Info.plist` to `ios/emurgo/` to enable Crashlytics.
 
 Setup React Native third-party libraries:
 ```


### PR DESCRIPTION
Crashlytics config file is required in ios build.