### PR TITLE
attempt to remove BIND_GET_INSTALL_REFERRER_SERVICE perm

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.emurgo">
 
     <uses-permission android:name="android.permission.INTERNET" />
@@ -12,6 +13,10 @@
     <!-- note(v-almonacid): added FINE_LOCATION instead of COARSE_LOCATION as target API >= 29 -->
     <!-- see https://developer.android.com/guide/topics/connectivity/bluetooth-le.html#permissions -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission
+      android:name="com.google.android.finsky.permission.BIND_GET_INSTALL_REFERRER_SERVICE"
+      tools:node="remove"
+    />
 
     <application
       android:name=".MainApplication"


### PR DESCRIPTION
This issue appears to be linked with `react-native-device-info`, which has been bumped recently from 2.3.2 to 5.5.7.

Somebody already reported a similar issue here https://github.com/react-native-community/react-native-device-info/issues/955

As a general solution to avoid undesired/non-required permission requests from other dependencies, see https://stackoverflow.com/questions/31616334/how-to-remove-specific-permission-when-build-android-app-with-gradle