### PR TITLE
bump @cardano-foundation/ledgerjs-hw-app-cardano to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@babel/core": "7.9.0",
     "@babel/node": "7.0.0",
     "@babel/runtime": "7.9.0",
-    "@cardano-foundation/ledgerjs-hw-app-cardano": "2.0.1",
+    "@cardano-foundation/ledgerjs-hw-app-cardano": "2.1.0",
     "@emurgo/cip4-js": "1.0.5",
     "@ledgerhq/react-native-hw-transport-ble": "5.28.0",
     "@react-native-community/async-storage": "1.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1797,10 +1797,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@cardano-foundation/ledgerjs-hw-app-cardano@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@cardano-foundation/ledgerjs-hw-app-cardano/-/ledgerjs-hw-app-cardano-2.0.1.tgz#096d2644a7991254105b4aa0528b5cb42d32cafe"
-  integrity sha512-aIlLxp9qmVec9W8//b5hwTZ0N0PHJP2qWGI8h7vUA1mBfqglN9BqqELoKSy0oFPFrBYb431UCj9BDK/HLahDwQ==
+"@cardano-foundation/ledgerjs-hw-app-cardano@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@cardano-foundation/ledgerjs-hw-app-cardano/-/ledgerjs-hw-app-cardano-2.1.0.tgz#e2e4b1a0d5b672f8dbe7c46dc514c27d6603082f"
+  integrity sha512-44rezv9eGE/AvFeEqQ80V7xZgTvsRPnxlb1aSZnMDSVZhgxWBV9LHNPtT5kjWsrKzalsX7k+xrDybp7+ay/2HQ==
   dependencies:
     "@ledgerhq/hw-transport" "^5.12.0"
     babel-polyfill "^6.26.0"


### PR DESCRIPTION
Needed for compatibility with the upcoming upgrade in the ledger ADA app.