### PR TITLE
Fix ApiError crash

### DIFF
--- a/src/components/Send/ConfirmScreen.js
+++ b/src/components/Send/ConfirmScreen.js
@@ -30,7 +30,7 @@ import {
 } from '../../actions'
 import {withNavigationTitle} from '../../utils/renderUtils'
 import {formatAdaWithSymbol, formatAdaWithText} from '../../utils/format'
-import {NetworkError} from '../../api/errors'
+import {NetworkError, ApiError} from '../../api/errors'
 
 import styles from './styles/ConfirmScreen.style'
 
@@ -99,6 +99,8 @@ const handleOnConfirm = async (
     } catch (e) {
       if (e instanceof NetworkError) {
         await showErrorDialog(errorMessages.networkError, intl)
+      } else if (e instanceof ApiError) {
+        await showErrorDialog(errorMessages.apiError, intl)
       } else {
         throw e
       }

--- a/src/i18n/global-messages.js
+++ b/src/i18n/global-messages.js
@@ -97,6 +97,18 @@ export const errorMessages = {
         'Please check your internet connection',
     },
   }),
+  apiError: defineMessages({
+    title: {
+      id: 'global.actions.dialogs.apiError.title',
+      defaultMessage: '!!!API error',
+    },
+    message: {
+      id: 'global.actions.dialogs.apiError.message',
+      defaultMessage:
+        '!!!Error received from api method call while sending transaction. ' +
+        'Please try again later or check our Twitter account (https://twitter.com/YoroiWallet)',
+    },
+  }),
   disableEasyConfirmationFirst: defineMessages({
     title: {
       id: 'global.actions.dialogs.disableEasyConfirmationFirst.title',

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -225,6 +225,8 @@
   "global.actions.dialogs.logout.noButton": "No",
   "global.actions.dialogs.logout.title": "Logout",
   "global.actions.dialogs.logout.yesButton": "Yes",
+  "global.actions.dialogs.apiError.title": "API error",
+  "global.actions.dialogs.apiError.message": "Error received from api method call while sending transaction. Please try again later or check our Twitter account (https://twitter.com/YoroiWallet)",
   "global.actions.dialogs.networkError.message": "Error connecting to the server. Please check your internet connection",
   "global.actions.dialogs.networkError.title": "Network error",
   "global.actions.dialogs.pinMismatch.message": "PINs do not match.",


### PR DESCRIPTION
This PR avoids the app from crashing when there is a bad response (ie., different from `200`) from the backend. Users should now get the following error dialog (similar messages are used in `yoroy-frontend`):

![image](https://user-images.githubusercontent.com/7271744/63711568-fc1e9880-c83b-11e9-96b1-ffc86097f4ed.png)