### PR TITLE
fixes incorrect pin confirmation crash

### DIFF
--- a/src/components/Common/PinRegistrationForm.js
+++ b/src/components/Common/PinRegistrationForm.js
@@ -26,7 +26,7 @@ const handlePinEnter = ({
 }) => async (pinConfirmation) => {
   if (pin !== pinConfirmation) {
     setPin('')
-    await showErrorDialog(errorMessages.pinMismatch)
+    await showErrorDialog(errorMessages.pinMismatch, intl)
 
     return true
   }


### PR DESCRIPTION
See: https://app.clubhouse.io/emurgo/story/1714/android-1-3-incorrect-pin-confirmation-crash