### PR TITLE
Fix crash when no internet connection or wrong date/time

### DIFF
--- a/src/actions/history.js
+++ b/src/actions/history.js
@@ -1,6 +1,6 @@
 // @flow
 import walletManager, {WalletClosed} from '../crypto/wallet'
-import {Logger} from '../utils/logging'
+// import {Logger} from '../utils/logging'
 
 import {type Dispatch} from 'redux'
 
@@ -39,7 +39,7 @@ export const updateHistory = () => async (dispatch: Dispatch<any>) => {
     } else {
       // TODO(ppershing): should we set error object or just
       // some message code?
-      Logger.error('Sync error', e)
+      // Logger.error('Sync error', e)  // commented out as presumably causing crashes
       dispatch(_setSyncError(e.message))
     }
   } finally {


### PR DESCRIPTION
Apparently the crash is due to a rare bug in react-native that happens when logging an error through `console.error`. This fix prevents the crash but probably will not be needed once we upgrade to react native `0.59+`.

Consider merging in case the `0.59+` upgrade is delayed for some reason.