### PR TITLE
fix delegation confirmation (wrong password) error handling

### DIFF
--- a/src/components/Delegation/FlawedWalletScreen.js
+++ b/src/components/Delegation/FlawedWalletScreen.js
@@ -53,9 +53,7 @@ const FlawedWalletScreen = ({
     <ScrollView style={styles.scrollView}>
       <View style={styles.content}>
         <View style={styles.heading}>
-          <Text style={styles.title}>
-            {intl.formatMessage(messages.title)}
-          </Text>
+          <Text style={styles.title}>{intl.formatMessage(messages.title)}</Text>
           <Image source={image} />
         </View>
         <Text style={styles.paragraph}>

--- a/src/crypto/byron/util.js
+++ b/src/crypto/byron/util.js
@@ -32,7 +32,7 @@ export type CryptoAccount = {
   root_cached_key: string,
 }
 
-const KNOWN_ERROR_MSG = {
+export const KNOWN_ERROR_MSG = {
   DECRYPT_FAILED: 'Decryption failed. Check your password.',
   INSUFFICIENT_FUNDS_RE: /NotEnoughInput/,
   SIGN_TX_BUG: /TxBuildError\(CoinError\(Negative\)\)/,

--- a/src/crypto/wallet.js
+++ b/src/crypto/wallet.js
@@ -1200,15 +1200,15 @@ class WalletManager {
           CARDANO_CONFIG.MAINNET,
         )
       }
-      if (this._wallet == null) throw new WalletClosed()
       Logger.debug(
         'WalletManager::checkForFlawedWallets wallet addresses [0]:',
         this._wallet._externalChain.addresses[0],
       )
       Logger.debug(
         'WalletManager::checkForFlawedWallets flawedAddresses [0]:',
-        flawedAddresses
+        flawedAddresses,
       )
+      if (this._wallet == null) throw new WalletClosed()
       if (this._wallet._externalChain.isMyAddress(flawedAddresses[0])) {
         Logger.debug('WalletManager::checkForFlawedWallets: address match')
         affected = true

--- a/src/crypto/wallet.js
+++ b/src/crypto/wallet.js
@@ -1200,16 +1200,17 @@ class WalletManager {
           CARDANO_CONFIG.MAINNET,
         )
       }
+      if (this._wallet == null) throw new WalletClosed()
+      const externalChain = this._wallet._externalChain
       Logger.debug(
         'WalletManager::checkForFlawedWallets wallet addresses [0]:',
-        this._wallet._externalChain.addresses[0],
+        externalChain.addresses[0],
       )
       Logger.debug(
         'WalletManager::checkForFlawedWallets flawedAddresses [0]:',
         flawedAddresses,
       )
-      if (this._wallet == null) throw new WalletClosed()
-      if (this._wallet._externalChain.isMyAddress(flawedAddresses[0])) {
+      if (externalChain.isMyAddress(flawedAddresses[0])) {
         Logger.debug('WalletManager::checkForFlawedWallets: address match')
         affected = true
         return affected


### PR DESCRIPTION
Previously when a user entered a wrong password to confirm a delegation tx, the app responded with a generic "Unexpected error: request operation failed... could not submit transaction", triggering a `console.error` and reporting a crash to sentry.

This PR fixes this and now the app should show the following dialog instead:

<img width="338" alt="Screenshot 2020-02-17 at 09 43 05" src="https://user-images.githubusercontent.com/7271744/74655886-e5faf080-516b-11ea-9039-83d81568d6aa.png">

(note: this commit also prettifies a few unrelated lines of code)