### PR TITLE
move to new AsyncStorage and attempt to disable auto-backup on iOS

### DIFF
--- a/ios/Nightly-Info.plist
+++ b/ios/Nightly-Info.plist
@@ -61,6 +61,8 @@
 	<string>Enable photo library</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>Enable speech recognition</string>
+	<key>RCTAsyncStorageExcludeFromBackup</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -115,7 +115,7 @@ PODS:
     - React-fishhook (= 0.60.0)
   - RNCardano (0.2.3):
     - React
-  - RNCAsyncStorage (1.12.1):
+  - RNCAsyncStorage (1.13.3):
     - React-Core
   - RNCMaskedView (0.1.10):
     - React
@@ -176,7 +176,7 @@ DEPENDENCIES:
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - React-RCTWebSocket (from `../node_modules/react-native/Libraries/WebSocket`)
   - RNCardano (from `../node_modules/react-native-cardano`)
-  - "RNCAsyncStorage (from `../node_modules/@react-native-community/async-storage`)"
+  - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
@@ -264,7 +264,7 @@ EXTERNAL SOURCES:
   RNCardano:
     :path: "../node_modules/react-native-cardano"
   RNCAsyncStorage:
-    :path: "../node_modules/@react-native-community/async-storage"
+    :path: "../node_modules/@react-native-async-storage/async-storage"
   RNCMaskedView:
     :path: "../node_modules/@react-native-community/masked-view"
   RNDeviceInfo:
@@ -323,7 +323,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 4ee1cf208ab17a50fafb1c16ffe28fe594a64e4f
   React-RCTWebSocket: fca087d583724aa0e5fef7d911f0f2a28d0f2736
   RNCardano: ffdd908e7dde81508914dbff2fbd739183b2bf34
-  RNCAsyncStorage: b03032fdbdb725bea0bd9e5ec5a7272865ae7398
+  RNCAsyncStorage: da95b83e241a7f5efe3da1a949b3ec3175380be0
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNDeviceInfo: 6dd5c07a482f2a5e4a29fe8a9d99eadd4277175a
   RNGestureHandler: 9b7e605a741412e20e13c512738a31bd1611759b

--- a/ios/emurgo/Info.plist
+++ b/ios/emurgo/Info.plist
@@ -63,6 +63,8 @@
 	<string>Enable photo library</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>Enable speech recognition</string>
+	<key>RCTAsyncStorageExcludeFromBackup</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@cardano-foundation/ledgerjs-hw-app-cardano": "2.1.0",
     "@emurgo/cip4-js": "1.0.5",
     "@ledgerhq/react-native-hw-transport-ble": "5.34.0",
-    "@react-native-community/async-storage": "1.12.1",
+    "@react-native-async-storage/async-storage": "1.13.3",
     "@react-native-community/masked-view": "0.1.10",
     "@react-native-community/netinfo": "5.9.9",
     "@react-navigation/bottom-tabs": "5.11.2",

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -2,7 +2,7 @@
 import assert from './assert'
 
 import ExtendableError from 'es6-error'
-import AsyncStorage from '@react-native-community/async-storage'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import _ from 'lodash'
 
 export class StorageError extends ExtendableError {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2469,10 +2469,10 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
-"@react-native-community/async-storage@1.12.1":
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/async-storage/-/async-storage-1.12.1.tgz#25f821b4f6b13abe005ad67e47c6f1cee9f27b24"
-  integrity sha512-70WGaH3PKYASi4BThuEEKMkyAgE9k7VytBqmgPRx3MzJx9/MkspwqJGmn3QLCgHLIFUgF1pit2mWICbRJ3T3lg==
+"@react-native-async-storage/async-storage@1.13.3":
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.13.3.tgz#bba0c69541de4da12f3a47fe07698fda84b16135"
+  integrity sha512-s/7KyzFxS3WesYn5RrfRg1Pyz5EYDZAJxIxIuzmJZ1FlvpvaZGAZq9xJmVN2OG6S6NhfiY8Tszkau15hHreRag==
   dependencies:
     deep-assign "^3.0.0"
 


### PR DESCRIPTION
I say "attempt" because I can't test this correctly. At least dev builds are still included in the list of apps being back-up by default. I will re-check once we release a prod build on Nightly.