### PR TITLE
use git urls for fetching certificates

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -23,7 +23,7 @@ platform :ios do
     match(type: "appstore",
           app_identifier: "com.emurgo.yoroi-stag",
           verbose: true,
-          git_url: "https://github.com/Emurgo/yoroi-certs.git")
+          git_url: "git@github.com:Emurgo/yoroi-certs.git")
 
     increment_build_number(xcodeproj: "emurgo.xcodeproj")
     build_app(workspace: "emurgo.xcworkspace", scheme: "emurgo-staging")
@@ -37,7 +37,7 @@ platform :ios do
     match(type: "appstore",
           app_identifier: "com.emurgo.yoroi",
           verbose: true,
-          git_url: "https://github.com/Emurgo/yoroi-certs.git")
+          git_url: "git@github.com:Emurgo/yoroi-certs.git")
 
     increment_build_number(xcodeproj: "emurgo.xcodeproj")
     build_app(workspace: "emurgo.xcworkspace", scheme: "emurgo")

--- a/ios/fastlane/Matchfile
+++ b/ios/fastlane/Matchfile
@@ -1,3 +1,3 @@
-git_url "https://github.com/Emurgo/yoroi-certs.git"
+git_url "git@github.com:Emurgo/yoroi-certs.git"
 
 type "appstore" # The default type, can be: appstore, adhoc, enterprise or development


### PR DESCRIPTION
Use git urls instead of https urls to fetch for certificates from the certificate repo when deploying through Fastlane. This avoids a possible authentication issue, using the ssh keys (of course, ssh authentication must be set up for this work).