### PR TITLE
fix network info in settings

### DIFF
--- a/src/components/Settings/ApplicationSettingsScreen.js
+++ b/src/components/Settings/ApplicationSettingsScreen.js
@@ -235,7 +235,7 @@ const ApplicationSettingsScreen = ({
 
       <SettingsBuildItem
         label={intl.formatMessage(messages.network)}
-        value={CONFIG.NETWORK}
+        value={'Byron Mainnet / Shelley Testnet'}
       />
 
       <SettingsBuildItem


### PR DESCRIPTION
Currently we can only have builds that support both the Byron mainnet and the shelley testnet, so I'm hardcoding this information in the "network" label displayed in the settings.

This should be fixed in the future once the `.env` and `CONFIG.js` files are fixed.

Result:

<img width="339" alt="Screenshot 2020-02-27 at 13 41 43" src="https://user-images.githubusercontent.com/7271744/75446428-b4520880-5967-11ea-81f3-0482c4a0384e.png">
