### PR TITLE
fix general error handling

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -385,9 +385,10 @@ const showDialog = (translations: DialogOptions): Promise<DialogButton> =>
   })
 
 export const showErrorDialog = (
-  dialog: DialogOptions,
+  dialog: Object,
   intl: ?intlShape,
-  msgOptions?: any,
+  msgOptions?: Object,
+  // $FlowFixMe
 ): Promise<DialogButton> => {
   let title, message, yesButton
   if (intl != null) {
@@ -398,10 +399,15 @@ export const showErrorDialog = (
     // in this case the function was called without providing the intlShape
     // object, so only an english dialog will be displayed
     title = dialog.title.defaultMessage
-    message = msgOptions.message != null ?
-      dialog.message.defaultMessage
-        .replace(new RegExp('{message}', 'gi'), msgOptions.message)
-      : 'unknown error'
+    // seems impossible to pass eslint check using a ternary operator here
+    if (msgOptions != null && 'message' in msgOptions) {
+      message = dialog.message.defaultMessage.replace(
+        new RegExp('{message}', 'gi'),
+        msgOptions.message,
+      )
+    } else {
+      message = 'unknown error'
+    }
     yesButton = globalMessages.ok.defaultMessage
   }
   showDialog({title, message, yesButton})

--- a/src/actions.js
+++ b/src/actions.js
@@ -386,14 +386,26 @@ const showDialog = (translations: DialogOptions): Promise<DialogButton> =>
 
 export const showErrorDialog = (
   dialog: DialogOptions,
-  intl: intlShape,
+  intl: ?intlShape,
   msgOptions?: any,
-): Promise<DialogButton> =>
-  showDialog({
-    title: intl.formatMessage(dialog.title),
-    message: intl.formatMessage(dialog.message, msgOptions),
-    yesButton: intl.formatMessage(globalMessages.ok),
-  })
+): Promise<DialogButton> => {
+  let title, message, yesButton
+  if (intl != null) {
+    title = intl.formatMessage(dialog.title)
+    message = intl.formatMessage(dialog.message, msgOptions)
+    yesButton = intl.formatMessage(globalMessages.ok)
+  } else {
+    // in this case the function was called without providing the intlShape
+    // object, so only an english dialog will be displayed
+    title = dialog.title.defaultMessage
+    message = msgOptions.message != null ?
+      dialog.message.defaultMessage
+        .replace(new RegExp('{message}', 'gi'), msgOptions.message)
+      : 'unknown error'
+    yesButton = globalMessages.ok.defaultMessage
+  }
+  showDialog({title, message, yesButton})
+}
 
 export const showConfirmationDialog = (
   dialog: DialogOptions,
@@ -438,7 +450,7 @@ export const setSystemAuth = (enable: boolean) => async (
 
 export const handleGeneralError = async (message: string, e: Error) => {
   Logger.error(`${message}: ${e.message}`, e)
-  await showErrorDialog(errorMessages.generalError, {message})
+  await showErrorDialog(errorMessages.generalError, null, {message})
   crashReporting.crash()
 }
 

--- a/src/helpers/crashReporting.js
+++ b/src/helpers/crashReporting.js
@@ -55,7 +55,7 @@ const setBoolValue = (key: string, value: ?boolean) => {
 
 // Note(ppershing): crashing here is fine :-)
 const crash = () => {
-  Sentry.crash()
+  _enabled && Sentry.crash()
 }
 
 export default {


### PR DESCRIPTION
Many times when an `onunhandledrejection` event occurs (there is a listener registered at app startup in `src/index.js`) and the app crashes, it is not easy to debug because the error message, both in console logs and the user interface, is hidden in a pile of `'intl.formatMessage is not a function (...)`. This is because of a bug in the function that reports the error, `handleGeneralError`, which was calling `showErrorDialog()` without providing the `intl` object.

To fix this, we may just call `showErrorDialog()` with `intl=null`, as providing a valid object is not possible at the stage in which the `onunhandledrejection` event listener is registered.

Now, after that is fixed, the app crashes again because apparently that was the intended behaviour.   `handleGeneralError` calls `Sentry.crash()`, which throws, but the problem is that it keeps throwing forever, polluting once again the logs.

So **unless there is a good reason for that, I propose we remove this behaviour.** If this fix is accepted, then I also propose to apply it on `shelley`, as that may help for debugging unexpected errors.

### Reproduction steps
Simply call `handleGeneralError()` somewhere:
```
const e = {title: 'title', message: 'message'}
handleGeneralError('Could not submit transaction', e)
```