### PR TITLE
fix mnemonics input height on ios

### DIFF
--- a/src/components/WalletInit/BalanceCheck/BalanceCheckScreen.js
+++ b/src/components/WalletInit/BalanceCheck/BalanceCheckScreen.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React, {Component} from 'react'
-import {View, ScrollView} from 'react-native'
+import {View, ScrollView, Platform} from 'react-native'
 import {compose} from 'redux'
 import {connect} from 'react-redux'
 import {SafeAreaView} from 'react-navigation'
@@ -217,7 +217,7 @@ class BalanceCheckScreen extends Component<Props, State> {
               <ValidatedTextInput
                 multiline
                 numberOfLines={3}
-                style={styles.phrase}
+                style={Platform.OS === 'ios' ? styles.iosPhrase : styles.phrase}
                 value={phrase}
                 onChangeText={this.setPhrase}
                 placeholder={intl.formatMessage(messages.mnemonicInputLabel)}

--- a/src/components/WalletInit/BalanceCheck/styles/BalanceCheckScreen.style.js
+++ b/src/components/WalletInit/BalanceCheck/styles/BalanceCheckScreen.style.js
@@ -1,6 +1,11 @@
 // @flow
 import {StyleSheet} from 'react-native'
 
+const phrase = {
+  lineHeight: 24,
+  borderColor: '#9b9b9b',
+}
+
 export default StyleSheet.create({
   safeAreaView: {
     flex: 1,
@@ -14,7 +19,11 @@ export default StyleSheet.create({
     backgroundColor: '#fff',
   },
   phrase: {
-    lineHeight: 24,
-    borderColor: '#9b9b9b',
+    ...phrase,
+  },
+  iosPhrase: {
+    ...phrase,
+    height: 'auto',
+    marginTop: 24,
   },
 })


### PR DESCRIPTION
Fixes the following display issue observed on iOS:
<img width="381" alt="Screenshot 2019-11-22 at 21 32 32" src="https://user-images.githubusercontent.com/7271744/69458616-0cc5a880-0d70-11ea-84ed-f7ea8976fd5d.png">

Should now look like:
![Screenshot 2019-11-22 at 21 39 04](https://user-images.githubusercontent.com/7271744/69458819-89f11d80-0d70-11ea-907e-4dad0f3d646d.png)

