### PR TITLE
update react-native-easy-markdown dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "react-native-cardano": "https://github.com/Emurgo/react-native-cardano.git",
     "react-native-config": "^0.11.7",
     "react-native-crypto": "^2.1.2",
-    "react-native-easy-markdown": "https://github.com/Emurgo/react-native-easy-markdown.git",
+    "react-native-easy-markdown": "1.4.1",
     "react-native-fs": "^2.11.18",
     "react-native-keychain": "3.0.0",
     "react-native-linear-gradient": "^2.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7293,9 +7293,10 @@ react-native-drawer-layout@1.3.2:
   dependencies:
     react-native-dismiss-keyboard "1.0.0"
 
-"react-native-easy-markdown@https://github.com/Emurgo/react-native-easy-markdown.git":
-  version "1.3.0"
-  resolved "https://github.com/Emurgo/react-native-easy-markdown.git#5583825d104d10358de3bc5d813ef37fb2669f00"
+react-native-easy-markdown@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/react-native-easy-markdown/-/react-native-easy-markdown-1.4.1.tgz#adfe7c8082308bf7ca4e94bbe8fb6eaa27317dfd"
+  integrity sha512-vKBPVmYtt1UNyW/c6zMJdIA9+eXqBBdqTwURktQ62DzOGhNWFq7U3IEkArSFsJjgJq3AHvaf71PtSXndGE+c5g==
   dependencies:
     simple-markdown "^0.4.4"
 


### PR DESCRIPTION
The `react-native-easy-markdown` dependency has finally been updated to point to `simple-markdown 0.4.4`,  which fixes a security issue.

We can now point back to this dependency and remove our fork.