### PR TITLE
Fix/ci divergences

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           keys:
           - v1-0-dependencies-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
           # fallback to using the latest cache if no exact match is found
-          - v1-0-dependencies-
+          #- v1-0-dependencies-
 
       # install rustup
       - run: curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,9 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/project
+      - run:
+          name: Match bitrise's yarn version
+          command: sudo npm install -g yarn@${BITRISE_YARN_VER}
       - run: yarn flow
 
   test:
@@ -56,6 +59,9 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/project
+      - run:
+          name: Match bitrise's yarn version
+          command: sudo npm install -g yarn@${BITRISE_YARN_VER}
       - run: yarn test
 
   lint:
@@ -64,6 +70,9 @@ jobs:
       - attach_workspace:
          at: ~/project
 
+      - run:
+          name: Match bitrise's yarn version
+          command: sudo npm install -g yarn@${BITRISE_YARN_VER}
       # Because npm link will write in this path
       - run: sudo chown -R "$(whoami):$(whoami)" /usr/local/lib/node_modules
       - run: npm link rust-cardano-crypto

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,6 @@ jobs:
       - restore_cache:
           keys:
           - v1-0-dependencies-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
-          # fallback to using the latest cache if no exact match is found
-          #- v1-0-dependencies-
 
       # install rustup
       - run: curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           at: ~/project 
       - restore_cache:
           keys:
-          - v1-0-dependencies-{{ checksum "package.json" }}
+          - v1-0-dependencies-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
           # fallback to using the latest cache if no exact match is found
           - v1-0-dependencies-
 
@@ -34,7 +34,7 @@ jobs:
           name: Install Dependencies
           command: yarn install --network-concurrency 1
       - save_cache:
-          key: v1-0-dependencies-{{ checksum "package.json" }}
+          key: v1-0-dependencies-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
             - yarn.lock


### PR DESCRIPTION
This is fruit of the research done for fixing `l10n_develop` integration failures. 

Outdated branches (in e.g.: a crowdin PR coming from an "old" `develop` branch) tries to install depends from an old `yarn.lock` with a newer CI cache (coming from newer builds) and this lead to failure scenarios [[1]](https://circleci.com/gh/Emurgo/yoroi-mobile/7860) [[2]](https://circleci.com/gh/Emurgo/yoroi-mobile/7953) [[3]](https://circleci.com/gh/Emurgo/yoroi-mobile/7954).