### PR TITLE
change dialog message in balance check

### DIFF
--- a/src/components/WalletInit/BalanceCheck/BalanceCheckScreen.js
+++ b/src/components/WalletInit/BalanceCheck/BalanceCheckScreen.js
@@ -86,15 +86,17 @@ const messages = defineMessages({
 
 const snapshotEndMsg = defineMessages({
   title: {
-    id: 'components.walletinit.balancecheck.balancecheckscreen.snapshotend.title',
+    id:
+      'components.walletinit.balancecheck.balancecheckscreen.snapshotend.title',
     defaultMessage: '!!!Snapshot has ended',
   },
   message: {
-    id: 'components.walletinit.balancecheck.balancecheckscreen.snapshotend.message',
+    id:
+      'components.walletinit.balancecheck.balancecheckscreen.snapshotend.message',
     defaultMessage:
-    '!!!The snapshot period has endeded. You can start delegating now using ' +
-    'the Yoroi extension, and soon you will be able to do it from the mobile ' +
-    'app as well.',
+      '!!!The snapshot period has endeded. You can start delegating now using ' +
+      'the Yoroi extension, and soon you will be able to do it from the mobile ' +
+      'app as well.',
   },
 })
 

--- a/src/components/WalletInit/BalanceCheck/BalanceCheckScreen.js
+++ b/src/components/WalletInit/BalanceCheck/BalanceCheckScreen.js
@@ -84,6 +84,20 @@ const messages = defineMessages({
   },
 })
 
+const snapshotEndMsg = defineMessages({
+  title: {
+    id: 'components.walletinit.balancecheck.balancecheckscreen.snapshotend.title',
+    defaultMessage: '!!!Snapshot has ended',
+  },
+  message: {
+    id: 'components.walletinit.balancecheck.balancecheckscreen.snapshotend.message',
+    defaultMessage:
+    '!!!The snapshot period has endeded. You can start delegating now using ' +
+    'the Yoroi extension, and soon you will be able to do it from the mobile ' +
+    'app as well.',
+  },
+})
+
 const _translateInvalidPhraseError = (intl: any, error: InvalidPhraseError) => {
   if (error.code === INVALID_PHRASE_ERROR_CODES.UNKNOWN_WORDS) {
     return intl.formatMessage(mnemonicInputErrorsMessages.UNKNOWN_WORDS, {
@@ -173,7 +187,7 @@ class BalanceCheckScreen extends Component<Props, State> {
       if (e instanceof NetworkError) {
         await showErrorDialog(errorMessages.networkError, intl)
       } else if (e instanceof ApiError) {
-        await showErrorDialog(errorMessages.apiError, intl)
+        await showErrorDialog(snapshotEndMsg, intl)
       } else {
         throw e
       }

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -170,6 +170,8 @@
   "components.walletinit.balancecheck.balancecheckscreen.headsUp": "You are on the Shelley Balance Check Testnet",
   "components.walletinit.balancecheck.balancecheckscreen.instructions": "Enter the 15-word recovery phrase used to back up your wallet to validate the balance. It will take about 1 minute to verify your balance.",
   "components.walletinit.balancecheck.balancecheckscreen.mnemonicInputLabel": "Recovery phrase",
+  "components.walletinit.balancecheck.balancecheckscreen.snapshotend.title": "Snapshot has ended",
+  "components.walletinit.balancecheck.balancecheckscreen.snapshotend.message": "The snapshot period has endeded. You can start delegating now using the Yoroi extension, and soon you will be able to do it from the mobile app as well.",
   "components.walletinit.balancecheck.balancecheckscreen.title" : "Balance Check",
   "components.walletinit.createwallet.createwalletscreen.title": "Create a new wallet",
   "components.walletinit.createwallet.mnemonicbackupimportancemodal.confirmationButton": "I understand",


### PR DESCRIPTION
Instead of a generic API error, now users should see:

<img width="343" alt="Screenshot 2020-01-17 at 16 53 30" src="https://user-images.githubusercontent.com/7271744/72642450-2be54e80-394b-11ea-9318-36eaaba10fb2.png">

