### PR TITLE
modify delegation delay explanation string

### DIFF
--- a/src/components/Delegation/dashboard/UpcomingRewardInfo.js
+++ b/src/components/Delegation/dashboard/UpcomingRewardInfo.js
@@ -18,9 +18,9 @@ const messages = defineMessages({
   rewardDisclaimerText: {
     id: 'components.delegationsummary.upcomingReward.rewardDisclaimerText',
     defaultMessage:
-      '!!!Remember that your first reward will be allocated ' +
-      'two  epochs after the end of the epoch in which you have submitted ' +
-      'your delegation transaction.',
+      '!!!Note that after you delegate to a stake pool, you will need ' +
+      'to wait until the end of the epoch, plus two additional epochs, ' +
+      'before starting receiving rewards.',
   },
 })
 

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -27,7 +27,7 @@
   "components.delegationsummary.notDelegatedInfo.secondLine": "Go to Staking center to choose which stake pool you want to delegate in. Note, you may delegate only to one stake pool in this Tesnnet.",
   "components.delegationsummary.upcomingReward.followingLabel": "Following reward",
   "components.delegationsummary.upcomingReward.nextLabel": "Next reward",
-  "components.delegationsummary.upcomingReward.rewardDisclaimerText": "Remember that your first reward will be allocated two epochs after the end of the epoch in which you have submitted your delegation transaction.",
+  "components.delegationsummary.upcomingReward.rewardDisclaimerText": "Note that after you delegate to a stake pool, there will be a delay of two epochs before you start receiving rewards.",
   "components.delegationsummary.userSummary.title": "Your summary",
   "components.delegationsummary.userSummary.totalDelegated": "Total Delegated",
   "components.delegationsummary.userSummary.totalRewards": "Total Rewards",

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -294,8 +294,6 @@
   "global.actions.dialogs.logout.noButton": "No",
   "global.actions.dialogs.logout.title": "Logout",
   "global.actions.dialogs.logout.yesButton": "Yes",
-  "global.actions.dialogs.apiError.title": "API error",
-  "global.actions.dialogs.apiError.message": "Error received from api method call while sending transaction. Please try again later or check our Twitter account (https://twitter.com/YoroiWallet)",
   "global.actions.dialogs.insufficientBalance.title": "Transaction error",
   "global.actions.dialogs.insufficientBalance.message": "Not enough funds to make this transaction",
   "global.actions.dialogs.networkError.message": "Error connecting to the server. Please check your internet connection",

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -27,7 +27,7 @@
   "components.delegationsummary.notDelegatedInfo.secondLine": "Go to Staking center to choose which stake pool you want to delegate in. Note, you may delegate only to one stake pool in this Tesnnet.",
   "components.delegationsummary.upcomingReward.followingLabel": "Following reward",
   "components.delegationsummary.upcomingReward.nextLabel": "Next reward",
-  "components.delegationsummary.upcomingReward.rewardDisclaimerText": "Note that after you delegate to a stake pool, there will be a delay of two epochs before you start receiving rewards.",
+  "components.delegationsummary.upcomingReward.rewardDisclaimerText": "Note that after you delegate to a stake pool, you will need to wait until the end of the current epoch, plus two additional epochs, before starting receiving rewards.",
   "components.delegationsummary.userSummary.title": "Your summary",
   "components.delegationsummary.userSummary.totalDelegated": "Total Delegated",
   "components.delegationsummary.userSummary.totalRewards": "Total Rewards",


### PR DESCRIPTION
As requested, changed

> "Remember that your first reward will be allocated two epochs after the end of the epoch in which you have submitted your delegation transaction" 


by

>~~"Note that after you delegate to a stake pool, there will be a delay of two epochs before you start receiving rewards".~~

> Note that after you delegate to a stake pool, you will need to wait until the end of the epoch, plus two additional epochs, before starting receiving rewards.