### PR TITLE
add activity indicator in send screen

### DIFF
--- a/src/components/Send/SendScreen.js
+++ b/src/components/Send/SendScreen.js
@@ -4,7 +4,7 @@ import React, {Component} from 'react'
 import {BigNumber} from 'bignumber.js'
 import {compose} from 'redux'
 import {connect} from 'react-redux'
-import {ScrollView, View} from 'react-native'
+import {ScrollView, View, ActivityIndicator} from 'react-native'
 import _ from 'lodash'
 import SafeAreaView from 'react-native-safe-area-view'
 import {injectIntl, defineMessages} from 'react-intl'
@@ -453,6 +453,10 @@ class SendScreen extends Component<Props, State> {
   }
 
   async revalidate({utxos, address, amount, sendAll, selectedAsset}) {
+    this.setState({
+      fee: null,
+      balanceAfter: null,
+    })
     const {defaultAsset, availableAssets, tokenBalance} = this.props
     if (availableAssets[selectedAsset.identifier] == null) {
       throw new Error(
@@ -750,12 +754,14 @@ class SendScreen extends Component<Props, State> {
             assetsMetadata={availableAssets}
             unselectEnabled={false}
           />
+          {this.state.fee == null &&
+            !!this.state.amount && <ActivityIndicator />}
         </ScrollView>
         <View style={styles.actions}>
           <Button
             onPress={this.handleConfirm}
             title={intl.formatMessage(messages.continueButton)}
-            disabled={!isValid}
+            disabled={!isValid || this.state.fee == null}
           />
         </View>
       </SafeAreaView>

--- a/src/components/Send/SendScreen.js
+++ b/src/components/Send/SendScreen.js
@@ -176,6 +176,12 @@ const messages = defineMessages({
   },
 })
 
+const Indicator = () => (
+  <View style={styles.indicator}>
+    <ActivityIndicator size="large" />
+  </View>
+)
+
 const getMinAda = async (selectedToken: Token, defaultAsset: DefaultAsset) => {
   const fakeAmount = new BigNumber('0') // amount doesn't matter for calculating min UTXO amount
   const fakeMultitoken = new MultiToken(
@@ -755,7 +761,7 @@ class SendScreen extends Component<Props, State> {
             unselectEnabled={false}
           />
           {this.state.fee == null &&
-            !!this.state.amount && <ActivityIndicator />}
+            !!this.state.amount && <Indicator />}
         </ScrollView>
         <View style={styles.actions}>
           <Button

--- a/src/components/Send/styles/SendScreen.style.js
+++ b/src/components/Send/styles/SendScreen.style.js
@@ -26,6 +26,9 @@ const styles = StyleSheet.create({
     marginHorizontal: 16,
     marginBottom: 16,
   },
+  indicator: {
+    marginTop: 26,
+  },
 })
 
 export default styles


### PR DESCRIPTION
Computing the fee, which requires to create a transaction, is taking more time after the new upgrade in the Cardano libs.

So I added an `<ActivityIndicator>` in the send screen to signal users the fee is being computed. The button is also disabled while the fee is computed.

![activity](https://user-images.githubusercontent.com/7271744/109323097-5e9e8d80-7853-11eb-8d5c-e7a7272a9fc8.gif)
