### PR TITLE
fixes vulnerability alerts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 # Gemfile
 source "https://rubygems.org"
-gem 'fastlane'
+gem 'fastlane', '2.127.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,11 +14,11 @@ GEM
     declarative (0.0.10)
     declarative-option (0.1.0)
     digest-crc (0.4.1)
-    domain_name (0.5.20180417)
+    domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.7.2)
+    dotenv (2.7.4)
     emoji_regex (1.0.1)
-    excon (0.64.0)
+    excon (0.65.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.6)
@@ -27,7 +27,7 @@ GEM
     faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
     fastimage (2.1.5)
-    fastlane (2.125.2)
+    fastlane (2.127.2)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -47,7 +47,7 @@ GEM
       highline (>= 1.7.2, < 2.0.0)
       json (< 3.0.0)
       jwt (~> 2.1.0)
-      mini_magick (~> 4.5.1)
+      mini_magick (>= 4.9.4, < 5.0.0)
       multi_xml (~> 0.5)
       multipart-post (~> 2.0.0)
       plist (>= 3.1.0, < 4.0.0)
@@ -75,7 +75,7 @@ GEM
       signet (~> 0.9)
     google-cloud-core (1.3.0)
       google-cloud-env (~> 1.0)
-    google-cloud-env (1.1.0)
+    google-cloud-env (1.2.0)
       faraday (~> 0.11)
     google-cloud-storage (1.16.0)
       digest-crc (~> 0.4)
@@ -99,7 +99,7 @@ GEM
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.0331)
-    mini_magick (4.5.1)
+    mini_magick (4.9.5)
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -138,7 +138,7 @@ GEM
     unf_ext (0.0.7.6)
     unicode-display_width (1.6.0)
     word_wrap (1.0.0)
-    xcodeproj (1.9.0)
+    xcodeproj (1.11.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -153,7 +153,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fastlane
+  fastlane (= 2.127.2)
 
 BUNDLED WITH
-   1.15.4
+   2.0.2

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "react-native-cardano": "https://github.com/Emurgo/react-native-cardano.git",
     "react-native-config": "^0.11.7",
     "react-native-crypto": "^2.1.2",
-    "react-native-easy-markdown": "^1.3.0",
+    "react-native-easy-markdown": "https://github.com/Emurgo/react-native-easy-markdown.git",
     "react-native-fs": "^2.11.18",
     "react-native-keychain": "3.0.0",
     "react-native-linear-gradient": "^2.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7293,12 +7293,11 @@ react-native-drawer-layout@1.3.2:
   dependencies:
     react-native-dismiss-keyboard "1.0.0"
 
-react-native-easy-markdown@^1.3.0:
+"react-native-easy-markdown@https://github.com/Emurgo/react-native-easy-markdown.git":
   version "1.3.0"
-  resolved "https://registry.yarnpkg.com/react-native-easy-markdown/-/react-native-easy-markdown-1.3.0.tgz#7694657e74eaf3ebf4a782f45a040f0334f3e338"
-  integrity sha512-hUNOdIG2M7CGifKgV9LvfKJaeq/PJZwbGNniAArosrp9pzfdD8UKF+rePUiOofu5SlD6vV9BgO7UVAYQfklk6g==
+  resolved "https://github.com/Emurgo/react-native-easy-markdown.git#5583825d104d10358de3bc5d813ef37fb2669f00"
   dependencies:
-    simple-markdown "^0.1.1"
+    simple-markdown "^0.4.4"
 
 react-native-fit-image@^1.5.2:
   version "1.5.4"
@@ -8254,10 +8253,10 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
-simple-markdown@^0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/simple-markdown/-/simple-markdown-0.1.2.tgz#3c1510fe40bd9ea067717b8a533c9cf36325b413"
-  integrity sha1-PBUQ/kC9nqBncXuKUzyc82MltBM=
+simple-markdown@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/simple-markdown/-/simple-markdown-0.4.4.tgz#9bd597bdd5c2f5a789e56a4dbf06427d76c3834f"
+  integrity sha512-ZmlNUGR1KI12sPHeQ7dQY1qM5KfOgFqClNNVO8zQ9Pg6u7gHLCPFGD+VC7MCwpGDMd1uw3Bb2TfFfR8d6bB34A==
 
 simple-plist@^0.2.1:
   version "0.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3724,9 +3724,9 @@ fsevents@^1.2.3, fsevents@^1.2.7:
     node-pre-gyp "^0.12.0"
 
 fstream@~1.0.10:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
-  integrity sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
+  integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
   dependencies:
     graceful-fs "^4.1.2"
     inherits "~2.0.0"
@@ -5387,14 +5387,14 @@ lodash.camelcase@^4.3.0:
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
 lodash.merge@^4.6.1:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
-  integrity sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lodash.mergewith@^4.6.1:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
-  integrity sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
+  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
 
 lodash.pad@^4.1.0:
   version "4.5.1"


### PR DESCRIPTION
Note:
- Vulnerability in `mini_magick` has been addressed by bumping fastlane to version 2.127.2 (see https://github.com/fastlane/fastlane/issues/15044)
- `simple-markdown` is a nested dependency from [`react-native-simple-markdown`](https://github.com/TitanInvest/react-native-easy-markdown). Unfortunately we are already in the latest version so either we fork and update the dependency or we wait for the original repo to address the problem (not likely to be done soon since no activity for ~5 months)

pending:
- [x] simple-markdown
- [x] mini-magick