### PR TITLE
preventive fix wallet restore from storage

### DIFF
--- a/src/crypto/shelley/delegationUtils.js
+++ b/src/crypto/shelley/delegationUtils.js
@@ -196,7 +196,6 @@ export const signDelegationTx = async (
   signingKey: Bip32PrivateKey,
   stakingKey: PrivateKey,
 ): Promise<V3SignedTx> => {
-  Logger.debug('signDelegationTx called')
   const {certificate, changeAddr, senderUtxos, IOs} = unsignedDelegationTx
   try {
     if (certificate == null) {
@@ -223,12 +222,10 @@ export const signDelegationTx = async (
     )
     const encodedTx = await signedTx.as_bytes()
 
-    const response = {
+    return {
       id,
       encodedTx,
     }
-    Logger.debug('signDelegationTx success', response)
-    return response
   } catch (error) {
     Logger.error(`signDelegationTx error: ${error}`)
     throw error

--- a/src/crypto/wallet.js
+++ b/src/crypto/wallet.js
@@ -322,8 +322,8 @@ export class Wallet {
     this._state = {
       lastGeneratedAddressIndex: data.lastGeneratedAddressIndex,
     }
-    this._isShelley = data.isShelley
-    this._accountAddress = data.accountAddress
+    this._isShelley = data.isShelley != null ? data.isShelley : false
+    this._accountAddress = data.accountAddress != null ? data.accountAddress : null
     this._version = data.version != null ? data.version : null
     this._internalChain = AddressChain.fromJSON(data.internalChain)
     this._externalChain = AddressChain.fromJSON(data.externalChain)

--- a/src/crypto/wallet.js
+++ b/src/crypto/wallet.js
@@ -323,7 +323,8 @@ export class Wallet {
       lastGeneratedAddressIndex: data.lastGeneratedAddressIndex,
     }
     this._isShelley = data.isShelley != null ? data.isShelley : false
-    this._accountAddress = data.accountAddress != null ? data.accountAddress : null
+    this._accountAddress =
+      data.accountAddress != null ? data.accountAddress : null
     this._version = data.version != null ? data.version : null
     this._internalChain = AddressChain.fromJSON(data.internalChain)
     this._externalChain = AddressChain.fromJSON(data.externalChain)
@@ -648,10 +649,6 @@ export class Wallet {
   ): Promise<V3SignedTx> {
     assert.assert(this._isShelley, 'signShelleyTx: isShelley')
     Logger.debug('wallet::signDelegationTx::unsignedTx ', unsignedTx)
-    Logger.debug(
-      'wallet::signDelegationTx::decryptedMasterKey',
-      decryptedMasterKey,
-    )
     const masterKey = await Bip32PrivateKey.from_bytes(
       Buffer.from(decryptedMasterKey, 'hex'),
     )
@@ -1005,9 +1002,6 @@ class WalletManager {
     assert.assert(wallet._id, 'saveState:: wallet._id')
     /* :: if (!this._wallet) throw 'assert' */
     const data = wallet.toJSON()
-
-    Logger.debug('saveState::isShelley', data.isShelley)
-
     await storage.write(`/wallet/${wallet._id}/data`, data)
   }
 
@@ -1207,7 +1201,7 @@ class WalletManager {
       )
       Logger.debug(
         'WalletManager::checkForFlawedWallets flawedAddresses [0]:',
-        flawedAddresses
+        flawedAddresses,
       )
       if (this._wallet._externalChain.isMyAddress(flawedAddresses[0])) {
         Logger.debug('WalletManager::checkForFlawedWallets: address match')


### PR DESCRIPTION
Just in case I added a small change to check for null values in variables added for Shelley wallets. Might be redundant but with JS we never know.

Also I removed a few `Logger.debug()` lines.