### PR TITLE
Add precompiled targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ node_modules/react-native/scripts/ios-install-third-party.sh
 node_modules/react-native/third-party/glog-0.3.5/configure
 ```
 
+In case of problems generating the compiled targets for iOS. You can use the precompiled targets
+```
+sh install_precompiled_targets.sh
+```
+
 If you get an error of the style:
 
 `Could not list contents of '/Users/myself/yoroi-mobile/third-party/glog-0.3.5/test-driver'. Couldn't follow symbolic link.`

--- a/install_precompiled_targets.sh
+++ b/install_precompiled_targets.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# -a ./node_modules/react-native-cardano/rust/target 
+if [ -d ./node_modules/node-cardano-wallet/native/target -a -d ./node_modules/react-native-cardano/rust/target ]
+then
+    tar -xvf ./precompiled-targets/ios_and_android.zip -C ./node_modules/node-cardano-wallet/native/target
+    tar -xvf ./precompiled-targets/ios_and_android.zip -C ./node_modules/react-native-cardano/rust/target
+else
+	echo "You need to run yarn install first"
+fi


### PR DESCRIPTION
Add precompiled targets with an easy to simple bash script.

A lot of people are having issues with the Rust / Rustup / Cardano React Native setup. This files avoid having to compile the files and avoids those issues.