### PR TITLE
fix network security config for testing with emulator

### DIFF
--- a/android/app/src/dev/res/xml/network_security_config.xml
+++ b/android/app/src/dev/res/xml/network_security_config.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">localhost</domain>
+        <domain includeSubdomains="false">localhost</domain>
+        <domain includeSubdomains="false">10.0.2.2</domain>
+        <domain includeSubdomains="false">10.0.3.2</domain>
     </domain-config>
 </network-security-config>

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">localhost</domain>
+        <domain includeSubdomains="false">localhost</domain>
+        <domain includeSubdomains="false">10.0.2.2</domain>
+        <domain includeSubdomains="false">10.0.3.2</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
In #749 and  #753 I added a `network_security_config.xml` file to allow for non-encrypted local data connections (recall: this basically allows to test the app using a real android device, after non-encrypted connections were blocked starting from Android API 28).

However, today I needed to use an Android emulator instead and noticed it didn't work. This PR hopefully fixes it. Tested locally with emulator and real device.