### PR TITLE
V almonacid/ch2321/always use byte encoding for shelley addresses

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "vm-browserify": "^1.1.0"
   },
   "devDependencies": {
+    "@emurgo/js-chain-libs-node": "git+https://github.com/SebastienGllmt/js-chain-libs-node-pkg.git",
     "babel-jest": "^24.8.0",
     "babel-plugin-react-intl": "^3.0.1",
     "babel-plugin-require-context-hook": "^1.0.0",
@@ -95,7 +96,6 @@
     "flow-bin": "0.92",
     "jest": "24.8.0",
     "jetifier": "^1.6.4",
-    "@emurgo/js-chain-libs-node": "git+https://github.com/SebastienGllmt/js-chain-libs-node-pkg.git",
     "metro-react-native-babel-preset": "0.54.1",
     "prettier": "1.14.3",
     "prettylint": "1.0.0",

--- a/src/config.js
+++ b/src/config.js
@@ -106,4 +106,8 @@ export const CONFIG = {
   NETWORK: _USE_TESTNET ? 'Testnet' : 'Mainnet',
   COMMIT: _COMMIT,
   DECIMAL_PLACES_IN_ADA: 6,
+  STAKING_KEY_INDEX: 0,
+  BECH32_PREFIX: {
+    ADDRESS: 'addr',
+  },
 }

--- a/src/crypto/shelley/certificateUtils.js
+++ b/src/crypto/shelley/certificateUtils.js
@@ -1,0 +1,11 @@
+// @flow
+
+// this is a temporary solution since the js-chain-libs classes are not yet
+// implemented in react-native-chain-libs
+export const CertificateKind = {
+  StakeDelegation: 0,
+  OwnerStakeDelegation: 1,
+  PoolRegistration: 2,
+  PoolRetirement: 3,
+  PoolUpdate: 4,
+}

--- a/src/crypto/shelley/transactions/accountingTransactions.js
+++ b/src/crypto/shelley/transactions/accountingTransactions.js
@@ -45,6 +45,7 @@ export const buildUnsignedAccountTx = async (
   typeSpecific: SendType,
   accountBalance: BigNumber,
 ): Promise<InputOutput> => {
+  const wasmReceiver = await Address.from_bytes(Buffer.from(receiver, 'hex'))
   if (typeSpecific.amount != null && typeSpecific.amount.gt(accountBalance)) {
     throw new InsufficientFunds()
   }
@@ -74,7 +75,7 @@ export const buildUnsignedAccountTx = async (
     )
     if (typeSpecific.amount != null) {
       await fakeTxBuilder.add_output(
-        await Address.from_string(receiver),
+        wasmReceiver,
         // the value we put in here is irrelevant. Just need some value to be able to calculate fee
         await Value.from_str('1'),
       )
@@ -103,7 +104,7 @@ export const buildUnsignedAccountTx = async (
     // typeSpecific.amount.toString()
     const outputAmount = typeSpecific.amount
     await ioBuilder.add_output(
-      await Address.from_string(receiver),
+      wasmReceiver,
       await Value.from_str(outputAmount.toString()),
     )
   }

--- a/src/crypto/shelley/transactions/accountingTransactions.test.js
+++ b/src/crypto/shelley/transactions/accountingTransactions.test.js
@@ -29,7 +29,11 @@ describe('Create unsigned TX for account', () => {
 
     const unsignedTxResponse = await buildUnsignedAccountTx(
       await senderKey.to_public(),
-      'ca1qw8mq0p65pf028qgd32t6szeatfd9epx4jyl5jeuuswtlkyqpdguqeh83d4',
+      Buffer.from(
+        await (await Address.from_string(
+          'ca1qw8mq0p65pf028qgd32t6szeatfd9epx4jyl5jeuuswtlkyqpdguqeh83d4',
+        )).as_bytes(),
+      ).toString('hex'),
       {
         amount: new BigNumber(2000000),
       },
@@ -80,7 +84,11 @@ describe('Create unsigned TX for account', () => {
     )
     const promise = buildUnsignedAccountTx(
       await senderKey.to_public(),
-      'ca1qw8mq0p65pf028qgd32t6szeatfd9epx4jyl5jeuuswtlkyqpdguqeh83d4',
+      Buffer.from(
+        await (await Address.from_string(
+          'ca1qw8mq0p65pf028qgd32t6szeatfd9epx4jyl5jeuuswtlkyqpdguqeh83d4',
+        )).as_bytes(),
+      ).toString('hex'),
       {
         amount: new BigNumber(2000000),
       },
@@ -95,7 +103,11 @@ describe('Create unsigned TX for account', () => {
     )
     const promise = buildUnsignedAccountTx(
       await senderKey.to_public(),
-      'ca1qw8mq0p65pf028qgd32t6szeatfd9epx4jyl5jeuuswtlkyqpdguqeh83d4',
+      Buffer.from(
+        await (await Address.from_string(
+          'ca1qw8mq0p65pf028qgd32t6szeatfd9epx4jyl5jeuuswtlkyqpdguqeh83d4',
+        )).as_bytes(),
+      ).toString('hex'),
       {
         amount: new BigNumber(2000000),
       },

--- a/src/crypto/shelley/transactions/utils.js
+++ b/src/crypto/shelley/transactions/utils.js
@@ -5,11 +5,12 @@ import {
   Certificate,
   InputOutput,
   PayloadAuthData,
-  StakeDelegation,
+  // CertificateKind
   StakeDelegationAuthData,
 } from 'react-native-chain-libs'
 import type {BaseSignRequest} from '../../../types/HistoryTransaction'
 import {CONFIG} from '../../../config'
+import {CertificateKind} from '../certificateUtils'
 
 import {BigNumber} from 'bignumber.js'
 
@@ -147,8 +148,8 @@ export const generateAuthData = async (
   }
 
   switch (await certificate.get_type()) {
-    // TODO: maybe should be `await CertificateKind.StakeDelegation`
-    case StakeDelegation: {
+    // TODO: update to CertificateKind.StakeDelegation from react-native-chain-libs
+    case CertificateKind.StakeDelegation: {
       return await PayloadAuthData.for_stake_delegation(
         await StakeDelegationAuthData.new(bindingSignature),
       )

--- a/src/crypto/shelley/transactions/utxoTransactions.js
+++ b/src/crypto/shelley/transactions/utxoTransactions.js
@@ -70,7 +70,7 @@ export const newAdaUnsignedTxFromUtxo = async (
 
   const ioBuilder = await InputOutputBuilder.empty()
   await ioBuilder.add_output(
-    await Address.from_string(receiver),
+    await Address.from_bytes(Buffer.from(receiver, 'hex')),
     await Value.from_str(amount),
   )
 
@@ -100,7 +100,9 @@ export const newAdaUnsignedTxFromUtxo = async (
     IOs = await ioBuilder.seal_with_output_policy(
       payload,
       feeAlgorithm,
-      await OutputPolicy.one(await Address.from_string(changeAddress.address)),
+      await OutputPolicy.one(
+        await Address.from_bytes(Buffer.from(changeAddress.address, 'hex')),
+      ),
     )
     // given the change address, compute how much coin will be sent to it
     const addedChange = await filterToUsedChange(
@@ -211,7 +213,9 @@ async function filterToUsedChange(
   )
 
   const change = []
-  const changeAddrWasm = await Address.from_string(changeAddr.address)
+  const changeAddrWasm = await Address.from_bytes(
+    Buffer.from(changeAddr.address, 'hex'),
+  )
   const changeAddrPayload = Buffer.from(
     await changeAddrWasm.as_bytes(),
   ).toString('hex')
@@ -359,7 +363,7 @@ export const sendAllUnsignedTxFromUtxo = async (
       await fakeIOBuilder.add_input(input)
     }
     await fakeIOBuilder.add_output(
-      await Address.from_string(receiver),
+      await Address.from_bytes(Buffer.from(receiver, 'hex')),
       await Value.from_str(totalBalance.toString()),
     )
     const feeValue = await (await fakeIOBuilder.estimate_fee(

--- a/src/crypto/shelley/transactions/utxoTransactions.test.js
+++ b/src/crypto/shelley/transactions/utxoTransactions.test.js
@@ -24,24 +24,27 @@ const keys = [
   {
     legacyAddress:
       'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
+    // ca1qw8mq0p65pf028qgd32t6szeatfd9epx4jyl5jeuuswtlkyqpdguqeh83d4
     bechAddress:
-      'ca1qw8mq0p65pf028qgd32t6szeatfd9epx4jyl5jeuuswtlkyqpdguqeh83d4',
+      '038fb03c3aa052f51c086c54bd4059ead2d2e426ac89fa4b3ce41cbfd8800b51c0',
     pubKey:
       '8fb03c3aa052f51c086c54bd4059ead2d2e426ac89fa4b3ce41cbfd8800b51c02623fceb96b07408531a5cb259f53845a38d6b68928e7c0c7e390f07545d0e62',
   },
   {
     legacyAddress:
       'Ae2tdPwUPEZ4xAL3nxLq4Py7BfS1D2tJ3u2rxZGnrAXC8TNkWhTaz41J3FN',
+    // ca1q0j6cetm7zqsagm5zz5fmav9jg37n4cferj23h370kptrpfj095fxcy43lj
     bechAddress:
-      'ca1q0j6cetm7zqsagm5zz5fmav9jg37n4cferj23h370kptrpfj095fxcy43lj',
+      '03e5ac657bf0810ea37410a89df5859223e9d709c8e4a8de3e7d82b18532796893',
     pubKey:
       'e5ac657bf0810ea37410a89df5859223e9d709c8e4a8de3e7d82b185327968939a254def91bb75e94bda9c605f7f87481082742e1e51d8858965c9a40491fc94',
   },
   {
     legacyAddress:
       'Ae2tdPwUPEZEtwz7LKtJn9ub8y7ireuj3sq2yUCZ57ccj6ZkJKn7xEiApV9',
+    // ca1q0ewtxsk489t9g7vs64prkm0hfvz6aemtvtv57rkfwmxyp3yhtxtwhtm3gd
     bechAddress:
-      'ca1q0ewtxsk489t9g7vs64prkm0hfvz6aemtvtv57rkfwmxyp3yhtxtwhtm3gd',
+      '03f2e59a16a9cab2a3cc86aa11db6fba582d773b5b16ca78764bb6620624baccb7',
     pubKey:
       'f2e59a16a9cab2a3cc86aa11db6fba582d773b5b16ca78764bb6620624baccb7c03adf6448459f2b8d5c32033a160de8b5412d1952794190c4fc6b4716a8b8eb',
   },
@@ -76,7 +79,9 @@ const sampleUtxos: Array<RawUtxo> = [
 
 const sampleAdaAddresses: Array<{|address: string, ...Addressing|}> = [
   {
-    address: 'ca1q0ewtxsk489t9g7vs64prkm0hfvz6aemtvtv57rkfwmxyp3yhtxtwhtm3gd',
+    // ca1q0ewtxsk489t9g7vs64prkm0hfvz6aemtvtv57rkfwmxyp3yhtxtwhtm3gd
+    address:
+      '03f2e59a16a9cab2a3cc86aa11db6fba582d773b5b16ca78764bb6620624baccb7',
     addressing: {
       account: 0,
       change: 1,


### PR DESCRIPTION
See https://github.com/Emurgo/yoroi-frontend/pull/1183

Note: this PR modifies #747 which should be merged first.