### PR TITLE
Add shelley utxo tx support

### DIFF
--- a/src/crypto/shelley/utils.js
+++ b/src/crypto/shelley/utils.js
@@ -1,6 +1,7 @@
 // @flow
 
-import {Transaction} from 'react-native-chain-libs'
+import {Transaction, PublicKey, PrivateKey} from 'react-native-chain-libs'
+import {HdWallet} from 'react-native-cardano'
 import {BigNumber} from 'bignumber.js'
 
 export async function getTxInputTotal(tx: Transaction): Promise<BigNumber> {
@@ -9,8 +10,7 @@ export async function getTxInputTotal(tx: Transaction): Promise<BigNumber> {
   const inputs = await tx.inputs()
   for (let i = 0; i < (await inputs.size()); i++) {
     const input = await inputs.get(i)
-    // todo: input.value() not yet implemented
-    const value = new BigNumber(input.value().to_str())
+    const value = new BigNumber(await (await input.value()).to_str())
     sum = sum.plus(value)
   }
   return sum
@@ -21,10 +21,27 @@ export async function getTxOutputTotal(tx: Transaction): Promise<BigNumber> {
 
   const outputs = await tx.outputs()
   for (let i = 0; i < (await outputs.size()); i++) {
-    const output = outputs.get(i)
-    // todo: input.value() not yet implemented
-    const value = new BigNumber(output.value().to_str())
+    const output = await outputs.get(i)
+    const value = new BigNumber(await (await output.value()).to_str())
     sum = sum.plus(value)
   }
   return sum
+}
+
+// TODO: test
+export const v2SkKeyToV3Key = async (
+  v2Key: HdWallet.XPrv
+): PrivateKey => {
+  return await PrivateKey.from_extended_bytes(
+    // need to slice out the chain code from the private key
+    Buffer.from(v2Key.slice(0, 128), 'hex')
+  )
+}
+export const v2PkKeyToV3Key = async (
+  v2Key: HdWallet.XPub,
+): PublicKey => {
+  return await PublicKey.from_bytes(
+    // need to slice out the chain code from the public key
+    Buffer.from(v2Key.slice(0, 64), 'hex')
+  )
 }

--- a/src/crypto/shelley/utils.js
+++ b/src/crypto/shelley/utils.js
@@ -29,19 +29,15 @@ export async function getTxOutputTotal(tx: Transaction): Promise<BigNumber> {
 }
 
 // TODO: test
-export const v2SkKeyToV3Key = async (
-  v2Key: HdWallet.XPrv
-): PrivateKey => {
+export const v2SkKeyToV3Key = async (v2Key: HdWallet.XPrv): PrivateKey => {
   return await PrivateKey.from_extended_bytes(
     // need to slice out the chain code from the private key
-    Buffer.from(v2Key.slice(0, 128), 'hex')
+    Buffer.from(v2Key.slice(0, 128), 'hex'),
   )
 }
-export const v2PkKeyToV3Key = async (
-  v2Key: HdWallet.XPub,
-): PublicKey => {
+export const v2PkKeyToV3Key = async (v2Key: HdWallet.XPub): PublicKey => {
   return await PublicKey.from_bytes(
     // need to slice out the chain code from the public key
-    Buffer.from(v2Key.slice(0, 64), 'hex')
+    Buffer.from(v2Key.slice(0, 64), 'hex'),
   )
 }

--- a/src/crypto/shelley/utxoTransactions.js
+++ b/src/crypto/shelley/utxoTransactions.js
@@ -1,0 +1,227 @@
+// @flow
+
+/**
+  * note: the functions in this module have been borrowed from yoroi-frontend:
+  * https://github.com/Emurgo/yoroi-frontend/blob/shelley/app/api/ada/
+  * transactions/shelley/utxoTransactions.js
+ */
+
+import {InsufficientFunds} from '../errors'
+import {BigNumber} from 'bignumber.js'
+import {
+  Address,
+  Fee,
+  FragmentId,
+  Hash,
+  Input,
+  OutputPolicy,
+  TransactionBuilder,
+  TransactionFinalizer,
+  UtxoPointer,
+  Value,
+  Witness,
+} from 'react-native-chain-libs'
+
+import type {
+  V3UnsignedTransactionData,
+  Addressing,
+} from '../../types/HistoryTransaction'
+import {CARDANO_CONFIG} from '../../config'
+
+const CONFIG = CARDANO_CONFIG.SHELLEY
+
+/**
+ * This function operates on UTXOs without a way to generate the private key for them
+ * Private key needs to be added afterwards either through
+ * A) Addressing
+ * B) Having the key provided externally
+ */
+export const newAdaUnsignedTxFromUtxo = async (
+  receiver: string,
+  amount: string,
+  changeAddresses: Array<{| address: string, ...Addressing |}>,
+  allUtxos: Array<RawUtxo>,
+): Promise<V3UnsignedTransactionData> => {
+  const feeAlgorithm = await Fee.linear_fee(
+    await Value.from_str(CONFIG.LINEAR_FEE.CONSTANT),
+    await Value.from_str(CONFIG.LINEAR_FEE.COEFFICIENT),
+    await Value.from_str(CONFIG.LINEAR_FEE.CERTIFICATE),
+  )
+
+  const txBuilder = await TransactionBuilder.new_no_payload()
+  await txBuilder.add_output(
+    await Address.from_string(receiver),
+    await Value.from_str(amount)
+  )
+  const selectedUtxos = firstMatchFirstInputSelection(
+    txBuilder,
+    allUtxos,
+    feeAlgorithm
+  )
+  let transaction
+  const change = []
+  if (changeAddresses.length === 1) {
+    const changeAddress = changeAddresses[0]
+
+    /**
+     * Note: The balance of the transaction may be slightly positive.
+     * This is because the fee of adding a change address
+     * may be more expensive than the amount leftover
+     * In this case we don't add a change address
+     */
+    transaction = await txBuilder.seal_with_output_policy(
+      feeAlgorithm,
+      await OutputPolicy.one(
+        await Address.from_string(changeAddress.address)
+      )
+    )
+    // given the change address, compute how much coin will be sent to it
+    change.push(...filterToUsedChange(
+      changeAddress,
+      await transaction.outputs(),
+      selectedUtxos
+    ))
+  } else {
+    transaction = await txBuilder.seal_with_output_policy(
+      feeAlgorithm,
+      await OutputPolicy.forget()
+    )
+  }
+
+  return {
+    senderUtxos: selectedUtxos,
+    unsignedTx: transaction,
+    changeAddr: change,
+  }
+}
+
+async function firstMatchFirstInputSelection(
+  txBuilder: TransactionBuilder,
+  allUtxos: Array<RawUtxo>,
+  feeAlgorithm: Fee,
+): Promise<Array<RawUtxo>> {
+  const selectedOutputs = []
+  if (allUtxos.length === 0) {
+    throw new InsufficientFunds()
+  }
+  // add UTXOs in whatever order they're sorted until we have enough for amount+fee
+  for (let i = 0; i < allUtxos.length; i++) {
+    selectedOutputs.push(allUtxos[i])
+    await txBuilder.add_input(utxoToTxInput(allUtxos[i]))
+    // TODO: TransactionBuilder.get_balance() is not yet implemented
+    const txBalance = await txBuilder.get_balance(feeAlgorithm)
+    if (!await txBalance.is_negative()) {
+      break
+    }
+    if (i === allUtxos.length - 1) {
+      throw new InsufficientFunds()
+    }
+  }
+  return selectedOutputs
+}
+
+/**
+ * WASM doesn't explicitly tell us how much Ada will be sent to the change address
+ * so instead, we iterate over all outputs of a transaction
+ * and figure out which one was not added by us (therefore must have been added as change)
+ */
+async function filterToUsedChange(
+  changeAddr: {| address: string, ...Addressing |},
+  outputs: Outputs,
+  selectedUtxos: Array<RawUtxo>,
+): Promise<Array<{| address: string, value: void | BigNumber, ...Addressing |}>> {
+  // we should never have the change address also be an input
+  // but we handle this edge case just in case
+  const possibleDuplicates = selectedUtxos.filter((utxo) => utxo.receiver === changeAddr.address)
+
+  const change = []
+  for (let i = 0; i < await outputs.size(); i++) {
+    const output = await outputs.get(i)
+    // we can't know which bech32 prefix was used
+    // so we instead assume the suffix must match
+    const suffix = (await (await output.address()).to_string('dummy')).slice('dummy'.length)
+    const val = (await (await output.value())).to_str()
+    if (changeAddr.address.endsWith(suffix)) {
+      const indexInInput = possibleDuplicates.findIndex(
+        (utxo) => utxo.amount === val
+      )
+      if (indexInInput === -1) {
+        change.push({
+          ...changeAddr,
+          value: new BigNumber(val),
+        })
+      }
+      // remove the duplicate and keep searching
+      possibleDuplicates.splice(indexInInput, 1)
+    }
+  }
+  // note: if no element found, then no change was needed (tx was perfectly balanced)
+  return change
+}
+
+// TODO
+export const signTransaction = async (
+  signRequest: V3UnsignedTxAddressedUtxoResponse, // TODO
+  keyLevel: number,
+  signingKey: RustModule.WalletV2.PrivateKey // TODO
+): AuthenticatedTransaction => {
+  const {senderUtxos, unsignedTx} = signRequest
+  const txFinalizer = await new TransactionFinalizer(unsignedTx)
+  addWitnesses(
+    txFinalizer,
+    senderUtxos,
+    keyLevel,
+    signingKey
+  )
+  const signedTx = await txFinalizer.finalize()
+  return signedTx
+}
+
+async function utxoToTxInput(
+  utxo: RawUtxo,
+): Input {
+  const txoPointer = await UtxoPointer.new(
+    await FragmentId.from_bytes(
+      Buffer.from(utxo.tx_hash, 'hex')
+    ),
+    utxo.tx_index,
+    await Value.from_str(utxo.amount),
+  )
+  return Input.from_utxo(txoPointer)
+}
+
+// TODO
+async function addWitnesses(
+  txFinalizer: TransactionFinalizer,
+  senderUtxos: Array<AddressedUtxo>,
+  keyLevel: number,
+  signingKey: RustModule.WalletV2.PrivateKey // TODO
+): Promise<void> {
+  // get private keys
+  const privateKeys = senderUtxos.map((utxo) => {
+    const lastLevelSpecified = utxo.addressing.startLevel + utxo.addressing.path.length - 1
+    if (lastLevelSpecified !== Bip44DerivationLevels.ADDRESS.level) {
+      throw new Error('addWitnesses incorrect addressing size')
+    }
+    if (keyLevel + 1 < utxo.addressing.startLevel) {
+      throw new Error('addWitnesses keyLevel < startLevel')
+    }
+    let key = signingKey
+    for (let i = keyLevel - utxo.addressing.startLevel + 1; i < utxo.addressing.path.length; i++) {
+      key = key.derive(
+        RustModule.WalletV2.DerivationScheme.v2(), // TODO
+        utxo.addressing.path[i]
+      )
+    }
+    return key
+  })
+
+  for (let i = 0; i < senderUtxos.length; i++) {
+    const witness = Witness.for_utxo(
+      await Hash.from_hex(CONFIG.GENESISHASH),
+      txFinalizer.get_txid(),
+      v2SkKeyToV3Key(privateKeys[i]), // TODO
+    )
+    txFinalizer.set_witness(i, witness)
+  }
+}

--- a/src/crypto/shelley/utxoTransactions.test.js
+++ b/src/crypto/shelley/utxoTransactions.test.js
@@ -11,8 +11,9 @@ import type {
 import {
   newAdaUnsignedTx,
   newAdaUnsignedTxFromUtxo,
-  // signTransaction,
+  signTransaction,
 } from './utxoTransactions'
+import {getWalletFromMasterKey} from '../util'
 import {InsufficientFunds} from '../errors'
 import {getTxInputTotal, getTxOutputTotal} from './utils'
 
@@ -201,87 +202,86 @@ describe('Create unsigned TX from addresses', () => {
 
 // TODO
 
-// describe('Create signed transactions', () => {
-//   it('Witness should match on valid private key', () => {
-//     const unsignedTxResponse = newAdaUnsignedTx(
-//       keys[0].bechAddress,
-//       '5001', // smaller than input
-//       [],
-//       [addressedUtxos[0], addressedUtxos[1]],
-//     );
-//
-//     const accountPrivateKey = RustModule.WalletV2.Bip44AccountPrivate.new(
-//       RustModule.WalletV2.PrivateKey.from_hex(
-//         '70afd5ff1f7f551c481b7e3f3541f7c63f5f6bcb293af92565af3deea0bcd6481a6e7b8acbe38f3906c63ccbe8b2d9b876572651ac5d2afc0aca284d9412bb1b4839bf02e1d990056d0f06af22ce4bcca52ac00f1074324aab96bbaaaccf290d'
-//       ),
-//       RustModule.WalletV2.DerivationScheme.v2()
-//     );
-//     const signedTx = signTransaction(
-//       unsignedTxResponse,
-//       Bip44DerivationLevels.ACCOUNT.level,
-//       accountPrivateKey.key(),
-//     );
-//     const witnesses = signedTx.witnesses();
-//
-//     expect(witnesses.size()).toEqual(2);
-//     expect(witnesses.get(0).to_bech32()).toEqual(
-//       'witness1q8n7j65qjf5jraj3uqy0praq77fszhuxdsdxlagp706sh9jsz7x07gddztlx25s66lusjkjh7hlqct3d8xk6aujrhzq4rd54jnzn94ggppm0c7'
-//     );
-//     expect(witnesses.get(1).to_bech32()).toEqual(
-//       'witness1q8n7j65qjf5jraj3uqy0praq77fszhuxdsdxlagp706sh9jsz7x07gddztlx25s66lusjkjh7hlqct3d8xk6aujrhzq4rd54jnzn94ggppm0c7'
-//     );
-//   });
-//
-//   it('Witness should with addressing from root', () => {
-//     const unsignedTxResponse = newAdaUnsignedTx(
-//       keys[0].bechAddress,
-//       '5001', // smaller than input
-//       [],
-//       [
-//         {
-//           amount: '7001',
-//           receiver: 'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
-//           tx_hash: '05ec4a4a7f4645fa66886cef2e34706907a3a7f9d88e0d48b313ad2cdf76fb5f',
-//           tx_index: 0,
-//           utxo_id: '05ec4a4a7f4645fa66886cef2e34706907a3a7f9d88e0d48b313ad2cdf76fb5f0',
-//           addressing: {
-//             path: [BIP44_PURPOSE, CARDANO_COINTYPE, HARD_DERIVATION_START + 0, 0, 135],
-//             startLevel: 1
-//           }
-//         },
-//         {
-//           amount: '1000001',
-//           receiver: 'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
-//           tx_hash: '6930f123df83e4178b0324ae617b2028c0b38c6ff4660583a2abf1f7b08195fe',
-//           tx_index: 0,
-//           utxo_id: '6930f123df83e4178b0324ae617b2028c0b38c6ff4660583a2abf1f7b08195fe0',
-//           addressing: {
-//             path: [BIP44_PURPOSE, CARDANO_COINTYPE, HARD_DERIVATION_START + 0, 0, 135],
-//             startLevel: 1
-//           }
-//         }
-//       ],
-//     );
-//
-//     const accountPrivateKey = RustModule.WalletV2.Bip44AccountPrivate.new(
-//       RustModule.WalletV2.PrivateKey.from_hex(
-//         '70afd5ff1f7f551c481b7e3f3541f7c63f5f6bcb293af92565af3deea0bcd6481a6e7b8acbe38f3906c63ccbe8b2d9b876572651ac5d2afc0aca284d9412bb1b4839bf02e1d990056d0f06af22ce4bcca52ac00f1074324aab96bbaaaccf290d'
-//       ),
-//       RustModule.WalletV2.DerivationScheme.v2()
-//     );
-//     const signedTx = signTransaction(
-//       unsignedTxResponse,
-//       Bip44DerivationLevels.ACCOUNT.level,
-//       accountPrivateKey.key(),
-//     );
-//     const witnesses = signedTx.witnesses();
-//
-//     expect(witnesses.size()).toEqual(2);
-//     expect(witnesses.get(0).to_bech32()).toEqual(
-//       'witness1q8n7j65qjf5jraj3uqy0praq77fszhuxdsdxlagp706sh9jsz7x07gddztlx25s66lusjkjh7hlqct3d8xk6aujrhzq4rd54jnzn94ggppm0c7'
-//     );
-//     expect(witnesses.get(1).to_bech32()).toEqual(
-//       'witness1q8n7j65qjf5jraj3uqy0praq77fszhuxdsdxlagp706sh9jsz7x07gddztlx25s66lusjkjh7hlqct3d8xk6aujrhzq4rd54jnzn94ggppm0c7'
-//     );
-//   });
-// });
+describe('Create signed transactions', () => {
+  it('Witness should match on valid private key', async () => {
+    const unsignedTxResponse = await newAdaUnsignedTx(
+      keys[0].bechAddress,
+      '5001', // smaller than input
+      [],
+      [addressedUtxos[0], addressedUtxos[1]],
+    )
+
+    const wallet = await getWalletFromMasterKey(
+      '70afd5ff1f7f551c481b7e3f3541f7c63f5f6bcb293af92565af3deea0bcd6481a6e7b8acbe38f3906c63ccbe8b2d9b876572651ac5d2afc0aca284d9412bb1b4839bf02e1d990056d0f06af22ce4bcca52ac00f1074324aab96bbaaaccf290d',
+    )
+
+    // const signedTx = await signTransaction(
+    //   unsignedTxResponse,
+    //   wallet,
+    // )
+    await signTransaction(unsignedTxResponse, wallet)
+
+    // const witnesses = signedTx.witnesses();
+    //
+    //     expect(witnesses.size()).toEqual(2);
+    //     expect(witnesses.get(0).to_bech32()).toEqual(
+    //       'witness1q8n7j65qjf5jraj3uqy0praq77fszhuxdsdxlagp706sh9jsz7x07gddztlx25s66lusjkjh7hlqct3d8xk6aujrhzq4rd54jnzn94ggppm0c7'
+    //     );
+    //     expect(witnesses.get(1).to_bech32()).toEqual(
+    //       'witness1q8n7j65qjf5jraj3uqy0praq77fszhuxdsdxlagp706sh9jsz7x07gddztlx25s66lusjkjh7hlqct3d8xk6aujrhzq4rd54jnzn94ggppm0c7'
+    //     );
+  })
+  //
+  //   it('Witness should with addressing from root', () => {
+  //     const unsignedTxResponse = newAdaUnsignedTx(
+  //       keys[0].bechAddress,
+  //       '5001', // smaller than input
+  //       [],
+  //       [
+  //         {
+  //           amount: '7001',
+  //           receiver: 'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
+  //           tx_hash: '05ec4a4a7f4645fa66886cef2e34706907a3a7f9d88e0d48b313ad2cdf76fb5f',
+  //           tx_index: 0,
+  //           utxo_id: '05ec4a4a7f4645fa66886cef2e34706907a3a7f9d88e0d48b313ad2cdf76fb5f0',
+  //           addressing: {
+  //             path: [BIP44_PURPOSE, CARDANO_COINTYPE, HARD_DERIVATION_START + 0, 0, 135],
+  //             startLevel: 1
+  //           }
+  //         },
+  //         {
+  //           amount: '1000001',
+  //           receiver: 'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
+  //           tx_hash: '6930f123df83e4178b0324ae617b2028c0b38c6ff4660583a2abf1f7b08195fe',
+  //           tx_index: 0,
+  //           utxo_id: '6930f123df83e4178b0324ae617b2028c0b38c6ff4660583a2abf1f7b08195fe0',
+  //           addressing: {
+  //             path: [BIP44_PURPOSE, CARDANO_COINTYPE, HARD_DERIVATION_START + 0, 0, 135],
+  //             startLevel: 1
+  //           }
+  //         }
+  //       ],
+  //     );
+  //
+  //     const accountPrivateKey = RustModule.WalletV2.Bip44AccountPrivate.new(
+  //       RustModule.WalletV2.PrivateKey.from_hex(
+  //         '70afd5ff1f7f551c481b7e3f3541f7c63f5f6bcb293af92565af3deea0bcd6481a6e7b8acbe38f3906c63ccbe8b2d9b876572651ac5d2afc0aca284d9412bb1b4839bf02e1d990056d0f06af22ce4bcca52ac00f1074324aab96bbaaaccf290d'
+  //       ),
+  //       RustModule.WalletV2.DerivationScheme.v2()
+  //     );
+  //     const signedTx = signTransaction(
+  //       unsignedTxResponse,
+  //       Bip44DerivationLevels.ACCOUNT.level,
+  //       accountPrivateKey.key(),
+  //     );
+  //     const witnesses = signedTx.witnesses();
+  //
+  //     expect(witnesses.size()).toEqual(2);
+  //     expect(witnesses.get(0).to_bech32()).toEqual(
+  //       'witness1q8n7j65qjf5jraj3uqy0praq77fszhuxdsdxlagp706sh9jsz7x07gddztlx25s66lusjkjh7hlqct3d8xk6aujrhzq4rd54jnzn94ggppm0c7'
+  //     );
+  //     expect(witnesses.get(1).to_bech32()).toEqual(
+  //       'witness1q8n7j65qjf5jraj3uqy0praq77fszhuxdsdxlagp706sh9jsz7x07gddztlx25s66lusjkjh7hlqct3d8xk6aujrhzq4rd54jnzn94ggppm0c7'
+  //     );
+  //   });
+})

--- a/src/crypto/shelley/utxoTransactions.test.js
+++ b/src/crypto/shelley/utxoTransactions.test.js
@@ -1,0 +1,277 @@
+// @flow
+/* eslint-disable max-len */
+
+import jestSetup from '../../jestSetup'
+
+import type {
+  RawUtxo,
+  AddressedUtxo,
+  Addressing,
+} from '../../types/HistoryTransaction'
+import {
+  newAdaUnsignedTx,
+  newAdaUnsignedTxFromUtxo,
+  // signTransaction,
+} from './utxoTransactions'
+import {InsufficientFunds} from '../errors'
+import {
+  getTxInputTotal,
+  getTxOutputTotal,
+} from './utils'
+
+jestSetup.setup()
+
+const keys = [
+  {
+    legacyAddress: 'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
+    bechAddress: 'ca1qw8mq0p65pf028qgd32t6szeatfd9epx4jyl5jeuuswtlkyqpdguqeh83d4',
+    pubKey: '8fb03c3aa052f51c086c54bd4059ead2d2e426ac89fa4b3ce41cbfd8800b51c02623fceb96b07408531a5cb259f53845a38d6b68928e7c0c7e390f07545d0e62',
+  },
+  {
+    legacyAddress: 'Ae2tdPwUPEZ4xAL3nxLq4Py7BfS1D2tJ3u2rxZGnrAXC8TNkWhTaz41J3FN',
+    bechAddress: 'ca1q0j6cetm7zqsagm5zz5fmav9jg37n4cferj23h370kptrpfj095fxcy43lj',
+    pubKey: 'e5ac657bf0810ea37410a89df5859223e9d709c8e4a8de3e7d82b185327968939a254def91bb75e94bda9c605f7f87481082742e1e51d8858965c9a40491fc94',
+  },
+  {
+    legacyAddress: 'Ae2tdPwUPEZEtwz7LKtJn9ub8y7ireuj3sq2yUCZ57ccj6ZkJKn7xEiApV9',
+    bechAddress: 'ca1q0ewtxsk489t9g7vs64prkm0hfvz6aemtvtv57rkfwmxyp3yhtxtwhtm3gd',
+    pubKey: 'f2e59a16a9cab2a3cc86aa11db6fba582d773b5b16ca78764bb6620624baccb7c03adf6448459f2b8d5c32033a160de8b5412d1952794190c4fc6b4716a8b8eb',
+  },
+]
+
+const sampleUtxos: Array<RawUtxo> = [
+  {
+    amount: '7001',
+    receiver: 'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
+    tx_hash: '05ec4a4a7f4645fa66886cef2e34706907a3a7f9d88e0d48b313ad2cdf76fb5f',
+    tx_index: 0,
+    utxo_id: '05ec4a4a7f4645fa66886cef2e34706907a3a7f9d88e0d48b313ad2cdf76fb5f0',
+  },
+  {
+    amount: '1000001',
+    receiver: 'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
+    tx_hash: '6930f123df83e4178b0324ae617b2028c0b38c6ff4660583a2abf1f7b08195fe',
+    tx_index: 0,
+    utxo_id: '6930f123df83e4178b0324ae617b2028c0b38c6ff4660583a2abf1f7b08195fe0',
+  },
+  {
+    amount: '10000001',
+    receiver: 'Ae2tdPwUPEZ4xAL3nxLq4Py7BfS1D2tJ3u2rxZGnrAXC8TNkWhTaz41J3FN',
+    tx_hash: '0df0273e382739f8b4ae3783d81168093e78e0b48ec2c5430ff03d444806a173',
+    tx_index: 0,
+    utxo_id: '0df0273e382739f8b4ae3783d81168093e78e0b48ec2c5430ff03d444806a1730',
+  },
+]
+
+const sampleAdaAddresses: Array<{| address: string, ...Addressing |}> = [
+  {
+    address: 'ca1q0ewtxsk489t9g7vs64prkm0hfvz6aemtvtv57rkfwmxyp3yhtxtwhtm3gd',
+    addressing: {
+      account: 0,
+      change: 1,
+      index: 11,
+    },
+  },
+  {
+    address: 'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
+    addressing: {
+      account: 0,
+      change: 0,
+      index: 135,
+    },
+  },
+  {
+    address: 'Ae2tdPwUPEZ4xAL3nxLq4Py7BfS1D2tJ3u2rxZGnrAXC8TNkWhTaz41J3FN',
+    addressing: {
+      account: 0,
+      change: 0,
+      index: 134,
+    },
+  },
+]
+const addresssingMap = new Map<string, Addressing>()
+for (const address of sampleAdaAddresses) {
+  addresssingMap.set(address.address, {addressing: address.addressing})
+}
+const addressedUtxos: Array<AddressedUtxo> = sampleUtxos.map((utxo) => {
+  const addressing = addresssingMap.get(utxo.receiver)
+  if (addressing == null) throw new Error('Should never happen')
+  return {
+    ...utxo,
+    ...addressing,
+  }
+})
+
+describe('Create unsigned TX from UTXO', () => {
+  it('Should create a valid transaction withhout selection', async () => {
+    const utxos: Array<RawUtxo> = [sampleUtxos[1]]
+    const unsignedTxResponse = await newAdaUnsignedTxFromUtxo(
+      keys[0].bechAddress,
+      '5001', // smaller than input
+      [],
+      utxos
+    )
+    expect(unsignedTxResponse.senderUtxos).toEqual(utxos)
+    const inputSum = await getTxInputTotal(unsignedTxResponse.unsignedTx)
+    const outputSum = await getTxOutputTotal(unsignedTxResponse.unsignedTx)
+    expect(inputSum.toString()).toEqual('1000001')
+    expect(outputSum.toString()).toEqual('5001')
+    expect(inputSum.minus(outputSum).toString()).toEqual('995000')
+  })
+
+  it('Should fail due to insufficient funds (bigger than all inputs)', async () => {
+    const utxos: Array<RawUtxo> = [sampleUtxos[1]]
+    const promise = newAdaUnsignedTxFromUtxo(
+      keys[0].bechAddress,
+      '1900001', // bigger than input including fees
+      [],
+      utxos
+    )
+    await expect (promise).rejects.toThrow(InsufficientFunds)
+  })
+
+  it('Should fail due to insufficient funds (no inputs)', async () => {
+    const promise = newAdaUnsignedTxFromUtxo(
+      keys[0].bechAddress,
+      '1', // bigger than input including fees
+      [],
+      [],
+    )
+    await expect (promise).rejects.toThrow(InsufficientFunds)
+  })
+
+  it('Should fail due to insufficient funds (not enough to cover fees)', async () => {
+    const utxos: Array<RawUtxo> = [sampleUtxos[0]]
+    const promise = newAdaUnsignedTxFromUtxo(
+      keys[0].bechAddress,
+      '1', // bigger than input including fees
+      [],
+      utxos,
+    )
+    await expect (promise).rejects.toThrow(InsufficientFunds)
+  })
+
+
+  it('Should pick inputs when using input selection', async () => {
+    const utxos: Array<RawUtxo> = sampleUtxos
+    const unsignedTxResponse = await newAdaUnsignedTxFromUtxo(
+      keys[0].bechAddress,
+      '1001', // smaller than input
+      [sampleAdaAddresses[0]],
+      utxos
+    )
+    // input selection will only take 2 of the 3 inputs
+    // it takes 2 inputs because input selection algorithm
+    expect(unsignedTxResponse.senderUtxos).toEqual([utxos[0], utxos[1]])
+    const inputSum = await getTxInputTotal(unsignedTxResponse.unsignedTx)
+    const outputSum = await getTxOutputTotal(unsignedTxResponse.unsignedTx)
+    expect(inputSum.toString()).toEqual('1007002')
+    expect(outputSum.toString()).toEqual('851617')
+    expect(inputSum.minus(outputSum).toString()).toEqual('155385')
+  })
+})
+
+describe('Create unsigned TX from addresses', () => {
+  it('Should create a valid transaction withhout selection', async () => {
+    const unsignedTxResponse = await newAdaUnsignedTx(
+      keys[0].bechAddress,
+      '5001', // smaller than input
+      [],
+      [addressedUtxos[0], addressedUtxos[1]],
+    )
+    expect(unsignedTxResponse.senderUtxos).toEqual([addressedUtxos[0], addressedUtxos[1]])
+    const inputSum = await getTxInputTotal(unsignedTxResponse.unsignedTx)
+    const outputSum = await getTxOutputTotal(unsignedTxResponse.unsignedTx)
+    expect(inputSum.toString()).toEqual('1007002')
+    expect(outputSum.toString()).toEqual('5001')
+    expect(inputSum.minus(outputSum).toString()).toEqual('1002001')
+  })
+})
+
+// TODO
+
+
+// describe('Create signed transactions', () => {
+//   it('Witness should match on valid private key', () => {
+//     const unsignedTxResponse = newAdaUnsignedTx(
+//       keys[0].bechAddress,
+//       '5001', // smaller than input
+//       [],
+//       [addressedUtxos[0], addressedUtxos[1]],
+//     );
+//
+//     const accountPrivateKey = RustModule.WalletV2.Bip44AccountPrivate.new(
+//       RustModule.WalletV2.PrivateKey.from_hex(
+//         '70afd5ff1f7f551c481b7e3f3541f7c63f5f6bcb293af92565af3deea0bcd6481a6e7b8acbe38f3906c63ccbe8b2d9b876572651ac5d2afc0aca284d9412bb1b4839bf02e1d990056d0f06af22ce4bcca52ac00f1074324aab96bbaaaccf290d'
+//       ),
+//       RustModule.WalletV2.DerivationScheme.v2()
+//     );
+//     const signedTx = signTransaction(
+//       unsignedTxResponse,
+//       Bip44DerivationLevels.ACCOUNT.level,
+//       accountPrivateKey.key(),
+//     );
+//     const witnesses = signedTx.witnesses();
+//
+//     expect(witnesses.size()).toEqual(2);
+//     expect(witnesses.get(0).to_bech32()).toEqual(
+//       'witness1q8n7j65qjf5jraj3uqy0praq77fszhuxdsdxlagp706sh9jsz7x07gddztlx25s66lusjkjh7hlqct3d8xk6aujrhzq4rd54jnzn94ggppm0c7'
+//     );
+//     expect(witnesses.get(1).to_bech32()).toEqual(
+//       'witness1q8n7j65qjf5jraj3uqy0praq77fszhuxdsdxlagp706sh9jsz7x07gddztlx25s66lusjkjh7hlqct3d8xk6aujrhzq4rd54jnzn94ggppm0c7'
+//     );
+//   });
+//
+//   it('Witness should with addressing from root', () => {
+//     const unsignedTxResponse = newAdaUnsignedTx(
+//       keys[0].bechAddress,
+//       '5001', // smaller than input
+//       [],
+//       [
+//         {
+//           amount: '7001',
+//           receiver: 'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
+//           tx_hash: '05ec4a4a7f4645fa66886cef2e34706907a3a7f9d88e0d48b313ad2cdf76fb5f',
+//           tx_index: 0,
+//           utxo_id: '05ec4a4a7f4645fa66886cef2e34706907a3a7f9d88e0d48b313ad2cdf76fb5f0',
+//           addressing: {
+//             path: [BIP44_PURPOSE, CARDANO_COINTYPE, HARD_DERIVATION_START + 0, 0, 135],
+//             startLevel: 1
+//           }
+//         },
+//         {
+//           amount: '1000001',
+//           receiver: 'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
+//           tx_hash: '6930f123df83e4178b0324ae617b2028c0b38c6ff4660583a2abf1f7b08195fe',
+//           tx_index: 0,
+//           utxo_id: '6930f123df83e4178b0324ae617b2028c0b38c6ff4660583a2abf1f7b08195fe0',
+//           addressing: {
+//             path: [BIP44_PURPOSE, CARDANO_COINTYPE, HARD_DERIVATION_START + 0, 0, 135],
+//             startLevel: 1
+//           }
+//         }
+//       ],
+//     );
+//
+//     const accountPrivateKey = RustModule.WalletV2.Bip44AccountPrivate.new(
+//       RustModule.WalletV2.PrivateKey.from_hex(
+//         '70afd5ff1f7f551c481b7e3f3541f7c63f5f6bcb293af92565af3deea0bcd6481a6e7b8acbe38f3906c63ccbe8b2d9b876572651ac5d2afc0aca284d9412bb1b4839bf02e1d990056d0f06af22ce4bcca52ac00f1074324aab96bbaaaccf290d'
+//       ),
+//       RustModule.WalletV2.DerivationScheme.v2()
+//     );
+//     const signedTx = signTransaction(
+//       unsignedTxResponse,
+//       Bip44DerivationLevels.ACCOUNT.level,
+//       accountPrivateKey.key(),
+//     );
+//     const witnesses = signedTx.witnesses();
+//
+//     expect(witnesses.size()).toEqual(2);
+//     expect(witnesses.get(0).to_bech32()).toEqual(
+//       'witness1q8n7j65qjf5jraj3uqy0praq77fszhuxdsdxlagp706sh9jsz7x07gddztlx25s66lusjkjh7hlqct3d8xk6aujrhzq4rd54jnzn94ggppm0c7'
+//     );
+//     expect(witnesses.get(1).to_bech32()).toEqual(
+//       'witness1q8n7j65qjf5jraj3uqy0praq77fszhuxdsdxlagp706sh9jsz7x07gddztlx25s66lusjkjh7hlqct3d8xk6aujrhzq4rd54jnzn94ggppm0c7'
+//     );
+//   });
+// });

--- a/src/crypto/shelley/utxoTransactions.test.js
+++ b/src/crypto/shelley/utxoTransactions.test.js
@@ -122,8 +122,8 @@ describe('Create unsigned TX from UTXO', () => {
       utxos,
     )
     expect(unsignedTxResponse.senderUtxos).toEqual(utxos)
-    const inputSum = await getTxInputTotal(unsignedTxResponse.unsignedTx)
-    const outputSum = await getTxOutputTotal(unsignedTxResponse.unsignedTx)
+    const inputSum = await getTxInputTotal(unsignedTxResponse.IOs)
+    const outputSum = await getTxOutputTotal(unsignedTxResponse.IOs)
     expect(inputSum.toString()).toEqual('1000001')
     expect(outputSum.toString()).toEqual('5001')
     expect(inputSum.minus(outputSum).toString()).toEqual('995000')
@@ -172,8 +172,8 @@ describe('Create unsigned TX from UTXO', () => {
     // input selection will only take 2 of the 3 inputs
     // it takes 2 inputs because input selection algorithm
     expect(unsignedTxResponse.senderUtxos).toEqual([utxos[0], utxos[1]])
-    const inputSum = await getTxInputTotal(unsignedTxResponse.unsignedTx)
-    const outputSum = await getTxOutputTotal(unsignedTxResponse.unsignedTx)
+    const inputSum = await getTxInputTotal(unsignedTxResponse.IOs)
+    const outputSum = await getTxOutputTotal(unsignedTxResponse.IOs)
     expect(inputSum.toString()).toEqual('1007002')
     expect(outputSum.toString()).toEqual('851617')
     expect(inputSum.minus(outputSum).toString()).toEqual('155385')
@@ -192,8 +192,8 @@ describe('Create unsigned TX from addresses', () => {
       addressedUtxos[0],
       addressedUtxos[1],
     ])
-    const inputSum = await getTxInputTotal(unsignedTxResponse.unsignedTx)
-    const outputSum = await getTxOutputTotal(unsignedTxResponse.unsignedTx)
+    const inputSum = await getTxInputTotal(unsignedTxResponse.IOs)
+    const outputSum = await getTxOutputTotal(unsignedTxResponse.IOs)
     expect(inputSum.toString()).toEqual('1007002')
     expect(outputSum.toString()).toEqual('5001')
     expect(inputSum.minus(outputSum).toString()).toEqual('1002001')

--- a/src/crypto/shelley/utxoTransactions.test.js
+++ b/src/crypto/shelley/utxoTransactions.test.js
@@ -14,28 +14,34 @@ import {
   // signTransaction,
 } from './utxoTransactions'
 import {InsufficientFunds} from '../errors'
-import {
-  getTxInputTotal,
-  getTxOutputTotal,
-} from './utils'
+import {getTxInputTotal, getTxOutputTotal} from './utils'
 
 jestSetup.setup()
 
 const keys = [
   {
-    legacyAddress: 'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
-    bechAddress: 'ca1qw8mq0p65pf028qgd32t6szeatfd9epx4jyl5jeuuswtlkyqpdguqeh83d4',
-    pubKey: '8fb03c3aa052f51c086c54bd4059ead2d2e426ac89fa4b3ce41cbfd8800b51c02623fceb96b07408531a5cb259f53845a38d6b68928e7c0c7e390f07545d0e62',
+    legacyAddress:
+      'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
+    bechAddress:
+      'ca1qw8mq0p65pf028qgd32t6szeatfd9epx4jyl5jeuuswtlkyqpdguqeh83d4',
+    pubKey:
+      '8fb03c3aa052f51c086c54bd4059ead2d2e426ac89fa4b3ce41cbfd8800b51c02623fceb96b07408531a5cb259f53845a38d6b68928e7c0c7e390f07545d0e62',
   },
   {
-    legacyAddress: 'Ae2tdPwUPEZ4xAL3nxLq4Py7BfS1D2tJ3u2rxZGnrAXC8TNkWhTaz41J3FN',
-    bechAddress: 'ca1q0j6cetm7zqsagm5zz5fmav9jg37n4cferj23h370kptrpfj095fxcy43lj',
-    pubKey: 'e5ac657bf0810ea37410a89df5859223e9d709c8e4a8de3e7d82b185327968939a254def91bb75e94bda9c605f7f87481082742e1e51d8858965c9a40491fc94',
+    legacyAddress:
+      'Ae2tdPwUPEZ4xAL3nxLq4Py7BfS1D2tJ3u2rxZGnrAXC8TNkWhTaz41J3FN',
+    bechAddress:
+      'ca1q0j6cetm7zqsagm5zz5fmav9jg37n4cferj23h370kptrpfj095fxcy43lj',
+    pubKey:
+      'e5ac657bf0810ea37410a89df5859223e9d709c8e4a8de3e7d82b185327968939a254def91bb75e94bda9c605f7f87481082742e1e51d8858965c9a40491fc94',
   },
   {
-    legacyAddress: 'Ae2tdPwUPEZEtwz7LKtJn9ub8y7ireuj3sq2yUCZ57ccj6ZkJKn7xEiApV9',
-    bechAddress: 'ca1q0ewtxsk489t9g7vs64prkm0hfvz6aemtvtv57rkfwmxyp3yhtxtwhtm3gd',
-    pubKey: 'f2e59a16a9cab2a3cc86aa11db6fba582d773b5b16ca78764bb6620624baccb7c03adf6448459f2b8d5c32033a160de8b5412d1952794190c4fc6b4716a8b8eb',
+    legacyAddress:
+      'Ae2tdPwUPEZEtwz7LKtJn9ub8y7ireuj3sq2yUCZ57ccj6ZkJKn7xEiApV9',
+    bechAddress:
+      'ca1q0ewtxsk489t9g7vs64prkm0hfvz6aemtvtv57rkfwmxyp3yhtxtwhtm3gd',
+    pubKey:
+      'f2e59a16a9cab2a3cc86aa11db6fba582d773b5b16ca78764bb6620624baccb7c03adf6448459f2b8d5c32033a160de8b5412d1952794190c4fc6b4716a8b8eb',
   },
 ]
 
@@ -45,25 +51,28 @@ const sampleUtxos: Array<RawUtxo> = [
     receiver: 'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
     tx_hash: '05ec4a4a7f4645fa66886cef2e34706907a3a7f9d88e0d48b313ad2cdf76fb5f',
     tx_index: 0,
-    utxo_id: '05ec4a4a7f4645fa66886cef2e34706907a3a7f9d88e0d48b313ad2cdf76fb5f0',
+    utxo_id:
+      '05ec4a4a7f4645fa66886cef2e34706907a3a7f9d88e0d48b313ad2cdf76fb5f0',
   },
   {
     amount: '1000001',
     receiver: 'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
     tx_hash: '6930f123df83e4178b0324ae617b2028c0b38c6ff4660583a2abf1f7b08195fe',
     tx_index: 0,
-    utxo_id: '6930f123df83e4178b0324ae617b2028c0b38c6ff4660583a2abf1f7b08195fe0',
+    utxo_id:
+      '6930f123df83e4178b0324ae617b2028c0b38c6ff4660583a2abf1f7b08195fe0',
   },
   {
     amount: '10000001',
     receiver: 'Ae2tdPwUPEZ4xAL3nxLq4Py7BfS1D2tJ3u2rxZGnrAXC8TNkWhTaz41J3FN',
     tx_hash: '0df0273e382739f8b4ae3783d81168093e78e0b48ec2c5430ff03d444806a173',
     tx_index: 0,
-    utxo_id: '0df0273e382739f8b4ae3783d81168093e78e0b48ec2c5430ff03d444806a1730',
+    utxo_id:
+      '0df0273e382739f8b4ae3783d81168093e78e0b48ec2c5430ff03d444806a1730',
   },
 ]
 
-const sampleAdaAddresses: Array<{| address: string, ...Addressing |}> = [
+const sampleAdaAddresses: Array<{|address: string, ...Addressing|}> = [
   {
     address: 'ca1q0ewtxsk489t9g7vs64prkm0hfvz6aemtvtv57rkfwmxyp3yhtxtwhtm3gd',
     addressing: {
@@ -109,7 +118,7 @@ describe('Create unsigned TX from UTXO', () => {
       keys[0].bechAddress,
       '5001', // smaller than input
       [],
-      utxos
+      utxos,
     )
     expect(unsignedTxResponse.senderUtxos).toEqual(utxos)
     const inputSum = await getTxInputTotal(unsignedTxResponse.unsignedTx)
@@ -125,9 +134,9 @@ describe('Create unsigned TX from UTXO', () => {
       keys[0].bechAddress,
       '1900001', // bigger than input including fees
       [],
-      utxos
+      utxos,
     )
-    await expect (promise).rejects.toThrow(InsufficientFunds)
+    await expect(promise).rejects.toThrow(InsufficientFunds)
   })
 
   it('Should fail due to insufficient funds (no inputs)', async () => {
@@ -137,7 +146,7 @@ describe('Create unsigned TX from UTXO', () => {
       [],
       [],
     )
-    await expect (promise).rejects.toThrow(InsufficientFunds)
+    await expect(promise).rejects.toThrow(InsufficientFunds)
   })
 
   it('Should fail due to insufficient funds (not enough to cover fees)', async () => {
@@ -148,9 +157,8 @@ describe('Create unsigned TX from UTXO', () => {
       [],
       utxos,
     )
-    await expect (promise).rejects.toThrow(InsufficientFunds)
+    await expect(promise).rejects.toThrow(InsufficientFunds)
   })
-
 
   it('Should pick inputs when using input selection', async () => {
     const utxos: Array<RawUtxo> = sampleUtxos
@@ -158,7 +166,7 @@ describe('Create unsigned TX from UTXO', () => {
       keys[0].bechAddress,
       '1001', // smaller than input
       [sampleAdaAddresses[0]],
-      utxos
+      utxos,
     )
     // input selection will only take 2 of the 3 inputs
     // it takes 2 inputs because input selection algorithm
@@ -179,7 +187,10 @@ describe('Create unsigned TX from addresses', () => {
       [],
       [addressedUtxos[0], addressedUtxos[1]],
     )
-    expect(unsignedTxResponse.senderUtxos).toEqual([addressedUtxos[0], addressedUtxos[1]])
+    expect(unsignedTxResponse.senderUtxos).toEqual([
+      addressedUtxos[0],
+      addressedUtxos[1],
+    ])
     const inputSum = await getTxInputTotal(unsignedTxResponse.unsignedTx)
     const outputSum = await getTxOutputTotal(unsignedTxResponse.unsignedTx)
     expect(inputSum.toString()).toEqual('1007002')
@@ -189,7 +200,6 @@ describe('Create unsigned TX from addresses', () => {
 })
 
 // TODO
-
 
 // describe('Create signed transactions', () => {
 //   it('Witness should match on valid private key', () => {

--- a/src/types/HistoryTransaction.js
+++ b/src/types/HistoryTransaction.js
@@ -57,8 +57,8 @@ export type Addressing = {|
     account: number,
     change: number,
     index: number,
-    },
-    |}
+  },
+|}
 
 export type RawUtxo = {|
   amount: string,
@@ -102,13 +102,17 @@ export type V3UnsignedTxData = {|
   unsignedTx: V3Transaction,
   changeAddr: Array<{|
     address: string,
-    value: string,
-    ...Addressing
+    value: void | BigNumber,
+    ...Addressing,
   |}>,
 |}
 
 export type V3UnsignedTxAddressedUtxoData = {|
   senderUtxos: Array<AddressedUtxo>,
   unsignedTx: V3Transaction,
-  changeAddr: Array<{| address: string, value: string, ...Addressing |}>,
+  changeAddr: Array<{|
+    address: string,
+    value: void | BigNumber,
+    ...Addressing,
+  |}>,
 |}

--- a/src/types/HistoryTransaction.js
+++ b/src/types/HistoryTransaction.js
@@ -52,6 +52,14 @@ export type Transaction = {|
   lastUpdatedAt: string,
 |}
 
+export type Addressing = {|
+  addressing: {
+    account: number,
+    change: number,
+    index: number,
+    },
+    |}
+
 export type RawUtxo = {|
   amount: string,
   receiver: string,
@@ -60,12 +68,9 @@ export type RawUtxo = {|
   utxo_id: string,
 |}
 
-export type Addressing = {|
-  addressing: {
-    account: number,
-    change: number,
-    index: number,
-  },
+export type AddressedUtxo = {|
+  ...RawUtxo,
+  ...Addressing,
 |}
 
 export type TransactionOutput = {|
@@ -92,7 +97,7 @@ export type PreparedTransactionData = {|
   outputs: Array<TransactionOutput>,
 |}
 
-export type V3UnsignedTransactionData = {|
+export type V3UnsignedTxData = {|
   senderUtxos: Array<RawUtxo>,
   unsignedTx: V3Transaction,
   changeAddr: Array<{|
@@ -100,4 +105,10 @@ export type V3UnsignedTransactionData = {|
     value: string,
     ...Addressing
   |}>,
+|}
+
+export type V3UnsignedTxAddressedUtxoData = {|
+  senderUtxos: Array<AddressedUtxo>,
+  unsignedTx: V3Transaction,
+  changeAddr: Array<{| address: string, value: string, ...Addressing |}>,
 |}

--- a/src/types/HistoryTransaction.js
+++ b/src/types/HistoryTransaction.js
@@ -1,5 +1,5 @@
 // @flow
-import {Transaction as V3Transaction} from 'react-native-chain-libs'
+import {InputOutput} from 'react-native-chain-libs'
 import {BigNumber} from 'bignumber.js'
 
 export const TRANSACTION_DIRECTION = {
@@ -99,7 +99,7 @@ export type PreparedTransactionData = {|
 
 export type V3UnsignedTxData = {|
   senderUtxos: Array<RawUtxo>,
-  unsignedTx: V3Transaction,
+  IOs: InputOutput,
   changeAddr: Array<{|
     address: string,
     value: void | BigNumber,
@@ -109,7 +109,7 @@ export type V3UnsignedTxData = {|
 
 export type V3UnsignedTxAddressedUtxoData = {|
   senderUtxos: Array<AddressedUtxo>,
-  unsignedTx: V3Transaction,
+  IOs: InputOutput,
   changeAddr: Array<{|
     address: string,
     value: void | BigNumber,

--- a/src/types/HistoryTransaction.js
+++ b/src/types/HistoryTransaction.js
@@ -1,4 +1,5 @@
 // @flow
+import {Transaction as V3Transaction} from 'react-native-chain-libs'
 import {BigNumber} from 'bignumber.js'
 
 export const TRANSACTION_DIRECTION = {
@@ -59,6 +60,14 @@ export type RawUtxo = {|
   utxo_id: string,
 |}
 
+export type Addressing = {|
+  addressing: {
+    account: number,
+    change: number,
+    index: number,
+  },
+|}
+
 export type TransactionOutput = {|
   address: string,
   value: string,
@@ -73,11 +82,7 @@ export type TransactionInput = {|
     address: string,
     value: string,
   },
-  addressing: {
-    account: number,
-    change: number,
-    index: number,
-  },
+  ...Addressing,
 |}
 
 export type PreparedTransactionData = {|
@@ -85,4 +90,14 @@ export type PreparedTransactionData = {|
   fee: BigNumber,
   inputs: Array<TransactionInput>,
   outputs: Array<TransactionOutput>,
+|}
+
+export type V3UnsignedTransactionData = {|
+  senderUtxos: Array<RawUtxo>,
+  unsignedTx: V3Transaction,
+  changeAddr: Array<{|
+    address: string,
+    value: string,
+    ...Addressing
+  |}>,
 |}


### PR DESCRIPTION
This PR implements the basic functions (creating unsigned tx, sign tx) for bip44 utxo transactions in Shelley. It combines v1 and v3 rust bindings.

The functions are borrowed from yoroi-frontend and adapted for asynchronous rust calls, v1 rust, and legacy types in mobile.

TODO:
- [x] update libs and transaction building acording to new format
- [ ] finish tests (will do on separate PR)
- [ ] some refactoring for Byron txs (will do on separate PR)
