### PR TITLE
add missing network_security_config.xml for mainnet builds

### DIFF
--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">localhost</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
In #749 I added `network_security_config.xml` to allow Android phones to connect to Metro. 

The file is referenced in `AndroidManifest.xml`, which is the same for testnet and mainnet builds. I just forgot to add it for `mainnetDebug` builds, and as a consequence prod builds are failing.