### PR TITLE
re-enable retry shelley modal

### DIFF
--- a/src/components/WalletSelection/WalletSelectionScreen.js
+++ b/src/components/WalletSelection/WalletSelectionScreen.js
@@ -57,16 +57,11 @@ const WalletListScreen = ({
   <SafeAreaView style={styles.safeAreaView}>
     <StatusBar type="dark" />
 
-    {/* eslint-disable indent */
-    false && (
-      <FailedWalletUpgradeModal
-        visible={showModal}
-        onPress={() => setShowModal(false)}
-        onRequestClose={() => setShowModal(false)}
-      />
-    )
-    /* eslint-enable indent */
-    }
+    <FailedWalletUpgradeModal
+      visible={showModal}
+      onPress={() => setShowModal(false)}
+      onRequestClose={() => setShowModal(false)}
+    />
 
     <Screen style={styles.container}>
       <ScreenBackground>
@@ -118,7 +113,7 @@ export default injectIntl(
     ),
     withStateHandlers(
       {
-        showModal: true,
+        showModal: false,
       },
       {
         setShowModal: (state) => (value) => ({showModal: value}),


### PR DESCRIPTION
This re-enables the modal introduced in https://github.com/Emurgo/yoroi-mobile/pull/781.

**Important:** This PR must be merged together with a version bump >= 2.0.5 (follow up PR), otherwise the modal will not be disabled after the user closes it and it will be shown every time the user visits the wallet list screen.