### PR TITLE
disable confirm delegation button while signing delegation tx

### DIFF
--- a/src/components/Delegation/DelegationConfirmation.js
+++ b/src/components/Delegation/DelegationConfirmation.js
@@ -200,8 +200,8 @@ const DelegationConfirmation = ({
   const transactionFee = navigation.getParam('transactionFee')
   const reward = approximateReward(amountToDelegate)
 
-  const isConfirmationDisabled = (!isEasyConfirmationEnabled && !password)
-    || processingTx
+  const isConfirmationDisabled =
+    (!isEasyConfirmationEnabled && !password) || processingTx
 
   return (
     <View style={styles.container}>

--- a/src/components/Delegation/DelegationConfirmation.js
+++ b/src/components/Delegation/DelegationConfirmation.js
@@ -101,8 +101,10 @@ const handleOnConfirm = async (
   password,
   submitShelleyTx,
   setSendingTransaction,
+  setProcessingTx,
   intl,
 ) => {
+  setProcessingTx(true)
   const delegationTxData = navigation.getParam('delegationTxData')
 
   const signAndSubmitTx = async (decryptedKey) => {
@@ -153,6 +155,8 @@ const handleOnConfirm = async (
       } else {
         throw e
       }
+    } finally {
+      setProcessingTx(false)
     }
 
     return
@@ -174,6 +178,8 @@ const handleOnConfirm = async (
     } else {
       handleGeneralError('Could not submit transaction', e, intl)
     }
+  } finally {
+    setProcessingTx(false)
   }
 }
 
@@ -185,6 +191,7 @@ const DelegationConfirmation = ({
   password,
   setPassword,
   sendingTransaction,
+  processingTx,
   doNothing,
 }) => {
   const poolHash = navigation.getParam('poolHash')
@@ -193,7 +200,8 @@ const DelegationConfirmation = ({
   const transactionFee = navigation.getParam('transactionFee')
   const reward = approximateReward(amountToDelegate)
 
-  const isConfirmationDisabled = !isEasyConfirmationEnabled && !password
+  const isConfirmationDisabled = (!isEasyConfirmationEnabled && !password)
+    || processingTx
 
   return (
     <View style={styles.container}>
@@ -279,12 +287,16 @@ export default injectIntl(
       {
         password: CONFIG.DEBUG.PREFILL_FORMS ? CONFIG.DEBUG.PASSWORD : '',
         sendingTransaction: false,
+        processingTx: false,
       },
       {
         doNothing: () => () => ({}),
         setPassword: (state) => (value) => ({password: value}),
         setSendingTransaction: () => (sendingTransaction) => ({
           sendingTransaction,
+        }),
+        setProcessingTx: () => (processingTx) => ({
+          processingTx,
         }),
       },
     ),
@@ -296,6 +308,7 @@ export default injectIntl(
           password,
           submitShelleyTx,
           setSendingTransaction,
+          setProcessingTx,
           intl,
         }) => async (event) => {
           await handleOnConfirm(
@@ -304,6 +317,7 @@ export default injectIntl(
             password,
             submitShelleyTx,
             setSendingTransaction,
+            setProcessingTx,
             intl,
           )
         },


### PR DESCRIPTION
Simple UI change that just disables the delegation button to signal users that their delegation tx is being processed and to avoid multiple clicks. 

Notes:
- **This change might be imperceptible**. It was more relevant when the PIN validation was taking several seconds. Decrypting the master key and signing the tx is now fast enough to make this change irrelevant---but they might be some exceptions. I tested for both easy confirmation (with fingerprint) and pin, and in both cases the "sending tx" dialog was displayed immediately.
- I didn't add another modal or rolling wheel because that doesn't work well in iOS and because there is already one for when the tx is actually being sent to the backend.

EDIT: Again, ignore lint and flow errors, which should be fixed in another open PR.