### PR TITLE
add/fix snapshot ending dialog

### DIFF
--- a/src/components/WalletInit/WalletInitScreen.js
+++ b/src/components/WalletInit/WalletInitScreen.js
@@ -14,6 +14,7 @@ import styles from './styles/WalletInitScreen.style'
 import {WALLET_INIT_ROUTES} from '../../RoutesList'
 import {withNavigationTitle} from '../../utils/renderUtils'
 import {walletIsInitializedSelector} from '../../selectors'
+import {showErrorDialog} from '../../actions'
 
 import type {State} from '../../state'
 
@@ -40,6 +41,23 @@ const messages = defineMessages({
   },
 })
 
+const snapshotEndMsg = defineMessages({
+  title: {
+    id:
+      'components.walletinit.balancecheck.balancecheckscreen.snapshotend.title',
+    defaultMessage: '!!!Snapshot has ended',
+  },
+  message: {
+    id:
+      'components.walletinit.balancecheck.balancecheckscreen.snapshotend.message',
+    defaultMessage:
+      '!!!The snapshot period has ended. You can start delegating now using ' +
+      'the Yoroi extension, and soon you will be able to do it from the mobile ' +
+      'app as well.',
+  },
+})
+
+
 type Props = {
   navigateBalanceCheck: () => mixed,
   navigateRestoreWallet: () => mixed,
@@ -63,7 +81,7 @@ const BalanceCheckButton = ({onPress, walletIsInitialized, intl}) => {
 }
 
 const WalletInitScreen = ({
-  navigateBalanceCheck,
+  showDialog,
   navigateCreateWallet,
   navigateRestoreWallet,
   intl,
@@ -79,7 +97,7 @@ const WalletInitScreen = ({
         </View>
 
         <BalanceCheckButton
-          onPress={navigateBalanceCheck}
+          onPress={showDialog}
           walletIsInitialized={walletIsInitialized}
           intl={intl}
         />
@@ -107,8 +125,8 @@ export default injectIntl(
     })),
     withNavigationTitle(({intl}) => intl.formatMessage(messages.title)),
     withHandlers({
-      navigateBalanceCheck: ({navigation}) => (event) =>
-        navigation.navigate(WALLET_INIT_ROUTES.BALANCE_CHECK),
+      showDialog: ({intl}) => async (event) =>
+        await showErrorDialog(snapshotEndMsg, intl),
       navigateRestoreWallet: ({navigation}) => (event) =>
         navigation.navigate(WALLET_INIT_ROUTES.RESTORE_WALLET),
       navigateCreateWallet: ({navigation}) => (event) =>

--- a/src/components/WalletInit/WalletInitScreen.js
+++ b/src/components/WalletInit/WalletInitScreen.js
@@ -57,9 +57,8 @@ const snapshotEndMsg = defineMessages({
   },
 })
 
-
 type Props = {
-  navigateBalanceCheck: () => mixed,
+  showDialog: () => mixed,
   navigateRestoreWallet: () => mixed,
   navigateCreateWallet: () => mixed,
   intl: any,

--- a/src/components/WalletSelection/WalletSelectionScreen.js
+++ b/src/components/WalletSelection/WalletSelectionScreen.js
@@ -42,11 +42,27 @@ const messages = defineMessages({
   },
 })
 
+const snapshotEndMsg = defineMessages({
+  title: {
+    id:
+      'components.walletinit.balancecheck.balancecheckscreen.snapshotend.title',
+    defaultMessage: '!!!Snapshot has ended',
+  },
+  message: {
+    id:
+      'components.walletinit.balancecheck.balancecheckscreen.snapshotend.message',
+    defaultMessage:
+      '!!!The snapshot period has ended. You can start delegating now using ' +
+      'the Yoroi extension, and soon you will be able to do it from the mobile ' +
+      'app as well.',
+  },
+})
+
 const WalletListScreen = ({
   navigation,
   wallets,
   navigateInitWallet,
-  navigateBalanceCheck,
+  showDialog,
   openWallet,
   intl,
 }) => (
@@ -79,7 +95,7 @@ const WalletListScreen = ({
 
         <Button
           outline
-          onPress={navigateBalanceCheck}
+          onPress={showDialog}
           title={intl.formatMessage(messages.balanceCheckButton)}
           style={styles.balanceCheckButton}
         />
@@ -98,8 +114,8 @@ export default injectIntl(
     withHandlers({
       navigateInitWallet: ({navigation}) => (event) =>
         navigation.navigate(WALLET_INIT_ROUTES.CREATE_RESTORE_SWITCH),
-      navigateBalanceCheck: ({navigation}) => (event) =>
-        navigation.navigate(WALLET_INIT_ROUTES.BALANCE_CHECK),
+      showDialog: ({intl}) => async (event) =>
+        await showErrorDialog(snapshotEndMsg, intl),
       openWallet: ({navigation, intl}) => async (wallet) => {
         try {
           await walletManager.openWallet(wallet.id)

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -170,6 +170,8 @@
   "components.walletinit.balancecheck.balancecheckscreen.headsUp": "You are on the Shelley Balance Check Testnet",
   "components.walletinit.balancecheck.balancecheckscreen.instructions": "Enter the 15-word recovery phrase used to back up your wallet to validate the balance. It will take about 1 minute to verify your balance.",
   "components.walletinit.balancecheck.balancecheckscreen.mnemonicInputLabel": "Recovery phrase",
+  "components.walletinit.balancecheck.balancecheckscreen.snapshotend.title": "Snapshot has ended",
+  "components.walletinit.balancecheck.balancecheckscreen.snapshotend.message": "The snapshot period has ended. You can start delegating now using the Yoroi extension, and soon you will be able to do it from the mobile app as well.",
   "components.walletinit.balancecheck.balancecheckscreen.title" : "Balance Check",
   "components.walletinit.createwallet.createwalletscreen.title": "Create a new wallet",
   "components.walletinit.createwallet.mnemonicbackupimportancemodal.confirmationButton": "I understand",


### PR DESCRIPTION
Now we add the dialog before user enter mnemonics, within the two screens the balance check button exists.

## `WalletInitScreen.js`

<img width="340" alt="Screenshot 2020-01-20 at 12 12 23" src="https://user-images.githubusercontent.com/7271744/72737775-02ad0400-3b7f-11ea-9552-a9f7bb649d63.png">

## `WalletSelectionScreen.js`
<img width="343" alt="Screenshot 2020-01-20 at 12 08 10" src="https://user-images.githubusercontent.com/7271744/72737848-24a68680-3b7f-11ea-9bd3-ff42edd55cce.png">


