### PR TITLE
Bug fixes

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -129,8 +129,8 @@ PODS:
     - React-Core
   - RNReanimated (1.13.2):
     - React-Core
-  - RNScreens (2.18.0):
-    - React-Core
+  - RNScreens (2.11.0):
+    - React
   - RNSentry (1.4.5):
     - React
     - Sentry (~> 5.1.4)
@@ -330,7 +330,7 @@ SPEC CHECKSUMS:
   RNKeychain: 3aa3cf891a09a0d18d306862ab2bb9e106079b24
   RNPermissions: 5df468064df661a4c8c017e2791ce90d7695eea5
   RNReanimated: e03f7425cb7a38dcf1b644d680d1bfc91c3337ad
-  RNScreens: f0d7a2a440a8ba9f4574ca1ddb3368f473891be4
+  RNScreens: 0e91da98ab26d5d04c7b59a9b6bd694124caf88c
   RNSentry: 0a70359ddacbfb9b1cbbb0971e54065b9f70ac57
   RNSVG: 6c8e8c6f9e5a0caf910dd25aa6e4216045426e1d
   Sentry: 81f7f2bd3cb041137ea7efcde3aa5ad0d5a67632

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "react-native-reanimated": "1.13.2",
     "react-native-safe-area-context": "3.1.9",
     "react-native-safe-area-view": "2.0.0",
-    "react-native-screens": "2.18.0",
+    "react-native-screens": "2.11.0",
     "react-native-splash-screen": "^3.1.1",
     "react-native-svg": "^7.2.0",
     "react-native-tab-view": "2.15.2",

--- a/src/components/Send/SendScreen.js
+++ b/src/components/Send/SendScreen.js
@@ -774,6 +774,7 @@ class SendScreen extends Component<Props, State> {
           />
           {this.state.fee == null &&
             !!this.state.amount &&
+            !!this.state.address &&
             amountErrorText == null && <Indicator />}
         </ScrollView>
         <View style={styles.actions}>

--- a/src/components/Send/SendScreen.js
+++ b/src/components/Send/SendScreen.js
@@ -709,19 +709,24 @@ class SendScreen extends Component<Props, State> {
       selectedAsset,
     } = this.state
 
-    const isErrorFree = _.isEmpty({
-      ...addressErrors,
-      ...amountErrors,
-      ...balanceErrors,
-    })
-
     const isValid =
       isOnline &&
       !hasPendingOutgoingTransaction &&
       !isFetchingBalance &&
       !lastFetchingError &&
       utxos &&
-      isErrorFree
+      _.isEmpty({
+        ...addressErrors,
+        ...amountErrors,
+        ...balanceErrors,
+      })
+
+    const amountErrorText = getAmountErrorText(
+      intl,
+      amountErrors,
+      balanceErrors,
+      defaultAsset,
+    )
 
     return (
       <SafeAreaView style={styles.container}>
@@ -750,12 +755,7 @@ class SendScreen extends Component<Props, State> {
           <AmountField
             amount={amount}
             setAmount={this.handleAmountChange}
-            error={getAmountErrorText(
-              intl,
-              amountErrors,
-              balanceErrors,
-              defaultAsset,
-            )}
+            error={amountErrorText}
             editable={!sendAll}
           />
           <Checkbox
@@ -774,7 +774,7 @@ class SendScreen extends Component<Props, State> {
           />
           {this.state.fee == null &&
             !!this.state.amount &&
-            isErrorFree && <Indicator />}
+            amountErrorText == null && <Indicator />}
         </ScrollView>
         <View style={styles.actions}>
           <Button

--- a/src/crypto/errors.js
+++ b/src/crypto/errors.js
@@ -34,6 +34,12 @@ export class NoOutputsError extends ExtendableError {
   }
 }
 
+export class AssetOverflowError extends ExtendableError {
+  constructor() {
+    super('AssetOverflowError')
+  }
+}
+
 export const _rethrow = <T>(x: Promise<T>): Promise<T> =>
   x.catch((e) => {
     throw new CardanoError(e.message)

--- a/src/crypto/shelley/transactions.test.js
+++ b/src/crypto/shelley/transactions.test.js
@@ -33,7 +33,7 @@ import {
   sendAllUnsignedTxFromUtxo,
   signTransaction,
 } from './transactions'
-import {InsufficientFunds, NoOutputsError} from '../errors'
+import {InsufficientFunds, NoOutputsError, AssetOverflowError} from '../errors'
 import {byronAddrToHex, identifierToCardanoAsset} from './utils'
 import {CONFIG, getDefaultAssets} from '../../config/config'
 import {NETWORKS} from '../../config/networks'
@@ -117,6 +117,27 @@ const genSampleUtxos: (void) => Promise<Array<RawUtxo>> = async () => [
     assets: [
       {
         amount: '1234',
+        assetId: testAssetId,
+        policyId: testAssetId.split('.')[0],
+        name: testAssetId.split('.')[1],
+      },
+    ],
+  },
+  {
+    amount: '10000001',
+    receiver: Buffer.from(
+      await ShelleyAddress.from_bech32(
+        // external addr 0, staking key 0
+        'addr1q8gpjmyy8zk9nuza24a0f4e7mgp9gd6h3uayp0rqnjnkl54v4dlyj0kwfs0x4e38a7047lymzp37tx0y42glslcdtzhqphf76y',
+      ).to_bytes(),
+    ).toString('hex'),
+    tx_hash: '86e36b6a65d82c9dcc0370b0ee3953aee579db0b837753306405c28a74de5550',
+    tx_index: 0,
+    utxo_id:
+      '86e36b6a65d82c9dcc0370b0ee3953aee579db0b837753306405c28a74de55500',
+    assets: [
+      {
+        amount: '18446744073709551615', // max u64
         assetId: testAssetId,
         policyId: testAssetId.split('.')[0],
         name: testAssetId.split('.')[1],
@@ -679,6 +700,101 @@ describe('Create unsigned TX from UTXO', () => {
         undefined,
       ),
     ).resolves.not.toThrow(InsufficientFunds)
+  })
+
+  it('Should fail when insufficient ADA when forcing change', async () => {
+    const sampleUtxos = await genSampleUtxos()
+    const sampleAdaAddresses = await genSampleAdaAddresses()
+    const output = new MultiToken(
+      [
+        {
+          // bigger than input including fees
+          amount: new BigNumber(1900001),
+          identifier: defaultIdentifier,
+          networkId: NETWORK.NETWORK_ID,
+        },
+      ],
+      {
+        defaultIdentifier,
+        defaultNetworkId: NETWORK.NETWORK_ID,
+      },
+    )
+
+    await expect(
+      newAdaUnsignedTxFromUtxo(
+        [
+          {
+            address: await byronAddrToHex(
+              'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
+            ),
+            amount: output,
+          },
+        ],
+        sampleAdaAddresses[0],
+        [sampleUtxos[4]],
+        new BigNumber(0),
+        await getProtocolParams(),
+        [],
+        [],
+        true,
+      ),
+    ).rejects.toThrow(InsufficientFunds)
+  })
+
+  it('Should fail when sending all where sum of tokens > 2^64', async () => {
+    const sampleUtxos = await genSampleUtxos()
+
+    await expect(
+      sendAllUnsignedTxFromUtxo(
+        {
+          address: await byronAddrToHex(
+            'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
+          ),
+        },
+        [sampleUtxos[4], sampleUtxos[5]],
+        new BigNumber(0),
+        await getProtocolParams(),
+        undefined,
+      ),
+    ).rejects.toThrow(AssetOverflowError)
+  })
+
+  it('Should skip inputs when sending where sum of tokens > 2^64', async () => {
+    const sampleUtxos = await genSampleUtxos()
+    const sampleAdaAddresses = await genSampleAdaAddresses()
+    const output = new MultiToken(
+      [
+        {
+          amount: new BigNumber(19001),
+          identifier: defaultIdentifier,
+          networkId: NETWORK.NETWORK_ID,
+        },
+      ],
+      {
+        defaultIdentifier,
+        defaultNetworkId: NETWORK.NETWORK_ID,
+      },
+    )
+
+    const result = await newAdaUnsignedTxFromUtxo(
+      [
+        {
+          address: await byronAddrToHex(
+            'Ae2tdPwUPEZKX8N2TjzBXLy5qrecnQUniTd2yxE8mWyrh2djNpUkbAtXtP4',
+          ),
+          amount: output,
+        },
+      ],
+      sampleAdaAddresses[0],
+      [sampleUtxos[4], sampleUtxos[5]],
+      new BigNumber(0),
+      await getProtocolParams(),
+      [],
+      [],
+      true,
+    )
+    // one of the inputs skipped to keep <= u64
+    expect(result.senderUtxos.length).toEqual(1)
   })
 })
 

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -110,6 +110,7 @@
   "components.send.confirmscreen.title": "Send",
   "components.send.sendscreen.addressInputErrorInvalidAddress": "Please enter a valid address",
   "components.send.sendscreen.addressInputLabel": "Address",
+  "components.send.sendscreen.amountInput.error.assetOverflow": "!Maximum value of a token inside a UTXO exceeded (overflow).",
   "components.send.sendscreen.amountInput.error.INVALID_AMOUNT": "Please enter a valid amount",
   "components.send.sendscreen.amountInput.error.LT_MIN_UTXO": "Cannot send less than {minUtxo} {ticker}",
   "components.send.sendscreen.amountInput.error.NEGATIVE": "Amount must be positive",

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -33,6 +33,7 @@ export type AmountValidationErrors = {|
 
 export type BalanceValidationErrors = {|
   insufficientBalance?: boolean,
+  assetOverflow?: boolean,
 |}
 
 export const INVALID_PHRASE_ERROR_CODES = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13050,10 +13050,10 @@ react-native-schemes-manager@^1.0.5:
     xcode "^0.9.1"
     yargs "^6.6.0"
 
-react-native-screens@2.18.0:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.18.0.tgz#8652f8e77fdfd38ffb355eab32a22644e956745c"
-  integrity sha512-8+lCEsxzSu55GWRw6yZpyt3OszxN1OngfBsFXdqspaEfq6uIChanzlcD2PLVQl+iN82GAcrZM800Kd1pA477ZQ==
+react-native-screens@2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.11.0.tgz#34b30b07c2d04aa100cba984b944b303bfa43ea6"
+  integrity sha512-vJzJE3zI1XUtqthrX3Dh2TBQWB+xFyaGhF52KBq9FjJUN5ws4xpLZJxBWa1KbGV3DilmcSZ4jmZR5LGordwE7w==
 
 react-native-splash-screen@^3.1.1:
   version "3.2.0"


### PR DESCRIPTION
This PR introduces several fixes:

- Applies fixes introduced in the extension transaction API (namely the utxo some overflow issue)
- Fixes the "underflow" crash
- Downgrades `react-native-screen`, which was bumped in the previous PR but unfortunately introduced an issue that prevents us from building the app on iOS (note: there will be no fix for this. Perhaps the only fix is to upgrade react native).
- Stops the activity indicator in the send screen when an user input error is encountered