### PR TITLE
enforce secure connections on iOS

### DIFF
--- a/ios/Staging-Info.plist
+++ b/ios/Staging-Info.plist
@@ -29,7 +29,7 @@
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
-		<true/>
+		<false/>
 		<key>NSExceptionDomains</key>
 		<dict>
 			<key>localhost</key>

--- a/ios/emurgo/Info.plist
+++ b/ios/emurgo/Info.plist
@@ -29,7 +29,7 @@
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
-		<true/>
+		<false/>
 		<key>NSExceptionDomains</key>
 		<dict>
 			<key>localhost</key>


### PR DESCRIPTION
This PR enables App Transport Security on iOS. From now on only HTPPS connections should be allowed.

More information: https://developer.apple.com/documentation/security/preventing_insecure_network_connections