### PR TITLE
add wallet on shelley button

### DIFF
--- a/src/components/WalletInit/WalletFreshInitScreen.js
+++ b/src/components/WalletInit/WalletFreshInitScreen.js
@@ -58,9 +58,22 @@ const WalletInitScreen = ({
             onPress={(event) =>
               navigateInitWallet(event, NETWORK_REGISTRY.HASKELL_SHELLEY)
             }
-            title={intl.formatMessage(messages.addWalletButton)}
+            title={`${intl.formatMessage(
+              messages.addWalletButton,
+            )} (Byron-era)`}
             style={styles.createButton}
             testID="addWalletOnByronButton"
+          />
+
+          <Button
+            onPress={(event) => ({})}
+            outline
+            disabled
+            title={`${intl.formatMessage(
+              messages.addWalletButton,
+            )} (Shelley-era)`}
+            style={styles.createButton}
+            testID="addWalletOnHaskellShelleyButton"
           />
 
           {NETWORKS.JORMUNGANDR.ENABLED && (

--- a/src/components/WalletSelection/WalletSelectionScreen.js
+++ b/src/components/WalletSelection/WalletSelectionScreen.js
@@ -89,8 +89,18 @@ const WalletListScreen = ({
           onPress={(event) =>
             navigateInitWallet(event, NETWORK_REGISTRY.HASKELL_SHELLEY)
           }
-          title={intl.formatMessage(messages.addWalletButton)}
+          title={`${intl.formatMessage(messages.addWalletButton)} (Byron-era)`}
           style={styles.addWalletButton}
+        />
+
+        <Button
+          disabled
+          outline
+          onPress={(event) => ({})}
+          title={`${intl.formatMessage(
+            messages.addWalletButton,
+          )} (Shelley-era)`}
+          style={styles.addWalletOnShelleyButton}
         />
 
         {NETWORKS.JORMUNGANDR.ENABLED && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -12608,7 +12608,7 @@ react-native-fs@^2.11.18:
 
 react-native-haskell-shelley@Emurgo/react-native-haskell-shelley:
   version "1.0.0"
-  resolved "https://codeload.github.com/Emurgo/react-native-haskell-shelley/tar.gz/918b84f976ecb5e0274106e662c25a5a7d564519"
+  resolved "https://codeload.github.com/Emurgo/react-native-haskell-shelley/tar.gz/b73fa933f9acd72df789a591f0e476920fba1c2c"
   dependencies:
     base-64 "0.1.0"
 


### PR DESCRIPTION
## Fresh install
Note: the "Add wallet (Shelley-era)" button is disabled.

![image](https://user-images.githubusercontent.com/7271744/89806756-d7e4c600-db37-11ea-86fa-bf939154ce38.png)

## Add wallet (Byron era) flow
Here the Ledger option is disabled.

![image](https://user-images.githubusercontent.com/7271744/89806964-1da18e80-db38-11ea-8cbb-56ab71da2b4b.png)

## Non-fresh install (user already has 1+ wallet)

![image](https://user-images.githubusercontent.com/7271744/89807008-2f833180-db38-11ea-8e2e-2b5b307e6c5b.png)
