### PR TITLE
Update Fastlane scripts

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -25,12 +25,12 @@ platform :android do
   desc "Deploy a new staging version to Google Play"
   lane :deploy_staging do
     gradle(task: "clean assembleDevRelease")
-    upload_to_play_store
+    upload_to_play_store(track: internal)
   end
 
   desc "Deploy a new version to Google Play"
   lane :deploy_mainnet do
     gradle(task: "clean assembleMainRelease")
-    upload_to_play_store
+    upload_to_play_store(track: rollout)
   end
 end

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -25,12 +25,18 @@ platform :android do
   desc "Deploy a new staging version to Google Play"
   lane :deploy_staging do
     gradle(task: "clean assembleDevRelease")
-    upload_to_play_store(track: internal)
+    upload_to_play_store(track: 'internal')
+  end
+
+  desc "Deploy a new mainet version to Google Play"
+  lane :deploy_mainnet do
+    gradle(task: "clean assembleMainRelease")
+    upload_to_play_store(track: 'internal')
   end
 
   desc "Deploy a new version to Google Play"
-  lane :deploy_mainnet do
+  lane :release_mainnet do
     gradle(task: "clean assembleMainRelease")
-    upload_to_play_store(track: rollout)
+    upload_to_play_store(track: 'production')
   end
 end

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -22,19 +22,19 @@ platform :android do
   end
 
 
-  desc "Deploy a new staging version to Google Play"
+  desc "Deploy a new staging (devRelease) version to Google Play"
   lane :deploy_staging do
     gradle(task: "clean assembleDevRelease")
     upload_to_play_store(track: 'internal')
   end
 
-  desc "Deploy a new mainet version to Google Play"
+  desc "Deploy an internal mainnet (mainRelease) version to Google Play"
   lane :deploy_mainnet do
     gradle(task: "clean assembleMainRelease")
     upload_to_play_store(track: 'internal')
   end
 
-  desc "Deploy a new version to Google Play"
+  desc "Deploy and make available to everyone a new version (mainRelease) in Google Play"
   lane :release_mainnet do
     gradle(task: "clean assembleMainRelease")
     upload_to_play_store(track: 'production')

--- a/android/fastlane/README.md
+++ b/android/fastlane/README.md
@@ -30,6 +30,11 @@ Deploy a new staging version to Google Play
 ```
 fastlane android deploy_mainnet
 ```
+Deploy a new mainet version to Google Play
+### android release_mainnet
+```
+fastlane android release_mainnet
+```
 Deploy a new version to Google Play
 
 ----

--- a/android/fastlane/README.md
+++ b/android/fastlane/README.md
@@ -16,16 +16,11 @@ or alternatively using `brew cask install fastlane`
 
 # Available Actions
 ## Android
-### android test
+### android build
 ```
-fastlane android test
+fastlane android build
 ```
-Runs all the tests
-### android beta
-```
-fastlane android beta
-```
-Submit a new Beta Build to Crashlytics Beta
+Builds a release version
 ### android deploy_staging
 ```
 fastlane android deploy_staging

--- a/android/fastlane/README.md
+++ b/android/fastlane/README.md
@@ -25,17 +25,17 @@ Builds a release version
 ```
 fastlane android deploy_staging
 ```
-Deploy a new staging version to Google Play
+Deploy a new staging (devRelease) version to Google Play
 ### android deploy_mainnet
 ```
 fastlane android deploy_mainnet
 ```
-Deploy a new mainet version to Google Play
+Deploy an internal mainnet (mainRelease) version to Google Play
 ### android release_mainnet
 ```
 fastlane android release_mainnet
 ```
-Deploy a new version to Google Play
+Deploy and make available to everyone a new version (mainRelease) in Google Play
 
 ----
 


### PR DESCRIPTION
The scripts were missing the `track` parameter that allows to set the distribution type in Google Play.

`staging` -> internal. we don’t want to confuse users.
`mainet` -> rollout. we would need to actually push the release, which is better as a second confirmation for a new release.