### PR TITLE
move debug flags to env variables and add check script

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -218,7 +218,18 @@ tasks.create('getCurrentCommitHash') {
     }
 }
 
+tasks.create('checkEnvVariables') {
+  doFirst {
+    if (project.env.get("SHOW_INIT_DEBUG_SCREEN") != "false" || project.env.get("PREFILL_WALLET_INFO") != "false") {
+      throw new GradleException("should not allow debug flags for release builds")
+    }
+  }
+}
+
 tasks.whenTaskAdded { task ->
+    if(task.name.startsWith("bundleMainnetReleaseJsAndAssets")) {
+      task.dependsOn checkEnvVariables
+    }
     if (task.name.startsWith('install') || task.name.startsWith('assemble')) {
         task.dependsOn getCurrentCommitHash
     }

--- a/check_env_variables.sh
+++ b/check_env_variables.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+BASE_DIR="$(dirname ${BASH_SOURCE[0]})"
+cd $BASE_DIR
+PROD_ENV_FILE=".env.production"
+
+echo "Checking env variables in file $PROD_ENV_FILE"
+
+# retreive value of each env var to check
+SHOW_INIT_DEBUG_SCREEN=`grep "SHOW_INIT_DEBUG_SCREEN" "$PROD_ENV_FILE" | awk -F= '{print $2}'`
+PREFILL_WALLET_INFO=`grep "PREFILL_WALLET_INFO" "$PROD_ENV_FILE" | awk -F= '{print $2}'`
+echo "SHOW_INIT_DEBUG_SCREEN=$SHOW_INIT_DEBUG_SCREEN"
+echo "PREFILL_WALLET_INFO=$PREFILL_WALLET_INFO"
+
+if [ $SHOW_INIT_DEBUG_SCREEN != 'false' ] || [ $PREFILL_WALLET_INFO != 'false' ]
+then
+  echo "error: should not allow debug flags for this scheme"
+  exit 1
+fi

--- a/ios/emurgo.xcodeproj/project.pbxproj
+++ b/ios/emurgo.xcodeproj/project.pbxproj
@@ -1143,6 +1143,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "emurgo" */;
 			buildPhases = (
+				E911CC5C23FB1F2E00D560F8 /* Check env variables */,
 				F90484421D44E955B0727931 /* [CP] Check Pods Manifest.lock */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
@@ -1842,6 +1843,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "export SENTRY_PROPERTIES=sentry.properties\n../node_modules/@sentry/cli/bin/sentry-cli upload-dsym\n";
+		};
+		E911CC5C23FB1F2E00D560F8 /* Check env variables */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Check env variables";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# check env variables\n${PROJECT_DIR}/../check_env_variables.sh\n";
 		};
 		F7DB15954E94922466B0837E /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/src/config.js
+++ b/src/config.js
@@ -4,12 +4,17 @@ import {BigNumber} from 'bignumber.js'
 import {LogLevel} from './utils/logging'
 import env from './env'
 
-const IS_DEBUG = false
-// debugging flags
-const _SHOW_INIT_DEBUG_SCREEN = false
-const _PREFILL_WALLET_INFO = false
+const IS_DEBUG = __DEV__
+/** debugging flags
+ *
+ * WARNING: NEVER change these flags direclty here.
+ * ALWAYS use the corresponding .env files.
+ */
+const _SHOW_INIT_DEBUG_SCREEN = env.getBoolean('SHOW_INIT_DEBUG_SCREEN', false)
+const _PREFILL_WALLET_INFO = env.getBoolean('PREFILL_WALLET_INFO', false)
 const _USE_TESTNET = env.getBoolean('USE_TESTNET', true)
 const _SENTRY = env.getString('SENTRY')
+
 const _LOG_LEVEL = IS_DEBUG ? LogLevel.Debug : LogLevel.Warn
 const _ASSURANCE_STRICT = false
 
@@ -100,8 +105,9 @@ export const NUMBERS = {
 
 export const CONFIG = {
   DEBUG: {
-    START_WITH_INDEX_SCREEN: _SHOW_INIT_DEBUG_SCREEN,
-    PREFILL_FORMS: _PREFILL_WALLET_INFO,
+    // WARNING: NEVER change these flags
+    START_WITH_INDEX_SCREEN: __DEV__ ? _SHOW_INIT_DEBUG_SCREEN : false,
+    PREFILL_FORMS: __DEV__ ? _PREFILL_WALLET_INFO : false,
     WALLET_NAME: 'My wallet',
     IS_SHELLEY_WALLET: true,
     PASSWORD: 'aeg?eP3M:)(:',


### PR DESCRIPTION
As a first response to the issue recently found with the debug flags, the following is proposed:

1. Set the debug flags only in the `.env` files. Release builds use a specific `.env` file, so for these builds we can check the value of any sensible variable and stop the building process when necessary.
2. Use `react-native-config` to access env variables in the project. `react-native-config` also allows to access the variables from gradle during the building process,  so I added an additional task that stops building if the debug flags are set. For iOS I have setup a custom bash script that is run only in the `emurgo` scheme. 

So now, if the debug flags are set in `release` builds for android, gradle will stop with an error message:
```
Execution failed for task ':app:checkEnvVariables'.
> should not allow debug flags for release builds
```

Similarly, building the `emurgo` scheme in ios with the debug flags set will end with the following error:
```
error: should not allow debug flags for this scheme
```

Note: This doesn't prevent a developer to change the debug flags explicitly in `config.js`, it's just a first step.

