### PR TITLE
disable ledger USB support on old android devices

### DIFF
--- a/src/components/Ledger/LedgerTransportSwitchModal.js
+++ b/src/components/Ledger/LedgerTransportSwitchModal.js
@@ -131,7 +131,8 @@ export default injectIntl(
       },
       {
         checkUSBSupport: () => (sdk) => {
-          const isUSBSupported = Platform.OS === 'android' &&
+          const isUSBSupported =
+            Platform.OS === 'android' &&
             sdk >= CONFIG.HARDWARE_WALLETS.LEDGER_NANO.USB_MIN_SDK
           return {isUSBSupported}
         },

--- a/src/config.js
+++ b/src/config.js
@@ -104,6 +104,7 @@ const HARDWARE_WALLETS = {
     VENDOR: 'ledger.com',
     MODEL: 'Nano',
     ENABLE_USB_TRANSPORT: true,
+    USB_MIN_SDK: 26, // USB transport only supported for Android SDK >= 26
   },
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -104,7 +104,7 @@ const HARDWARE_WALLETS = {
     VENDOR: 'ledger.com',
     MODEL: 'Nano',
     ENABLE_USB_TRANSPORT: true,
-    USB_MIN_SDK: 26, // USB transport only supported for Android SDK >= 26
+    USB_MIN_SDK: 24, // USB transport officially supported for Android SDK >= 24
   },
 }
 


### PR DESCRIPTION
As a mesure of precaution, I figured it'd be better to disable (by default) support for USB Ledger connection for Android < 24, which is the min sdk supported by Ledger's `react-native-hid` (recall: we use a fork of it with min sdk = 21).

I recently mentioned that there was a commit in which they bumped the min SDK and used a Java function for Android >= 26 but turns out I was wrong: after double checking I noticed they rolled-back that. Even though I *think* this should work on Android < 24, since we cannot do much testing on older devices I propose we just disable the feature.

Users on old devices will just see the button disabled (tested on emulator running SDK 21):

<img width="307" alt="Screenshot 2020-06-24 at 13 16 51" src="https://user-images.githubusercontent.com/7271744/85551370-3acedc00-b622-11ea-8f7c-a04bd0dbbd36.png">

