### PR TITLE
Fix Receive Screen

### DIFF
--- a/src/crypto/wallet.js
+++ b/src/crypto/wallet.js
@@ -52,7 +52,7 @@ export class Wallet {
   _externalChain: AddressChain = null
 
   _state: WalletState = {
-    lastGeneratedAddressIndex: -1,
+    lastGeneratedAddressIndex: 0,
   }
 
   _isInitialized: boolean = false
@@ -284,11 +284,6 @@ export class Wallet {
   }
 
   generateNewUiReceiveAddressIfNeeded() {
-    // generate one address when creating a new wallet
-    if (this._state.lastGeneratedAddressIndex === -1) {
-      return this.generateNewUiReceiveAddress()
-    }
-
     /* new addresse is automatically generated when you use the latest unused */
     const lastGeneratedAddress = this._externalChain.addresses[
       this._state.lastGeneratedAddressIndex

--- a/src/crypto/wallet.js
+++ b/src/crypto/wallet.js
@@ -280,9 +280,7 @@ export class Wallet {
     if (this._state.lastGeneratedAddressIndex >= maxIndex) {
       return false
     }
-    return (
-      this.numReceiveAddresses < this.externalAddresses.length
-    )
+    return this.numReceiveAddresses < this.externalAddresses.length
   }
 
   generateNewUiReceiveAddressIfNeeded() {
@@ -292,8 +290,9 @@ export class Wallet {
     }
 
     /* new addresse is automatically generated when you use the latest unused */
-    const lastGeneratedAddress
-      = this._externalChain.addresses[this._state.lastGeneratedAddressIndex]
+    const lastGeneratedAddress = this._externalChain.addresses[
+      this._state.lastGeneratedAddressIndex
+    ]
     if (!this.isUsedAddress(lastGeneratedAddress)) {
       return false
     }


### PR DESCRIPTION
The old receive screen would only show you addresses up to the first unused address in your wallet.

Now we properly show you addresses you've used as long as the gap between them is less than the bip44 gap size.

This will automatically fix all wallets already existing in production also (no extra work was needed for this)