### PR TITLE
Fixed placeholder color in darkmode (IOS)

### DIFF
--- a/ios/emurgo/Info.plist
+++ b/ios/emurgo/Info.plist
@@ -65,6 +65,8 @@
 	<string>Enable speech recognition</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>	
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>


### PR DESCRIPTION
after research about the problem seems like there are two ways to solve the bug
- override this behaviour by setting placeholderTextColor on the Input
- disable app's dark mode support in  Info.plist file

seems like setting the placeholderTextColor its more like a workaround the problem (since every time we use an Input we have to explicit specify placeholder color)
I think disable app dark mode its more approachable solution because its more general, will not affect the app and we have to change it just in one place in all the application without overriding any styles 

⚠️ on emulator its working ok but needs to be tested on a real device still just to be sure 

![Screenshot 2020-07-17 at 10 50 47](https://user-images.githubusercontent.com/37213944/87762710-39a55f00-c81c-11ea-866a-71f08f5f72a8.png)

