### PR TITLE
attempt to prevent null deviceId error

### DIFF
--- a/src/actions/hwWallet.js
+++ b/src/actions/hwWallet.js
@@ -1,6 +1,7 @@
 // @flow
 import {hwDeviceInfoSelector} from '../selectors'
 import {Logger} from '../utils/logging'
+import {NoDeviceInfoError} from '../crypto/shelley/ledgerUtils'
 
 import type {Dispatch} from 'redux'
 import type {
@@ -31,8 +32,7 @@ export const setLedgerDeviceId = (deviceId: DeviceId) => (
   const state = getState()
   const hwDeviceInfo = hwDeviceInfoSelector(state)
   if (hwDeviceInfo == null || hwDeviceInfo.hwFeatures == null) {
-    Logger.warn('hwDeviceInfo.hwFeatures is null')
-    return
+    throw new NoDeviceInfoError()
   }
   hwDeviceInfo.hwFeatures.deviceId = deviceId
   dispatch(_saveHW(hwDeviceInfo))
@@ -46,8 +46,7 @@ export const setLedgerDeviceObj = (deviceObj: DeviceObj) => (
   const state = getState()
   const hwDeviceInfo = hwDeviceInfoSelector(state)
   if (hwDeviceInfo == null || hwDeviceInfo.hwFeatures == null) {
-    Logger.warn('hwDeviceInfo.hwFeatures is null')
-    return
+    throw new NoDeviceInfoError()
   }
   hwDeviceInfo.hwFeatures.deviceObj = deviceObj
   dispatch(_saveHW(hwDeviceInfo))

--- a/src/components/Ledger/LedgerConnect.js
+++ b/src/components/Ledger/LedgerConnect.js
@@ -206,6 +206,10 @@ class LedgerConnect extends React.Component<Props, State> {
     this._unsubscribe()
     const {onConnectBLE} = this.props
     try {
+      if (device.id == null) {
+        // should never happen
+        throw new Error('device id is null')
+      }
       this.setState({
         deviceId: device.id.toString(),
         refreshing: false,
@@ -225,9 +229,12 @@ class LedgerConnect extends React.Component<Props, State> {
   }
 
   _onConfirm = async (deviceObj: ?DeviceObj): Promise<void> => {
-    if (deviceObj == null) return // should never happen
     this._unsubscribe()
     try {
+      if (deviceObj == null) {
+        // should never happen
+        throw new Error('deviceObj is null')
+      }
       this.setState({
         waiting: true,
       })

--- a/src/components/WalletInit/ConnectNanoX/SaveNanoXScreen.js
+++ b/src/components/WalletInit/ConnectNanoX/SaveNanoXScreen.js
@@ -136,8 +136,8 @@ export default injectIntl(
           walletImplementationId,
           hwDeviceInfo,
         )
-        navigation.navigate(ROOT_ROUTES.WALLET)
         saveHW(hwDeviceInfo)
+        navigation.navigate(ROOT_ROUTES.WALLET)
       },
     }),
     withHandlers({

--- a/src/crypto/shelley/ledgerUtils.js
+++ b/src/crypto/shelley/ledgerUtils.js
@@ -122,6 +122,15 @@ export class DeprecatedFirmwareError extends LocalizableError {
   }
 }
 
+export class NoDeviceInfoError extends LocalizableError {
+  constructor() {
+    super({
+      id: ledgerMessages.noDeviceInfoError.id,
+      defaultMessage: ledgerMessages.noDeviceInfoError.defaultMessage,
+    })
+  }
+}
+
 const _isConnectionError = (e: Error | TransportStatusError): boolean => {
   if (
     e instanceof BleError ||

--- a/src/i18n/global-messages.js
+++ b/src/i18n/global-messages.js
@@ -178,6 +178,12 @@ export const ledgerMessages = defineMessages({
     id: 'global.ledgerMessages.rejectedByUserError',
     defaultMessage: '!!!Operation rejected by user.',
   },
+  noDeviceInfoError: {
+    id: 'global.ledgerMessages.noDeviceInfoError',
+    defaultMessage:
+      '!!!Device metadata was lost or corrupted. To fix this issue' +
+      ', please add a new wallet and connect it with your device.',
+  },
 })
 
 export const errorMessages = {

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -400,6 +400,7 @@
   "global.ledgerMessages.haveOTGAdapter": "You have an on-the-go adapter allowing you to connect your Ledger device with your smartphone using a USB cable.",
   "global.ledgerMessages.keepUsbConnected": "Make sure your device remains connected until the operation is completed.",
   "global.ledgerMessages.locationEnabled": "Location is enabled on your device. Android requires location to be enabled to provide access to Bluetooth, but EMURGO will never store any location data.",
+  "global.ledgerMessages.noDeviceInfoError": "Device metadata was lost or corrupted. To fix this issue, please add a new wallet and connect it with your device.",
   "global.ledgerMessages.openApp": "Open Cardano ADA app on the Ledger device.",
   "global.ledgerMessages.rejectedByUserError": "Operation rejected by user.",
   "global.ledgerMessages.usbAlwaysConnected": "Your Ledger device remains connected through USB until the process is completed.",


### PR DESCRIPTION
It is not clear why a few users get `deviceId=null` error since:

- right after opening a wallet there is an integrity check that verifies that `HWDeviceInfo != null` (it doesn't check for `deviceId` though, which is a field of `HWDeviceInfo`.

- If for some reason `deviceId=null` (it's the case for a user who connected via USB and then decided to send a tx using BLE), then a connection dialog is displayed to retrieve the `deviceId`.

This PR tries to prevent this issue, and if detected, it suggests the user to create a new wallet (see pic below. Note: changed "device data" by "device metadata" to cause less panic).

![image](https://user-images.githubusercontent.com/7271744/95479778-6f756200-098b-11eb-83d2-068c6f79e92e.png)


