### PR TITLE
fix back button not showing up

### DIFF
--- a/src/components/Delegation/StakingDashboardNavigator.js
+++ b/src/components/Delegation/StakingDashboardNavigator.js
@@ -8,6 +8,7 @@ import {STAKING_DASHBOARD_ROUTES, WALLET_ROUTES} from '../../RoutesList'
 import SettingsScreenNavigator from '../Settings/SettingsScreenNavigator'
 import iconGear from '../../assets/img/gear.png'
 import {isJormungandr} from '../../config/networks'
+import HeaderBackButton from '../UiKit/HeaderBackButton'
 
 import {
   defaultNavigationOptions,
@@ -51,7 +52,10 @@ const DelegationNavigatorSummary = createStackNavigator(
   },
   {
     initialRouteName: STAKING_DASHBOARD_ROUTES.MAIN,
-    ...defaultStackNavigatorOptions,
+    navigationOptions: ({navigation}) => ({
+      headerLeft: <HeaderBackButton navigation={navigation} />,
+      ...defaultStackNavigatorOptions,
+    }),
   },
 )
 


### PR DESCRIPTION
This simply adds the back button in the dashboard, which is important for iOS devices which do not have a hardware back button (though some devices allow to swipe back)

<img width="339" alt="Screenshot 2020-08-31 at 22 15 24" src="https://user-images.githubusercontent.com/7271744/91764445-9c3d9900-ebd7-11ea-9623-33fa147bd07e.png">
