### PR TITLE
fix crash when renaming wallet

### DIFF
--- a/src/components/Settings/ChangeWalletName.js
+++ b/src/components/Settings/ChangeWalletName.js
@@ -70,9 +70,9 @@ const ChangeWalletName = ({
             onChangeText={setWalletName}
             error={getWalletNameError(
               {
-                tooLong: globalMessages.walletNameErrorTooLong,
+                tooLong: intl.formatMessage(globalMessages.walletNameErrorTooLong),
                 nameAlreadyTaken:
-                  globalMessages.walletNameErrorNameAlreadyTaken,
+                  intl.formatMessage(globalMessages.walletNameErrorNameAlreadyTaken),
               },
               validationErrors,
             )}


### PR DESCRIPTION
This simple fix should prevent two crashes that occur when renaming a wallet:
- Introducing a wallet name longer than 40 chars
- Introducing a wallet name that already exists