### PR TITLE
add TransferSummaryScreen and fixes routing problem

### DIFF
--- a/src/RoutesList.js
+++ b/src/RoutesList.js
@@ -57,6 +57,17 @@ export const WALLET_ROUTES = {
   SETTINGS: SETTINGS_ROUTES.MAIN,
 }
 
+export const STAKING_CENTER_ROUTES = {
+  MAIN: 'staking-center-main',
+}
+
+// temporary add a 'transfer-summary' route for showing
+// balance check
+export const DELEGATION_SUMMARY_ROUTES = {
+  MAIN: 'delegation-summary-main',
+  TRANSFER_SUMMARY: 'transfer-summary',
+}
+
 export const SHELLEY_WALLET_ROUTES = {
   STAKING_CENTER: 'staking-center',
   DELEGATION_SUMMARY: 'delegation-summary',

--- a/src/components/Delegation/DelegationNavigatorCenter.js
+++ b/src/components/Delegation/DelegationNavigatorCenter.js
@@ -2,7 +2,7 @@
 import React from 'react'
 import {createStackNavigator} from 'react-navigation'
 import DelegationCenter from './DelegationCenter'
-import {SHELLEY_WALLET_ROUTES} from '../../RoutesList'
+import {STAKING_CENTER_ROUTES} from '../../RoutesList'
 
 import {
   defaultNavigationOptions,
@@ -13,7 +13,7 @@ import HeaderBackButton from '../UiKit/HeaderBackButton'
 
 const DelegationNavigatorCenter = createStackNavigator(
   {
-    [SHELLEY_WALLET_ROUTES.STAKING_CENTER]: {
+    [STAKING_CENTER_ROUTES.MAIN]: {
       screen: DelegationCenter,
       navigationOptions: ({navigation}) => ({
         title: navigation.getParam('title'),
@@ -22,7 +22,7 @@ const DelegationNavigatorCenter = createStackNavigator(
     },
   },
   {
-    initialRouteName: SHELLEY_WALLET_ROUTES.STAKING_CENTER,
+    initialRouteName: STAKING_CENTER_ROUTES.MAIN,
     navigationOptions: ({navigation}) => ({
       title: navigation.getParam('title'),
       headerLeft: <HeaderBackButton navigation={navigation} />,

--- a/src/components/Delegation/DelegationNavigatorSummary.js
+++ b/src/components/Delegation/DelegationNavigatorSummary.js
@@ -3,20 +3,30 @@ import React from 'react'
 import {Button} from '../UiKit'
 import {createStackNavigator} from 'react-navigation'
 import DelegationSummary from './DelegationSummary'
-import {SHELLEY_WALLET_ROUTES, WALLET_ROUTES} from '../../RoutesList'
+import TransferSummaryScreen from './TransferSummaryScreen'
+import {DELEGATION_SUMMARY_ROUTES, WALLET_ROUTES} from '../../RoutesList'
 import SettingsScreenNavigator from '../Settings/SettingsScreenNavigator'
 import iconGear from '../../assets/img/gear.png'
 
 import {
   defaultNavigationOptions,
   defaultStackNavigatorOptions,
+  shelleyNavigationOptions,
 } from '../../navigationOptions'
 
 import styles from '../TxHistory/styles/SettingsButton.style'
 
 const DelegationNavigatorSummary = createStackNavigator(
   {
-    [SHELLEY_WALLET_ROUTES.DELEGATION_SUMMARY]: {
+    [DELEGATION_SUMMARY_ROUTES.TRANSFER_SUMMARY]: {
+      screen: TransferSummaryScreen,
+      navigationOptions: ({navigation}) => ({
+        title: navigation.getParam('title'),
+        ...defaultNavigationOptions,
+        ...shelleyNavigationOptions,
+      }),
+    },
+    [DELEGATION_SUMMARY_ROUTES.MAIN]: {
       screen: DelegationSummary,
       navigationOptions: ({navigation}) => ({
         title: navigation.getParam('title'),
@@ -30,6 +40,7 @@ const DelegationNavigatorSummary = createStackNavigator(
           />
         ),
         ...defaultNavigationOptions,
+        ...shelleyNavigationOptions,
       }),
     },
     [WALLET_ROUTES.SETTINGS]: {
@@ -37,11 +48,12 @@ const DelegationNavigatorSummary = createStackNavigator(
       navigationOptions: {
         header: null,
         ...defaultNavigationOptions,
+        ...shelleyNavigationOptions,
       },
     },
   },
   {
-    initialRouteName: SHELLEY_WALLET_ROUTES.DELEGATION_SUMMARY,
+    initialRouteName: DELEGATION_SUMMARY_ROUTES.TRANSFER_SUMMARY,
     ...defaultStackNavigatorOptions,
   },
 )

--- a/src/components/Delegation/TransferSummaryScreen.js
+++ b/src/components/Delegation/TransferSummaryScreen.js
@@ -1,0 +1,154 @@
+// @flow
+
+// TODO
+// this is just a placeholder, a clone of TxHistory.js
+
+import React from 'react'
+import type {ComponentType} from 'react'
+import {connect} from 'react-redux'
+import {compose} from 'redux'
+import {View, RefreshControl, ScrollView, Image} from 'react-native'
+import {SafeAreaView} from 'react-navigation'
+import _ from 'lodash'
+import {injectIntl, defineMessages} from 'react-intl'
+
+import {Text, Banner, OfflineBanner, StatusBar} from '../UiKit'
+import {
+  transactionsInfoSelector,
+  isSynchronizingHistorySelector,
+  lastHistorySyncErrorSelector,
+  isOnlineSelector,
+  availableAmountSelector,
+  walletNameSelector,
+  languageSelector,
+} from '../../selectors'
+import TxHistoryList from '../TxHistory/TxHistoryList'
+import TxNavigationButtons from '../TxHistory/TxNavigationButtons'
+import {updateHistory} from '../../actions/history'
+import {
+  onDidMount,
+  requireInitializedWallet,
+  withNavigationTitle,
+} from '../../utils/renderUtils'
+
+import {formatAdaWithText} from '../../utils/format'
+import image from '../../assets/img/no_transactions.png'
+
+import styles from '../TxHistory/styles/TxHistory.style'
+
+import type {Navigation} from '../../types/navigation'
+import type {State} from '../../state'
+import globalMessages from '../../i18n/global-messages'
+
+const messages = defineMessages({
+  noTransactions: {
+    id: 'components.txhistory.txhistory.noTransactions',
+    defaultMessage: '!!!No transactions to show yet',
+  },
+  syncErrorBannerTextWithoutRefresh: {
+    id: 'components.txhistory.txhistory.syncErrorBannerTextWithoutRefresh',
+    defaultMessage: '!!!We are experiencing synchronization issues.',
+  },
+  syncErrorBannerTextWithRefresh: {
+    id: 'components.txhistory.txhistory.syncErrorBannerTextWithRefresh',
+    defaultMessage:
+      '!!!We are experiencing synchronization issues. Pull to refresh',
+  },
+})
+
+const NoTxHistory = injectIntl(({intl}) => (
+  <View style={styles.empty}>
+    <Image source={image} />
+    <Text style={styles.emptyText}>
+      {intl.formatMessage(messages.noTransactions)}
+    </Text>
+  </View>
+))
+
+const SyncErrorBanner = injectIntl(({intl, showRefresh}) => (
+  <Banner
+    error
+    text={
+      showRefresh
+        ? intl.formatMessage(messages.syncErrorBannerTextWithRefresh)
+        : intl.formatMessage(messages.syncErrorBannerTextWithoutRefresh)
+    }
+  />
+))
+
+const AvailableAmountBanner = injectIntl(({intl, amount}) => (
+  <Banner
+    label={intl.formatMessage(globalMessages.availableFunds)}
+    text={formatAdaWithText(amount)}
+    boldText
+  />
+))
+
+const TxHistory = ({
+  amountPending,
+  transactionsInfo,
+  navigation,
+  isSyncing,
+  isOnline,
+  updateHistory,
+  lastSyncError,
+  availableAmount,
+}) => (
+  <SafeAreaView style={styles.scrollView}>
+    <StatusBar type="dark" />
+    <View style={styles.container}>
+      <OfflineBanner />
+      {isOnline &&
+        lastSyncError && <SyncErrorBanner showRefresh={!isSyncing} />}
+
+      <AvailableAmountBanner amount={availableAmount} />
+
+      {_.isEmpty(transactionsInfo) ? (
+        <ScrollView
+          refreshControl={
+            <RefreshControl onRefresh={updateHistory} refreshing={isSyncing} />
+          }
+        >
+          <NoTxHistory />
+        </ScrollView>
+      ) : (
+        <TxHistoryList
+          refreshing={isSyncing}
+          onRefresh={updateHistory}
+          navigation={navigation}
+          transactions={transactionsInfo}
+        />
+      )}
+
+      <TxNavigationButtons navigation={navigation} />
+    </View>
+  </SafeAreaView>
+)
+
+type ExternalProps = {|
+  navigation: Navigation,
+|}
+
+export default injectIntl(
+  (compose(
+    requireInitializedWallet,
+    connect(
+      (state: State) => ({
+        transactionsInfo: transactionsInfoSelector(state),
+        isSyncing: isSynchronizingHistorySelector(state),
+        lastSyncError: lastHistorySyncErrorSelector(state),
+        isOnline: isOnlineSelector(state),
+        availableAmount: availableAmountSelector(state),
+        walletName: walletNameSelector(state),
+        key: languageSelector(state),
+      }),
+      {
+        updateHistory,
+      },
+    ),
+    onDidMount(({updateHistory}) => {
+      updateHistory()
+    }),
+    withNavigationTitle(({walletName}) => walletName),
+  )(TxHistory): ComponentType<ExternalProps>),
+)

--- a/src/components/WalletInit/RestoreWallet/WalletCredentialsScreen.js
+++ b/src/components/WalletInit/RestoreWallet/WalletCredentialsScreen.js
@@ -48,8 +48,7 @@ export default injectIntl(
         ({navigation, createWallet}) => async ({name, password}) => {
           const phrase = navigation.getParam('phrase')
           await createWallet(name, phrase, password)
-          // TODO: Update this to consider SHelley wallet
-          navigation.navigate(ROOT_ROUTES.WALLET)
+          navigation.navigate(ROOT_ROUTES.SHELLEY_WALLET)
         },
         1000,
       ),

--- a/src/navigationOptions.js
+++ b/src/navigationOptions.js
@@ -1,6 +1,22 @@
 // @flow
 
+import React from 'react'
+import {View} from 'react-native'
+import {Header} from 'react-navigation'
+import LinearGradient from 'react-native-linear-gradient'
 import {COLORS} from './styles/config'
+
+const GradientHeader = (props) => (
+  <View style={{backgroundColor: COLORS.LIGHT_GRAY}}>
+    <LinearGradient
+      start={{x: 0, y: 0}}
+      end={{x: 1, y: 0}}
+      colors={['#1A44B7', '#F14D78']}
+    >
+      <Header {...props} />
+    </LinearGradient>
+  </View>
+)
 
 export const defaultNavigationOptions = {
   headerStyle: {
@@ -8,6 +24,13 @@ export const defaultNavigationOptions = {
     borderBottomWidth: 0,
   },
   headerTintColor: '#fff',
+}
+
+export const shelleyNavigationOptions = {
+  header: (props) => <GradientHeader {...props} />,
+  headerStyle: {
+    backgroundColor: 'transparent',
+  },
 }
 
 export const defaultStackNavigatorOptions = {


### PR DESCRIPTION
Starting from the branch `nicarq/ch2042/add-staking-center-ui-to-mobile`, this PR mainly modifies the routing structure to add a temporary `TransferSummaryScreen` for balance checking. As a corollary, the bug observed when switching wallets has been fixed.

Additional random change: this PR adds `shelleyNavigationOptions` in `navigationOptions.js` that implements the Shelley design for the navigation bar. 

Note: I created `shelley-snapshot-check` as the base branch, which is currently at the same state than `nicarq/ch2042/add-staking-center-ui-to-mobile` 