### PR TITLE
improve general error message UI

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,16 +34,6 @@ bluebird.config({
   warnings: true,
 })
 
-/*
-  Warning(ppershing): DO NOT EVER REMOVE FOLLOWING LINE!
-  React-native promise implementation is totally broken, see
-  https://github.com/facebook/react-native/issues/19490
-  https://github.com/facebook/react-native/issues/17972
-*/
-global.Promise = bluebird
-
-global.onunhandledrejection = (e) => handleGeneralError(e.message, e)
-
 // https://github.com/yahoo/react-intl/wiki#loading-locale-data
 addLocaleData([
   ...en,
@@ -58,6 +48,21 @@ addLocaleData([
   ...fr,
   ...it,
 ])
+
+/*
+  Warning(ppershing): DO NOT EVER REMOVE FOLLOWING LINE!
+  React-native promise implementation is totally broken, see
+  https://github.com/facebook/react-native/issues/19490
+  https://github.com/facebook/react-native/issues/17972
+*/
+global.Promise = bluebird
+
+const intlProvider = new IntlProvider({
+  locale: 'en-US',
+  messages: translations['en-US'],
+})
+const {intl} = intlProvider.getChildContext()
+global.onunhandledrejection = (e) => handleGeneralError(e.message, e, intl)
 
 const store = getConfiguredStore()
 


### PR DESCRIPTION
I found how to inject the `intl` object to a function (not a component), so that the general error handler (which intercepts any unexpected exception) can use it. It will only show the message in English though, as the actual user locale is not loaded at the point the handler is registered.

Before we saw:

<img width="338" alt="Screenshot 2020-04-15 at 21 29 01" src="https://user-images.githubusercontent.com/7271744/79383270-3375bd00-7f65-11ea-9556-ee49ffceef1e.png">


Now we should see:

<img width="338" alt="Screenshot 2020-04-15 at 21 48 57" src="https://user-images.githubusercontent.com/7271744/79383307-44263300-7f65-11ea-85f3-dec134bc3326.png">





