### PR TITLE
fix wrong password crash for good

### DIFF
--- a/src/components/Delegation/DelegationConfirmation.js
+++ b/src/components/Delegation/DelegationConfirmation.js
@@ -32,7 +32,6 @@ import {NetworkError, ApiError} from '../../api/errors'
 import {WrongPassword} from '../../crypto/errors'
 import walletManager, {SystemAuthDisabled} from '../../crypto/wallet'
 import KeyStore from '../../crypto/KeyStore'
-import {KNOWN_ERROR_MSG} from '../../crypto/byron/util'
 
 import styles from './styles/DelegationConfirmation.style'
 
@@ -155,12 +154,7 @@ const handleOnConfirm = async (
 
     signAndSubmitTx(decryptedData)
   } catch (e) {
-    if (
-      e instanceof WrongPassword ||
-      // for some reason WrongPassword is not detected by instanceof so I need
-      // to add this hack
-      e.message === KNOWN_ERROR_MSG.DECRYPT_FAILED
-    ) {
+    if (e instanceof WrongPassword) {
       await showErrorDialog(errorMessages.incorrectPassword, intl)
     } else {
       handleGeneralError(

--- a/src/crypto/byron/util.js
+++ b/src/crypto/byron/util.js
@@ -100,7 +100,7 @@ export const decryptData = async (
     if (useJs) {
       return await decryptWithPasswordJs(secretKeyHex, ciphertext)
     }
-    return PasswordProtect.decryptWithPassword(secretKeyHex, ciphertext)
+    return await PasswordProtect.decryptWithPassword(secretKeyHex, ciphertext)
   } catch (e) {
     if (e.message === KNOWN_ERROR_MSG.DECRYPT_FAILED) {
       throw new WrongPassword()

--- a/src/crypto/customPin.js
+++ b/src/crypto/customPin.js
@@ -1,5 +1,5 @@
 // @flow
-import {encryptData, decryptData, KNOWN_ERROR_MSG} from './byron/util'
+import {encryptData, decryptData} from './byron/util'
 import {WrongPassword} from './errors'
 
 export const encryptCustomPin = async (installationId: string, pin: string) => {
@@ -16,12 +16,7 @@ export const authenticateByCustomPin = async (
     await decryptData(customPinHash, pinCandidate)
     return true
   } catch (err) {
-    if (
-      err instanceof WrongPassword ||
-      // for some reason WrongPassword is not detected by instanceof so I need
-      // to add this hack
-      err.message === KNOWN_ERROR_MSG.DECRYPT_FAILED
-    ) {
+    if (err instanceof WrongPassword) {
       return false
     }
     throw err


### PR DESCRIPTION
The original bug that caused the wrong password crash was identified and fixed. It was simply a missing `await`.

The exception `WrongPassword` exception now is correctly caught. Tested in both Android and iOS.