### PR TITLE
bump ledgerjs to 2.2.1

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -36,10 +36,6 @@ node_modules/warning/.*
 .*/node_modules/@ledgerhq/react-native-hw-transport-ble/src/BleTransport.js
 .*/node_modules/@ledgerhq/react-native-hw-transport-ble/lib/BleTransport.js.flow
 
-; Ignore @cardano-foundation/ledgerjs-hw-app-cardano
-; Note: this should be removed from the untyped list once RN/flow is upgraded
-.*/node_modules/@cardano-foundation/ledgerjs-hw-app-cardano/lib/utils.js.flow
-
 ; Ignore @emurgo/cardano-serialization-lib-nodejs
 .*/node_modules/@emurgo/cardano-serialization-lib-nodejs/cardano_serialization_lib.js.flow
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -183,15 +183,6 @@ android {
             targetSdkVersion 29
             resValue "string", "build_config_package", "com.emurgo"
         }
-        mainnet2 {
-            dimension "version"
-            applicationId 'com.emurgo'
-            applicationIdSuffix ".mainnet2"
-            minSdkVersion 21
-            compileSdkVersion = 29
-            targetSdkVersion 29
-            resValue "string", "build_config_package", "com.emurgo"
-        }
         dev {
             dimension "version"
             applicationIdSuffix ".staging"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -183,6 +183,15 @@ android {
             targetSdkVersion 29
             resValue "string", "build_config_package", "com.emurgo"
         }
+        mainnet2 {
+            dimension "version"
+            applicationId 'com.emurgo'
+            applicationIdSuffix ".mainnet2"
+            minSdkVersion 21
+            compileSdkVersion = 29
+            targetSdkVersion 29
+            resValue "string", "build_config_package", "com.emurgo"
+        }
         dev {
             dimension "version"
             applicationIdSuffix ".staging"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@babel/core": "7.12.10",
     "@babel/node": "7.12.6",
     "@babel/runtime": "7.12.5",
-    "@cardano-foundation/ledgerjs-hw-app-cardano": "2.1.0",
+    "@cardano-foundation/ledgerjs-hw-app-cardano": "2.2.1",
     "@emurgo/cip4-js": "1.0.5",
     "@ledgerhq/react-native-hw-transport-ble": "5.41.0",
     "@react-native-async-storage/async-storage": "1.13.3",

--- a/src/crypto/shelley/ledgerUtils.js
+++ b/src/crypto/shelley/ledgerUtils.js
@@ -324,9 +324,7 @@ export const checkDeviceVersion = (version: GetVersionResponse): void => {
     return
   }
   for (let i = 0; i < minVersionArray.length; i++) {
-    if (
-      deviceVersionArray[i] < parseInt(minVersionArray[i], 10)
-    ) {
+    if (deviceVersionArray[i] < parseInt(minVersionArray[i], 10)) {
       throw new DeprecatedAdaAppError()
     }
   }

--- a/src/crypto/shelley/ledgerUtils.js
+++ b/src/crypto/shelley/ledgerUtils.js
@@ -61,8 +61,8 @@ import type {
   GetExtendedPublicKeyResponse,
   GetSerialResponse,
   InputTypeUTxO,
-  OutputTypeAddress,
-  OutputTypeAddressParams,
+  TxOutputTypeAddress,
+  TxOutputTypeAddressParams,
   SignTransactionResponse,
   StakingBlockchainPointer,
   Witness,
@@ -238,7 +238,7 @@ export type SignTransactionRequest = {|
   networkId: number,
   protocolMagic: number,
   inputs: Array<InputTypeUTxO>,
-  outputs: Array<OutputTypeAddress | OutputTypeAddressParams>,
+  outputs: Array<TxOutputTypeAddress | TxOutputTypeAddressParams>,
   feeStr: string,
   ttlStr: string,
   certificates: Array<Certificate>,
@@ -325,7 +325,7 @@ export const checkDeviceVersion = (version: GetVersionResponse): void => {
   }
   for (let i = 0; i < minVersionArray.length; i++) {
     if (
-      parseInt(deviceVersionArray[i], 10) < parseInt(minVersionArray[i], 10)
+      deviceVersionArray[i] < parseInt(minVersionArray[i], 10)
     ) {
       throw new DeprecatedAdaAppError()
     }
@@ -568,7 +568,7 @@ async function _transformToLedgerOutputs(request: {|
   txOutputs: TransactionOutputs,
   changeAddrs: Array<{|...JsAddress, ...Value, ...Addressing|}>,
   addressingMap: (string) => void | $PropertyType<Addressing, 'addressing'>,
-|}): Promise<Array<OutputTypeAddress | OutputTypeAddressParams>> {
+|}): Promise<Array<TxOutputTypeAddress | TxOutputTypeAddressParams>> {
   const result = []
   for (let i = 0; i < (await request.txOutputs.len()); i++) {
     const output = await request.txOutputs.get(i)
@@ -593,11 +593,13 @@ async function _transformToLedgerOutputs(request: {|
         stakingKeyHashHex: addressParams.stakingKeyHashHex,
         stakingPath: addressParams.stakingPath,
         amountStr: await (await output.amount()).to_str(),
+        tokenBundle: [],
       })
     } else {
       result.push({
         addressHex: Buffer.from(await address.to_bytes()).toString('hex'),
         amountStr: await (await output.amount()).to_str(),
+        tokenBundle: [],
       })
     }
   }

--- a/src/crypto/shelley/ledgerUtils.test.js
+++ b/src/crypto/shelley/ledgerUtils.test.js
@@ -10,9 +10,9 @@ describe('encryption/decryption', () => {
   it('should throw on outdated ledger Ada app', () => {
     expect.assertions(1)
     const mockResponse: GetVersionResponse = {
-      major: '2',
-      minor: '0',
-      patch: '4',
+      major: 2,
+      minor: 0,
+      patch: 4,
       flags: {isDebug: false},
     }
     expect(() => checkDeviceVersion(mockResponse)).toThrow(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1882,10 +1882,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@cardano-foundation/ledgerjs-hw-app-cardano@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@cardano-foundation/ledgerjs-hw-app-cardano/-/ledgerjs-hw-app-cardano-2.1.0.tgz#e2e4b1a0d5b672f8dbe7c46dc514c27d6603082f"
-  integrity sha512-44rezv9eGE/AvFeEqQ80V7xZgTvsRPnxlb1aSZnMDSVZhgxWBV9LHNPtT5kjWsrKzalsX7k+xrDybp7+ay/2HQ==
+"@cardano-foundation/ledgerjs-hw-app-cardano@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@cardano-foundation/ledgerjs-hw-app-cardano/-/ledgerjs-hw-app-cardano-2.2.1.tgz#775e4f34ccfd071eaf09b7bdd0dffe175b42d238"
+  integrity sha512-E37/vIGBpFFF9qyoWFccj7lW2iqCoYAGvC5hKIdMLqU8c6R0heyQHG0uIbsGLS+/TrhSih4UnIJtYG3fM2XMlQ==
   dependencies:
     "@ledgerhq/hw-transport" "^5.12.0"
     babel-polyfill "^6.26.0"
@@ -6694,7 +6694,6 @@ elliptic@^6.0.0, elliptic@^6.5.2:
 
 emip3js@Emurgo/emip3js:
   version "0.0.1"
-  uid a31b1aca3a9bead84c7084690cae15c126759512
   resolved "https://codeload.github.com/Emurgo/emip3js/tar.gz/a31b1aca3a9bead84c7084690cae15c126759512"
   dependencies:
     chacha "git+https://github.com/calvinmetcalf/chacha20poly1305.git"


### PR DESCRIPTION
Note: it's expected that jest tests fail. That's fixed in another PR.

