### PR TITLE
fix vulnerability in minimist

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
     "react-test-renderer": "16.8.3"
   },
   "resolutions": {
-    "base-x": "3.0.4"
+    "base-x": "3.0.4",
+    "minimist": "1.2.3"
   },
   "jest": {
     "transform": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6387,20 +6387,10 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
-  integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
+minimist@0.0.8, minimist@1.2.3, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@~0.0.1:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.3.tgz#3db5c0765545ab8637be71f333a104a965a9ca3f"
+  integrity sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==
 
 minipass@^2.2.1, minipass@^2.3.4:
   version "2.3.5"


### PR DESCRIPTION
As I mentioned in the ticket description, fixing this requires: 

1) update react-native (on going)
2) bump eslint to version >7.0.0
3) add `"minimist": "1.2.3"` in resolutions entry in `package.json`, effectively forcing all dependencies to rely on 1.2.3.

This PR only does 3). 

Doing 2) breaks our configuration and also, 7.0.0 is still in alpha. IMO, we can skip it because forcing resolution on 1.2.3 doesn't seem to break anything in eslint.

I'll keep this as a draft until 1) is completed.