### PR TITLE
prevent nightly builds to have debug flags set

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -247,7 +247,7 @@ tasks.create('checkEnvVariables') {
 }
 
 tasks.whenTaskAdded { task ->
-    if(task.name.startsWith("bundleMainnetReleaseJsAndAssets")) {
+    if(task.name.startsWith("bundleMainnetReleaseJsAndAssets") || task.name.startsWith("bundleNightly")) {
       task.dependsOn checkEnvVariables
     }
     if (task.name.startsWith('install') || task.name.startsWith('assemble')) {


### PR DESCRIPTION
Nightly builds shouldn't have debug flags set. So this change simply adds the 'check environmental variables' script to the Android compilation process (both _debug_ and _release_ variants).