### PR TITLE
Disable screenshots on non-sensitive screen

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -199,6 +199,8 @@ dependencies {
 
     implementation project(':react-native-background-timer')
     implementation "com.google.android.gms:play-services-base:15.0.1"
+    implementation project(':react-native-flag-secure-android')
+
 }
 
 // Run this once to be able to run the application with BUCK

--- a/android/app/src/main/java/com/emurgo/MainActivity.java
+++ b/android/app/src/main/java/com/emurgo/MainActivity.java
@@ -20,6 +20,6 @@ public class MainActivity extends ReactActivity {
     protected void onCreate(Bundle savedInstanceState) {
         SplashScreen.show(this);  
         super.onCreate(savedInstanceState);
-        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
+        // getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
     }
 }

--- a/android/app/src/main/java/com/emurgo/MainApplication.java
+++ b/android/app/src/main/java/com/emurgo/MainApplication.java
@@ -19,6 +19,7 @@ import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
 import com.facebook.soloader.SoLoader;
+import com.kristiansorens.flagsecure.FlagSecurePackage;
 
 import java.util.Arrays;
 import java.util.List;
@@ -47,7 +48,8 @@ public class MainApplication extends Application implements ReactApplication {
         new LinearGradientPackage(),
         new SvgPackage(),
         new KeyStorePackage(),
-        new BackgroundTimerPackage()
+        new BackgroundTimerPackage(),
+        new FlagSecurePackage()
       );
     }
 

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -23,5 +23,7 @@ include ':react-native-svg'
 project(':react-native-svg').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-svg/android')
 include ':react-native-background-timer'
 project(':react-native-background-timer').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-background-timer/android')
+include ':react-native-flag-secure-android'
+project(':react-native-flag-secure-android').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-flag-secure-android/android')
 
 include ':app'

--- a/package.json
+++ b/package.json
@@ -97,7 +97,8 @@
     "react-intl-translations-manager": "^5.0.3",
     "react-native-inhibit-warnings": "https://github.com/Emurgo/react-native-inhibit-warnings.git",
     "react-native-schemes-manager": "^1.0.5",
-    "react-test-renderer": "16.8.3"
+    "react-test-renderer": "16.8.3",
+    "react-native-flag-secure-android": "https://github.com/v-almonacid/react-native-flag-secure-android.git"
   },
   "resolutions": {
     "base-x": "3.0.4"

--- a/src/components/Send/SendScreen.js
+++ b/src/components/Send/SendScreen.js
@@ -50,6 +50,8 @@ import type {
 } from '../../utils/validators'
 import type {ComponentType} from 'react'
 
+import FlagSecure from 'react-native-flag-secure-android';
+
 const amountInputErrorMessages = defineMessages({
   INVALID_AMOUNT: {
     id: 'components.send.sendscreen.amountInput.error.INVALID_AMOUNT',
@@ -227,6 +229,7 @@ class SendScreen extends Component<Props, State> {
       this.handleAmountChange(CONFIG.DEBUG.SEND_AMOUNT)
     }
     this.props.navigation.setParams({onScanAddress: this.handleAddressChange})
+    FlagSecure.activate()
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -244,6 +247,11 @@ class SendScreen extends Component<Props, State> {
       this.revalidate({utxos, address, amount})
     }
   }
+
+  componentWillUnmount() {
+    FlagSecure.deactivate()
+  }
+
 
   async revalidate({utxos, address, amount}) {
     const newState = await recomputeAll({utxos, address, amount})

--- a/yarn.lock
+++ b/yarn.lock
@@ -7306,6 +7306,10 @@ react-native-fit-image@^1.5.2:
   dependencies:
     prop-types "^15.5.10"
 
+"react-native-flag-secure-android@https://github.com/v-almonacid/react-native-flag-secure-android.git":
+  version "1.0.0"
+  resolved "https://github.com/v-almonacid/react-native-flag-secure-android.git#e234251220f5d745eec8ebde3e83d4d369e81a14"
+
 react-native-fs@^2.11.18:
   version "2.13.3"
   resolved "https://registry.yarnpkg.com/react-native-fs/-/react-native-fs-2.13.3.tgz#a422f0ecd8a093a7e99d8d51ff51440e090a18a8"


### PR DESCRIPTION
Screenshots can be disabled on any given component by adding something like:
```
componentDidMount() {
    FlagSecure.activate()
  }

  componentWillUnmount() {
    FlagSecure.deactivate()
  }
```

The helper functions `FlagSecure.activate()` and `FlagSecure.deactivate()` are very simple and are written in native code (currently using a fork from third-party package, but we may just rewrite them and include them directly in our codebase to avoid an additional dependency).

The only problem I see is that most components are written as functional components, in which case the lifecycle methods are not directly available; so some non-negligible refactoring might be needed.

Note: this is just a PoC and is not ready for merge. Currently only disables screenshots in send screen.