### PR TITLE
fix metro server connection issue

### DIFF
--- a/android/app/src/dev/res/xml/network_security_config.xml
+++ b/android/app/src/dev/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">localhost</domain>
+    </domain-config>
+</network-security-config>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:allowBackup="false"
-      android:theme="@style/AppTheme">
+      android:theme="@style/AppTheme"
+      android:networkSecurityConfig="@xml/network_security_config">
       <activity
         android:name=".SplashActivity"
         android:label="@string/app_name">


### PR DESCRIPTION
## Issue
Starting on API 28, Android no longer accepts non-secure communications by default. This is a problem when building debug versions because the app gets the js bundle from Metro using a http server.

For more info, see: https://developer.android.com/about/versions/pie/android-9.0-changes-28#tls-enabled

## Fix
Instead of just re-enabling all non-secure connections (setting `android:usesCleartextTraffic=true` in `AndroidManifest.xml`) we only allow them from `localhost` and *only* for debug builds.

See: https://github.com/facebook/react-native/issues/22375