### PR TITLE
Additional ledger fixes

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -37,7 +37,8 @@ node_modules/warning/.*
 .*/node_modules/@ledgerhq/react-native-hw-transport-ble/lib/BleTransport.js.flow
 
 ; Ignore @cardano-foundation/ledgerjs-hw-app-cardano
-.*/node_modules/@cardano-foundation/ledgerjs-hw-app-cardano/lib/Ada.js.flow
+; Note: this should be removed from the untyped list once RN/flow is upgraded
+.*/node_modules/@cardano-foundation/ledgerjs-hw-app-cardano/lib/utils.js.flow
 
 ; Ignore @emurgo/cardano-serialization-lib-nodejs
 .*/node_modules/@emurgo/cardano-serialization-lib-nodejs/cardano_serialization_lib.js.flow

--- a/src/components/Delegation/DelegationConfirmation.js
+++ b/src/components/Delegation/DelegationConfirmation.js
@@ -158,7 +158,10 @@ const handleOnConfirm = async (
       if (e instanceof LocalizableError) {
         setErrorData(
           true,
-          intl.formatMessage({id: e.id, defaultMessage: e.defaultMessage}),
+          intl.formatMessage(
+            {id: e.id, defaultMessage: e.defaultMessage},
+            e.values,
+          ),
           null,
         )
       } else {

--- a/src/components/Receive/AddressView.js
+++ b/src/components/Receive/AddressView.js
@@ -66,10 +66,13 @@ const _handleOnVerifyAddress = async (
     } catch (e) {
       if (e instanceof LocalizableError) {
         await showErrorDialog(errorMessages.generalLocalizableError, intl, {
-          message: intl.formatMessage({
-            id: e.id,
-            defaultMessage: e.defaultMessage,
-          }),
+          message: intl.formatMessage(
+            {
+              id: e.id,
+              defaultMessage: e.defaultMessage,
+            },
+            e.values,
+          ),
         })
       } else {
         Logger.error(e)

--- a/src/components/Send/ConfirmScreen.js
+++ b/src/components/Send/ConfirmScreen.js
@@ -125,7 +125,10 @@ const handleOnConfirm = async (
         if (e instanceof LocalizableError) {
           setErrorData(
             true,
-            intl.formatMessage({id: e.id, defaultMessage: e.defaultMessage}),
+            intl.formatMessage(
+              {id: e.id, defaultMessage: e.defaultMessage},
+              e.values,
+            ),
             null,
           )
         } else {

--- a/src/components/WalletInit/ConnectNanoX/ConnectNanoXScreen.js
+++ b/src/components/WalletInit/ConnectNanoX/ConnectNanoXScreen.js
@@ -64,10 +64,13 @@ const _navigateToSave = async (
   } catch (e) {
     if (e instanceof LocalizableError) {
       await showErrorDialog(errorMessages.generalLocalizableError, intl, {
-        message: intl.formatMessage({
-          id: e.id,
-          defaultMessage: e.defaultMessage,
-        }),
+        message: intl.formatMessage(
+          {
+            id: e.id,
+            defaultMessage: e.defaultMessage,
+          },
+          e.values,
+        ),
       })
     } else {
       Logger.info(e)

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -87,7 +87,7 @@ const HARDWARE_WALLETS = {
     MODEL: 'Nano',
     ENABLE_USB_TRANSPORT: true,
     USB_MIN_SDK: 24, // USB transport officially supported for Android SDK >= 24
-    MIN_FIRMWARE_VERSION: '2.0.4',
+    MIN_ADA_APP_VERSION: '2.1.0',
   },
 }
 

--- a/src/crypto/shelley/ledgerUtils.test.js
+++ b/src/crypto/shelley/ledgerUtils.test.js
@@ -1,0 +1,22 @@
+// @flow
+import jestSetup from '../../jestSetup'
+import {checkDeviceVersion, DeprecatedAdaAppError} from './ledgerUtils'
+
+import type {GetVersionResponse} from '@cardano-foundation/ledgerjs-hw-app-cardano'
+
+jestSetup.setup()
+
+describe('encryption/decryption', () => {
+  it('should throw on outdated ledger Ada app', () => {
+    expect.assertions(1)
+    const mockResponse: GetVersionResponse = {
+      major: '2',
+      minor: '0',
+      patch: '4',
+      flags: {isDebug: false},
+    }
+    expect(() => checkDeviceVersion(mockResponse)).toThrow(
+      DeprecatedAdaAppError,
+    )
+  })
+})

--- a/src/i18n/LocalizableError.js
+++ b/src/i18n/LocalizableError.js
@@ -24,7 +24,7 @@ class LocalizableError extends ExtendableError {
     super(`${id}: ${JSON.stringify(values)}`)
     this.id = id
     this.defaultMessage = defaultMessage
-    this.values = values
+    this.values = values ?? {}
   }
 }
 

--- a/src/i18n/global-messages.js
+++ b/src/i18n/global-messages.js
@@ -170,9 +170,11 @@ export const ledgerMessages = defineMessages({
       'hardware wallet. Please, make sure you are following the steps' +
       'correctly. Restarting your hardware wallet may also fix the problem.',
   },
-  deprecatedFirmwareError: {
-    id: 'global.ledgerMessages.deprecatedFirmwareError',
-    defaultMessage: '!!!Your device firmware is not up-to-date.',
+  deprecatedAdaAppError: {
+    id: 'global.ledgerMessages.deprecatedAdaAppError',
+    defaultMessage:
+      '!!!The Cardano ADA app installed in your Ledger device' +
+      'is not up-to-date. Required version: {version}',
   },
   rejectedByUserError: {
     id: 'global.ledgerMessages.rejectedByUserError',

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -411,7 +411,7 @@
   "global.ledgerMessages.bluetoothDisabledError": "Bluetooth is disabled in your smartphone",
   "global.ledgerMessages.connectionError": "An error occurred while trying to connect with your hardware wallet. Please, make sure you are following the steps correctly. Restarting your hardware wallet may also fix the problem.",
   "global.ledgerMessages.connectUsb": "Connect your Ledger device through your smartphone's USB port using your OTG adapter.",
-  "global.ledgerMessages.deprecatedFirmwareError": "Your device firmware is not up-to-date.",
+  "global.ledgerMessages.deprecatedAdaAppError": "The Cardano ADA app installed in your Ledger device is not up-to-date. Required version: {version}",
   "global.ledgerMessages.enableLocation": "Enable location services.",
   "global.ledgerMessages.enableTransport": "Enable bluetooth.",
   "global.ledgerMessages.enterPin": "Power on your ledger device and enter your PIN.",


### PR DESCRIPTION
There was still some legacy ledgerjs code used that was renamed in 2.1.0, and this PR fixes it.

Other changes include:

- Enforce 2.1.0 as the minimum ledger ADA app
- If user doesn't meet the above, show the minimum required version in the error message
- Disable type checking only for `ledgerjs-hw-app-cardano/lib/utils.js.flow` (instead of `Ada.js.flow`)

## On type checking of ledgerjs

Unfortunately, flow types of ledgerjs were included in the [untyped] list, and that's why these errors were not caught. But enabling type checking for this library results in some flow errors which we cannot fix without bumping our flow version. This, in turn, cannot be done without upgrading react native. 
For now, I just put in [untyped] the specific file that is causing issues, and that allow us to enable type checking for most of the relevant API.

