### PR TITLE
removes ToS from state

### DIFF
--- a/src/actions/language.js
+++ b/src/actions/language.js
@@ -1,9 +1,5 @@
 // @flow
-import {
-  writeAppSettings,
-  APP_SETTINGS_KEYS,
-  loadTOS,
-} from '../helpers/appSettings'
+import {writeAppSettings, APP_SETTINGS_KEYS} from '../helpers/appSettings'
 
 import {type Dispatch} from 'redux'
 
@@ -22,25 +18,10 @@ export const changeLanguage = (languageCode: string) => (
   })
 }
 
-export const changeTOSLanguage = (tos: string) => (
-  dispatch: Dispatch<any>,
-  getState: any,
-) => {
-  dispatch({
-    path: ['tos'],
-    payload: tos,
-    reducer: (state, tos) => tos,
-    type: 'CHANGE_TOS_LANGUAGE',
-  })
-}
-
 export const changeAndSaveLanguage = (languageCode: string) => async (
   dispatch: Dispatch<any>,
 ) => {
   await writeAppSettings(APP_SETTINGS_KEYS.LANG, languageCode)
-  const tos = await loadTOS(languageCode)
-
-  dispatch(changeTOSLanguage(tos))
   dispatch(changeLanguage(languageCode))
 }
 

--- a/src/components/Common/TermsOfService.js
+++ b/src/components/Common/TermsOfService.js
@@ -3,21 +3,41 @@ import React from 'react'
 import {connect} from 'react-redux'
 import {compose} from 'redux'
 import Markdown from 'react-native-easy-markdown'
+import {loadTOS} from '../../helpers/appSettings'
 
 import type {ComponentType} from 'react'
 
 type Props = {
-  tos: any,
+  languageCode: any,
 }
 
-const TermsOfService = ({tos}: Props) => {
-  return <Markdown>{tos}</Markdown>
+type State = {
+  tos: string,
+}
+
+class TermsOfService extends React.Component<Props, State> {
+
+  constructor(props) {
+    super(props)
+    this.state = {tos: ''}
+  }
+
+  async componentDidMount() {
+    const languageCode = this.props.languageCode
+    const tos = await loadTOS(languageCode)
+    this.setState({tos}) // eslint-disable-line react/no-did-mount-set-state
+  }
+
+  render() {
+    return <Markdown>{this.state.tos}</Markdown>
+  }
+
 }
 
 export default (compose(
-  connect((state) => {
-    return {
-      tos: state.tos,
-    }
-  }),
+  connect(
+    (state) => ({
+      languageCode: state.appSettings.languageCode,
+    }),
+  )
 )(TermsOfService): ComponentType<any>)

--- a/src/components/Common/TermsOfService.js
+++ b/src/components/Common/TermsOfService.js
@@ -16,7 +16,6 @@ type State = {
 }
 
 class TermsOfService extends React.Component<Props, State> {
-
   constructor(props) {
     super(props)
     this.state = {tos: ''}
@@ -31,13 +30,10 @@ class TermsOfService extends React.Component<Props, State> {
   render() {
     return <Markdown>{this.state.tos}</Markdown>
   }
-
 }
 
 export default (compose(
-  connect(
-    (state) => ({
-      languageCode: state.appSettings.languageCode,
-    }),
-  )
+  connect((state) => ({
+    languageCode: state.appSettings.languageCode,
+  })),
 )(TermsOfService): ComponentType<any>)

--- a/src/state.js
+++ b/src/state.js
@@ -70,7 +70,6 @@ export const getInitialState = (): State => ({
   isOnline: true, // we are online by default
   isAppInitialized: false,
   isKeyboardOpen: false,
-  tos: '',
   appSettings: {
     acceptedTos: false,
     languageCode: 'en-US',


### PR DESCRIPTION
**Summary**

This is a simple refactoring that removes the whole Terms of Service text from the app state to instead retrieve it on-demand (through the component state) when the ToS component is instantiated.

**Discussion**

Removing the ToS from the app state is not straightforward from a design perspective because the ToS are retrieved from an asynchronous call. Asynchronous calls are typically associated to actions but actions are supposed to modify the state (and paradoxically, we want to remove the ToS from the state). Another alternative might have been to use a selector (of the form `languageCode => tos`) but selectors are not meant to be asynchronous (though this can be done using the `async-selector` package, we want to avoid adding new dependencies).
The approach here is simply to perform the asyn call within the component itself, in the `componentDidMount()` method which is where async calls are recommended to be placed ([1]), and save the ToS in the component state using `setState()`. Note that even if using `setState()` in `componentDidMount()` is traditionally not recommended because it triggers two consecutive `render()`, there seems to be consensus ([2]) in that this is acceptable (second rendering occurs before the browser updates the screen).

[1]: https://reactjs.org/docs/faq-ajax.html#how-can-i-make-an-ajax-call
[2]: https://github.com/airbnb/javascript/issues/684

PS: This solution may add a small lag before the ToS are loaded, but it may just be due to the fact I was testing on an emulator.