### PR TITLE
warn users of re-delegation tx delay

### DIFF
--- a/src/components/Delegation/dashboard/DelegatedStakepoolInfo.js
+++ b/src/components/Delegation/dashboard/DelegatedStakepoolInfo.js
@@ -16,6 +16,12 @@ const messages = defineMessages({
     id: 'components.delegationsummary.delegatedStakepoolInfo.title',
     defaultMessage: '!!!Stake pool delegated',
   },
+  warning: {
+    id: 'components.delegationsummary.delegatedStakepoolInfo.warning',
+    defaultMessage:
+      '!!!If you just delegated to a new stake pool it may ' +
+      ' take a couple of minutes for the network to process your request.',
+  },
   fullDescriptionButtonLabel: {
     id:
       'components.delegationsummary.delegatedStakepoolInfo.fullDescriptionButtonLabel',
@@ -42,7 +48,7 @@ const DelegatedStakepoolInfo = ({
   <View style={styles.wrapper}>
     <TitledCard title={intl.formatMessage(messages.title)} variant={'poolInfo'}>
       <View style={styles.topBlock}>
-        <Text bold style={styles.pooName}>
+        <Text bold style={styles.poolName}>
           {formatStakepoolNameWithTicker(poolTicker, poolName)}
         </Text>
         <View style={styles.poolHashBlock}>
@@ -66,6 +72,9 @@ const DelegatedStakepoolInfo = ({
         />
       </View>
     </TitledCard>
+    <Text secondary style={styles.warning}>
+      {intl.formatMessage(messages.warning)}
+    </Text>
   </View>
 )
 

--- a/src/components/Delegation/dashboard/styles/DelegatedStakepoolInfo.style.js
+++ b/src/components/Delegation/dashboard/styles/DelegatedStakepoolInfo.style.js
@@ -14,7 +14,7 @@ export default StyleSheet.create({
     paddingVertical: 10,
     paddingHorizontal: 16,
   },
-  pooName: {
+  poolName: {
     lineHeight: 24,
     fontSize: 16,
   },
@@ -31,5 +31,11 @@ export default StyleSheet.create({
   bottomBlock: {
     paddingHorizontal: 16,
     paddingVertical: 20,
+  },
+  warning: {
+    fontStyle: 'italic',
+    marginTop: 10,
+    fontSize: 12,
+    lineHeight: 14,
   },
 })

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -9,6 +9,7 @@
   "components.delegation.delegationnavigationbuttons.stakingCenterButton": "Go to Staking Center",
   "components.delegationsummary.delegatedStakepoolInfo.fullDescriptionButtonLabel": "Go to website",
   "components.delegationsummary.delegatedStakepoolInfo.title": "Stake pool delegated",
+  "components.delegationsummary.delegatedStakepoolInfo.warning": "If you just delegated to a new stake pool, it may take a couple of minutes for the network to process your request.",
   "components.delegationsummary.epochProgress.endsIn": "Ends in",
   "components.delegationsummary.epochProgress.title": "Epoch progress",
   "components.delegationsummary.failedwalletupgrademodal.title": "Heads up!",


### PR DESCRIPTION
This adds a paragraph below the "Stake pool delegated" card.

(I can't directly add it below the title because it's a `TitledCard` component and it doesn't allow to add a subtitle).

Result:

<img width="339" alt="Screenshot 2020-02-27 at 15 27 25" src="https://user-images.githubusercontent.com/7271744/75456468-dc973280-597a-11ea-820b-43563650f61c.png">






