### PR TITLE
more UI fixes

### DIFF
--- a/src/components/Common/MultiAsset/AssetSelector.js
+++ b/src/components/Common/MultiAsset/AssetSelector.js
@@ -59,7 +59,7 @@ const AssetSelector: (ExternalProps) => Node = ({
         {selectedAsset == null ? (
           <Text> {intl.formatMessage(messages.placeHolder)} </Text>
         ) : (
-          <Text>
+          <Text numberOfLines={1} ellipsizeMode="middle">
             {' '}
             {getAssetDenominationOrId(
               assetsMetadata[selectedAsset.identifier],

--- a/src/components/Send/ConfirmScreen.js
+++ b/src/components/Send/ConfirmScreen.js
@@ -25,6 +25,7 @@ import {
   isHWSelector,
   hwDeviceInfoSelector,
   defaultNetworkAssetSelector,
+  availableAssetsSelector,
 } from '../../selectors'
 import globalMessages, {
   errorMessages,
@@ -49,7 +50,7 @@ import LocalizableError from '../../i18n/LocalizableError'
 import {ISignRequest} from '../../crypto/ISignRequest'
 
 import type {CreateUnsignedTxResponse} from '../../crypto/shelley/transactionUtils'
-import type {Token} from '../../types/HistoryTransaction'
+import type {TokenEntry} from '../../crypto/MultiToken'
 
 import styles from './styles/ConfirmScreen.style'
 
@@ -215,6 +216,7 @@ const ConfirmScreen = ({
   isEasyConfirmationEnabled,
   isHW,
   defaultAsset,
+  availableAssets,
   sendingTransaction,
   buttonDisabled,
   ledgerDialogStep,
@@ -230,20 +232,18 @@ const ConfirmScreen = ({
 }) => {
   const {
     defaultAssetAmount,
-    tokenAmount,
-    tokenMetadata,
     address,
     balanceAfterTx,
     availableAmount,
     fee,
+    tokens,
   }: {|
     defaultAssetAmount: BigNumber,
-    tokenAmount: ?BigNumber,
-    tokenMetadata: Token,
     address: string,
     balanceAfterTx: BigNumber,
     availableAmount: BigNumber,
     fee: BigNumber,
+    tokens: Array<TokenEntry>,
   |} = route.params
 
   const isConfirmationDisabled =
@@ -281,11 +281,11 @@ const ConfirmScreen = ({
           <Text style={styles.amount}>
             {formatTokenWithSymbol(defaultAssetAmount, defaultAsset)}
           </Text>
-          {tokenAmount != null && (
-            <Text style={styles.amount}>
-              {formatTokenWithText(tokenAmount, tokenMetadata)}
+          {tokens.map((t, i) => (
+            <Text style={styles.amount} key={i}>
+              {formatTokenWithText(t.amount, availableAssets[t.identifier])}
             </Text>
-          )}
+          ))}
 
           {/* eslint-disable indent */
           !isEasyConfirmationEnabled &&
@@ -367,6 +367,7 @@ export default injectIntl(
         isHW: isHWSelector(state),
         hwDeviceInfo: hwDeviceInfoSelector(state),
         defaultAsset: defaultNetworkAssetSelector(state),
+        availableAssets: availableAssetsSelector(state),
       }),
       {
         submitTransaction,

--- a/src/components/Send/SendScreen.js
+++ b/src/components/Send/SendScreen.js
@@ -598,20 +598,31 @@ class SendScreen extends Component<Props, State> {
         // note: inside this if balanceAfter shouldn't be null
         : tokenBalance.getDefault().minus(balanceAfter ?? 0)
 
-      const tokenAmount: BigNumber | null = !selectedTokenMeta.isDefault
-        ? parseAmountDecimal(amount, selectedTokenMeta)
-        : null
+      const tokens: Array<TokenEntry> = await (async () => {
+        if (sendAll) {
+          return (await transactionData.totalOutput()).nonDefaultEntries()
+        }
+        if (!selectedTokenMeta.isDefault) {
+          return [
+            {
+              identifier: selectedTokenMeta.identifier,
+              networkId: selectedTokenMeta.networkId,
+              amount: parseAmountDecimal(amount, selectedTokenMeta),
+            },
+          ]
+        }
+        return []
+      })()
 
       navigation.navigate(SEND_ROUTES.CONFIRM, {
         availableAmount: tokenBalance.getDefault(),
         address,
         defaultAssetAmount,
-        tokenAmount,
-        tokenMetadata: selectedTokenMeta,
         transactionData,
         balanceAfterTx: balanceAfter,
         utxos,
         fee,
+        tokens,
       })
     }
   }

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -128,6 +128,8 @@
   "components.send.sendscreen.errorBannerPendingOutgoingTransaction": "You cannot send a new transaction while an existing one is still pending",
   "components.send.sendscreen.feeLabel": "Fee",
   "components.send.sendscreen.feeNotAvailable": "-",
+  "components.send.sendscreen.checkboxSendAllAssets": "Send all assets (including all tokens)",
+  "components.send.sendscreen.checkboxSendAll": "Send all {assetId}",
   "components.send.sendscreen.title": "Send",
   "components.settings.applicationsettingsscreen.biometricsSignIn": "Sign in with your biometrics",
   "components.settings.applicationsettingsscreen.changePin": "Change PIN",

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -110,7 +110,7 @@
   "components.send.confirmscreen.title": "Send",
   "components.send.sendscreen.addressInputErrorInvalidAddress": "Please enter a valid address",
   "components.send.sendscreen.addressInputLabel": "Address",
-  "components.send.sendscreen.amountInput.error.assetOverflow": "!Maximum value of a token inside a UTXO exceeded (overflow).",
+  "components.send.sendscreen.amountInput.error.assetOverflow": "Maximum value of a token inside a UTXO exceeded (overflow).",
   "components.send.sendscreen.amountInput.error.INVALID_AMOUNT": "Please enter a valid amount",
   "components.send.sendscreen.amountInput.error.LT_MIN_UTXO": "Cannot send less than {minUtxo} {ticker}",
   "components.send.sendscreen.amountInput.error.NEGATIVE": "Amount must be positive",

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -87,14 +87,22 @@ export const getAssetDenominationOrUnknown = (
   getAssetDenomination(token, denomination) ??
   intl.formatMessage(messages.unknownAssetName)
 
+
+export const normalizeTokenAmount = (
+  amount: BigNumber,
+  token: Token | DefaultAsset,
+): BigNumber => {
+  const normalizationFactor = Math.pow(10, token.metadata.numberOfDecimals)
+  return amount
+    .dividedBy(normalizationFactor)
+    .decimalPlaces(token.metadata.numberOfDecimals)
+}
+
 export const formatTokenAmount = (
   amount: BigNumber,
   token: Token | DefaultAsset,
-): string => {
-  const normalizationFactor = Math.pow(10, token.metadata.numberOfDecimals)
-  const num = amount.dividedBy(normalizationFactor)
-  return num.toFormat(token.metadata.numberOfDecimals)
-}
+): string =>
+  normalizeTokenAmount(amount, token).toFormat(token.metadata.numberOfDecimals)
 
 export const formatTokenWithSymbol = (
   amount: BigNumber,
@@ -142,6 +150,15 @@ export const formatTokenFractional = (
     .dividedBy(normalizationFactor)
   // remove leading '0'
   return fractional.toFormat(token.metadata.numberOfDecimals).substring(1)
+}
+
+export const truncateWithEllipsis = (s: string, n: number) => {
+  if (s.length > n) {
+    return `${s.substr(0, Math.floor(n / 2))}...${s.substr(
+      s.length - Math.floor(n / 2),
+    )}`
+  }
+  return s
 }
 
 // TODO(multi-asset): consider removing these

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -87,7 +87,6 @@ export const getAssetDenominationOrUnknown = (
   getAssetDenomination(token, denomination) ??
   intl.formatMessage(messages.unknownAssetName)
 
-
 export const normalizeTokenAmount = (
   amount: BigNumber,
   token: Token | DefaultAsset,


### PR DESCRIPTION
These include:

- Fix missing token amounts in tx confirmation page when sending *all* assets
- Change the sendAll checkbox label according to what is currently being sent (all assets vs one asset)
- Truncate asset IDs in some contexts
- Fix a minor issue in sendAll in which there was an amount error displayed but actually there was no error