### PR TITLE
improve chain libs memory management

### DIFF
--- a/src/crypto/shelley/delegationUtils.js
+++ b/src/crypto/shelley/delegationUtils.js
@@ -60,11 +60,14 @@ export const groupAddrContainsAccountKey = async (
     return false
   }
   const groupKey = await wasmAddr.to_group_address()
+  await wasmAddr.free()
   if (groupKey == null) return false
   const accountKey = await groupKey.get_account_key()
+  await groupKey.free()
   const accountKeyString = Buffer.from(await accountKey.as_bytes()).toString(
     'hex',
   )
+  await accountKey.free()
   return targetAccountKey === accountKeyString
 }
 
@@ -134,7 +137,9 @@ export const getDifferenceAfterTx = async (
         const value = new BigNumber(await (await output.value()).to_str())
         sumOutForKey = sumOutForKey.plus(value)
       }
+      await output.free()
     }
+    await outputs.free()
   }
 
   return sumOutForKey.minus(sumInForKey)
@@ -165,6 +170,7 @@ export const createDelegationTx = async (
     addressedUtxos,
     certificate,
   )
+  await certificate.free()
 
   const allUtxosForKey = await filterAddressesByStakingKey(
     stakingKey,
@@ -222,6 +228,7 @@ export const signDelegationTx = async (
       'hex',
     )
     const encodedTx = await signedTx.as_bytes()
+    await signedTx.free()
 
     const response = {
       id,

--- a/src/crypto/shelley/transactions/__mocks__/accountingTransactions.js
+++ b/src/crypto/shelley/transactions/__mocks__/accountingTransactions.js
@@ -115,7 +115,6 @@ export const buildUnsignedAccountTx = async (
     await OutputPolicy.forget(),
   )
 
-
   return IOs
 }
 

--- a/src/crypto/shelley/transactions/__mocks__/utxoTransactions.js
+++ b/src/crypto/shelley/transactions/__mocks__/utxoTransactions.js
@@ -1,6 +1,11 @@
 // @flow
 
 /**
+ * this file should be almost exaclty than the original (in ../). It basically
+ * doesn't free the rust pointers because jest uses a node version of chain
+ * libs that crashes when freeing a null pointer (by contrast, in the original
+ * file we free everything (including possible null pointers))
+ *
  * note: the functions in this module have been borrowed from yoroi-frontend:
  * https://github.com/Emurgo/yoroi-frontend/blob/shelley/app/api/ada/
  * transactions/shelley/utxoTransactions.js

--- a/src/crypto/shelley/transactions/utxoTransactions.js
+++ b/src/crypto/shelley/transactions/utxoTransactions.js
@@ -1,6 +1,9 @@
 // @flow
 
 /**
+ * HEADS UP: when modifying or adding new functions to this library, keep
+ * in mind there is a copy in ./__mocks__ that needs to be in sync.
+ *
  * note: the functions in this module have been borrowed from yoroi-frontend:
  * https://github.com/Emurgo/yoroi-frontend/blob/shelley/app/api/ada/
  * transactions/shelley/utxoTransactions.js

--- a/src/jestSetup.js
+++ b/src/jestSetup.js
@@ -11,6 +11,10 @@ jest.setMock(
   './crypto/shelley/transactions/utxoTransactions',
   require('./crypto/shelley/transactions/__mocks__/utxoTransactions'),
 )
+jest.setMock(
+  './crypto/shelley/transactions/accountingTransactions',
+  require('./crypto/shelley/transactions/__mocks__/accountingTransactions'),
+)
 jest.mock('react-native-device-info', () => {
   return {
     getVersion: () => '1.5.1',


### PR DESCRIPTION
In `js-chain-libs` some methods use a local copies of data while others operate on the input memory directly. As a consequence, it's difficul tot know when it's ok to free the pointers.

Fortunately, we can safely free everything in `react-native-chain-libs`, because freeing a null pointer doest not throw any error.

So I added a `.free()` to all objects once they are not used anymore.