### PR TITLE
fix android context menu missing (copy/paste on inputs)

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -129,8 +129,8 @@ PODS:
     - React-Core
   - RNReanimated (1.13.2):
     - React-Core
-  - RNScreens (2.11.0):
-    - React
+  - RNScreens (2.18.0):
+    - React-Core
   - RNSentry (1.4.5):
     - React
     - Sentry (~> 5.1.4)
@@ -330,7 +330,7 @@ SPEC CHECKSUMS:
   RNKeychain: 3aa3cf891a09a0d18d306862ab2bb9e106079b24
   RNPermissions: 5df468064df661a4c8c017e2791ce90d7695eea5
   RNReanimated: e03f7425cb7a38dcf1b644d680d1bfc91c3337ad
-  RNScreens: 0e91da98ab26d5d04c7b59a9b6bd694124caf88c
+  RNScreens: f0d7a2a440a8ba9f4574ca1ddb3368f473891be4
   RNSentry: 0a70359ddacbfb9b1cbbb0971e54065b9f70ac57
   RNSVG: 6c8e8c6f9e5a0caf910dd25aa6e4216045426e1d
   Sentry: 81f7f2bd3cb041137ea7efcde3aa5ad0d5a67632

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "react-native-reanimated": "1.13.2",
     "react-native-safe-area-context": "3.1.9",
     "react-native-safe-area-view": "2.0.0",
-    "react-native-screens": "2.11.0",
+    "react-native-screens": "2.18.0",
     "react-native-splash-screen": "^3.1.1",
     "react-native-svg": "^7.2.0",
     "react-native-tab-view": "2.15.2",

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@
 import React from 'react'
 import 'intl'
 import {SafeAreaProvider} from 'react-native-safe-area-context'
+import {enableScreens} from 'react-native-screens'
 
 import {injectIntl} from 'react-intl'
 
@@ -11,6 +12,8 @@ import {onDidMount} from './utils/renderUtils'
 import {compose} from 'recompose'
 import {connect} from 'react-redux'
 import {initApp} from './actions'
+
+enableScreens()
 
 const App = (_props, _context) => {
   return (

--- a/src/components/Send/SendScreen.js
+++ b/src/components/Send/SendScreen.js
@@ -760,8 +760,7 @@ class SendScreen extends Component<Props, State> {
             assetsMetadata={availableAssets}
             unselectEnabled={false}
           />
-          {this.state.fee == null &&
-            !!this.state.amount && <Indicator />}
+          {this.state.fee == null && !!this.state.amount && <Indicator />}
         </ScrollView>
         <View style={styles.actions}>
           <Button

--- a/yarn.lock
+++ b/yarn.lock
@@ -13050,10 +13050,10 @@ react-native-schemes-manager@^1.0.5:
     xcode "^0.9.1"
     yargs "^6.6.0"
 
-react-native-screens@2.11.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.11.0.tgz#34b30b07c2d04aa100cba984b944b303bfa43ea6"
-  integrity sha512-vJzJE3zI1XUtqthrX3Dh2TBQWB+xFyaGhF52KBq9FjJUN5ws4xpLZJxBWa1KbGV3DilmcSZ4jmZR5LGordwE7w==
+react-native-screens@2.18.0:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.18.0.tgz#8652f8e77fdfd38ffb355eab32a22644e956745c"
+  integrity sha512-8+lCEsxzSu55GWRw6yZpyt3OszxN1OngfBsFXdqspaEfq6uIChanzlcD2PLVQl+iN82GAcrZM800Kd1pA477ZQ==
 
 react-native-splash-screen@^3.1.1:
   version "3.2.0"


### PR DESCRIPTION
Unfortunately I don't have a clear diagnose about this issue, since there are multiple GitHub issues across different repos that may be linked, but most of these are a bit too old to be still valid.

The only recent change that might have introduced this issue was upgrading `react-navigation`, which uses `react-native-screens`  as a peer dependency. `react-native-screens` has an option to make `react-navigation` render native view containers instead of those provided by `react-native`, and doing this seem to effectively fix the problem.