### PR TITLE
fix displayed balance in tx history

### DIFF
--- a/src/components/Delegation/StakingDashboard.js
+++ b/src/components/Delegation/StakingDashboard.js
@@ -198,6 +198,10 @@ class StakingDashboard extends React.Component<Props, State> {
     if (this._intervalId != null) clearInterval(this._intervalId)
   }
 
+  /**
+   * TODO(v-almonacid): prefer computing balance from tx cache instead of
+   * utxo set
+   */
   navigateToStakingCenter: (void) => Promise<void> = async () => {
     const {navigation, utxos, poolOperator, accountBalance} = this.props
     /* eslint-disable indent */
@@ -619,6 +623,10 @@ class StakingDashboard extends React.Component<Props, State> {
                 s: leftPadDate(timeLeftInEpoch.getUTCSeconds()),
               }}
             />
+            {
+              // TODO(v-almonacid): prefer computing balance from tx cache
+              // instead of utxo set
+            }
             <UserSummary
               totalAdaSum={utxoBalance}
               totalRewards={accountBalance}

--- a/src/components/Send/SendScreen.js
+++ b/src/components/Send/SendScreen.js
@@ -331,6 +331,10 @@ class SendScreen extends Component<Props, State> {
   handleCheckBoxChange: (boolean) => void = (sendAll) =>
     this.setState({sendAll})
 
+  /**
+   * TODO(v-almonacid): prefer computing balance from tx cache instead of
+   * utxo set
+   */
   handleConfirm: () => Promise<void> = async () => {
     const {navigation, utxos, availableAmount} = this.props
     const {address, amount, sendAll} = this.state

--- a/src/components/TxHistory/TxHistory.js
+++ b/src/components/TxHistory/TxHistory.js
@@ -128,6 +128,10 @@ const TxHistory = ({
       {isOnline &&
         lastSyncError && <SyncErrorBanner showRefresh={!isSyncing} />}
 
+      {
+        // TODO(v-almonacid): prefer computing balance from tx cache
+        // instead of utxo set
+      }
       <AvailableAmountBanner amount={utxoBalance} />
 
       {_.isEmpty(transactionsInfo) ? (

--- a/src/components/TxHistory/TxHistory.js
+++ b/src/components/TxHistory/TxHistory.js
@@ -9,6 +9,7 @@ import {View, RefreshControl, ScrollView, Image} from 'react-native'
 import {SafeAreaView} from 'react-navigation'
 import _ from 'lodash'
 import {injectIntl, defineMessages} from 'react-intl'
+import {fetchUTXOs} from '../../actions/utxo'
 
 import {Text, Banner, OfflineBanner, StatusBar, WarningBanner} from '../UiKit'
 import infoIcon from '../../assets/img/icon/info-light-green.png'
@@ -18,6 +19,7 @@ import {
   lastHistorySyncErrorSelector,
   isOnlineSelector,
   availableAmountSelector,
+  utxoBalanceSelector,
   walletMetaSelector,
   languageSelector,
   isFlawedWalletSelector,
@@ -28,6 +30,7 @@ import {updateHistory} from '../../actions/history'
 import {checkForFlawedWallets} from '../../actions'
 import {
   onDidMount,
+  onDidUpdate,
   requireInitializedWallet,
   withNavigationTitle,
 } from '../../utils/renderUtils'
@@ -86,7 +89,7 @@ const SyncErrorBanner = injectIntl(({intl, showRefresh}) => (
 const AvailableAmountBanner = injectIntl(({intl, amount}) => (
   <Banner
     label={intl.formatMessage(globalMessages.availableFunds)}
-    text={formatAdaWithText(amount)}
+    text={amount != null ? formatAdaWithText(amount) : '-'}
     boldText
   />
 ))
@@ -98,7 +101,7 @@ const TxHistory = ({
   isOnline,
   updateHistory,
   lastSyncError,
-  availableAmount,
+  utxoBalance,
   isFlawedWallet,
   showWarning,
   setShowWarning,
@@ -125,7 +128,7 @@ const TxHistory = ({
       {isOnline &&
         lastSyncError && <SyncErrorBanner showRefresh={!isSyncing} />}
 
-      <AvailableAmountBanner amount={availableAmount} />
+      <AvailableAmountBanner amount={utxoBalance} />
 
       {_.isEmpty(transactionsInfo) ? (
         <ScrollView
@@ -179,6 +182,9 @@ export default injectIntl(
         lastSyncError: lastHistorySyncErrorSelector(state),
         isOnline: isOnlineSelector(state),
         availableAmount: availableAmountSelector(state),
+        utxoBalance: isSynchronizingHistorySelector(state)
+          ? null
+          : utxoBalanceSelector(state),
         key: languageSelector(state),
         isFlawedWallet: isFlawedWalletSelector(state),
         walletMeta: walletMetaSelector(state),
@@ -186,11 +192,18 @@ export default injectIntl(
       {
         updateHistory,
         checkForFlawedWallets,
+        fetchUTXOs,
       },
     ),
     onDidMount(({updateHistory, checkForFlawedWallets}) => {
       checkForFlawedWallets()
+      fetchUTXOs()
       updateHistory()
+    }),
+    onDidUpdate(({fetchUTXOs, isSyncing}, prevProps) => {
+      if (!isSyncing && isSyncing !== prevProps.isSyncing) {
+        fetchUTXOs()
+      }
     }),
     withStateHandlers(
       {


### PR DESCRIPTION
Currently the wallet balance shown in the tx history screen is computed from the local tx cache. However, this doesn't work when there are intra-wallet txs with implicit outputs.

This PR fixes this by computing the balance directly from the UTXO set given by the server. Not an ideal solution IMHO but it fixes the issue.