### PR TITLE
fix jest snapshot

### DIFF
--- a/src/api/__snapshots__/api.test.js.snap
+++ b/src/api/__snapshots__/api.test.js.snap
@@ -23,6 +23,6 @@ Object {
     },
   ],
   "status": "Successful",
-  "submittedAt": "2019-08-19T23:00:16.000Z",
+  "submittedAt": Any<String>,
 }
 `;

--- a/src/api/api.test.js
+++ b/src/api/api.test.js
@@ -28,7 +28,8 @@ describe('History API', () => {
     // $FlowFixMe it seems like toMatchSnapshot is badly typed
     expect(result.transactions[0]).toMatchSnapshot({
       bestBlockNum: expect.any(Number),
-      lastUpdatedAt: expect.any(String), // this field may change (e.g. after restarting a node)
+      lastUpdatedAt: expect.any(String), // these fields may change (e.g. after restarting a node)
+      submittedAt: expect.any(String),
     })
   })
 


### PR DESCRIPTION
Minor fix.

Context: Some tests are based on a snapshot of the Testnet which includes date fields that may slightly change in case the backend is restarted. These should be ignored.