### PR TITLE
close wallet when navigating back to wallet list

### DIFF
--- a/src/components/TxHistory/TxHistory.js
+++ b/src/components/TxHistory/TxHistory.js
@@ -120,7 +120,6 @@ const TxHistory = ({
   walletMeta,
   intl,
 }) => {
-
   const routes = useNavigationState((state) => state.routes)
 
   useEffect(
@@ -163,7 +162,10 @@ const TxHistory = ({
         {_.isEmpty(transactionsInfo) ? (
           <ScrollView
             refreshControl={
-              <RefreshControl onRefresh={updateHistory} refreshing={isSyncing} />
+              <RefreshControl
+                onRefresh={updateHistory}
+                refreshing={isSyncing}
+              />
             }
           >
             <NoTxHistory />

--- a/src/components/TxHistory/TxHistory.js
+++ b/src/components/TxHistory/TxHistory.js
@@ -1,16 +1,17 @@
 // @flow
 
-import React from 'react'
+import React, {useEffect} from 'react'
 import {connect} from 'react-redux'
 import {compose} from 'redux'
 import {withStateHandlers} from 'recompose'
+import {useNavigationState} from '@react-navigation/native'
 import {View, RefreshControl, ScrollView, Image} from 'react-native'
 import SafeAreaView from 'react-native-safe-area-view'
 import _ from 'lodash'
 import {BigNumber} from 'bignumber.js'
+
 import {injectIntl, defineMessages} from 'react-intl'
 import {fetchUTXOs} from '../../actions/utxo'
-
 import {Text, Banner, OfflineBanner, StatusBar, WarningBanner} from '../UiKit'
 import infoIcon from '../../assets/img/icon/info-light-green.png'
 import {
@@ -25,6 +26,7 @@ import {
   isFlawedWalletSelector,
 } from '../../selectors'
 import TxHistoryList from './TxHistoryList'
+import walletManager from '../../crypto/walletManager'
 import {updateHistory} from '../../actions/history'
 import {checkForFlawedWallets} from '../../actions'
 import {
@@ -117,68 +119,84 @@ const TxHistory = ({
   setShowWarning,
   walletMeta,
   intl,
-}) => (
-  <SafeAreaView style={styles.scrollView}>
-    <StatusBar type="dark" />
-    <View style={styles.container}>
-      {isFlawedWallet === true && (
-        <FlawedWalletModal
-          visible={isFlawedWallet === true}
-          disableButtons={false}
-          onPress={() =>
-            navigation.navigate(WALLET_ROOT_ROUTES.WALLET_SELECTION)
-          }
-          onRequestClose={() =>
-            navigation.navigate(WALLET_ROOT_ROUTES.WALLET_SELECTION)
-          }
-        />
-      )}
+}) => {
 
-      <OfflineBanner />
-      {isOnline &&
-        lastSyncError && <SyncErrorBanner showRefresh={!isSyncing} />}
+  const routes = useNavigationState((state) => state.routes)
 
-      <AvailableAmountBanner
-        amount={tokenBalance.getDefault()}
-        amountAssetMetaData={availableAssets[tokenBalance.getDefaultId()]}
-      />
-
-      {_.isEmpty(transactionsInfo) ? (
-        <ScrollView
-          refreshControl={
-            <RefreshControl onRefresh={updateHistory} refreshing={isSyncing} />
-          }
-        >
-          <NoTxHistory />
-        </ScrollView>
-      ) : (
-        <TxHistoryList
-          refreshing={isSyncing}
-          onRefresh={updateHistory}
-          navigation={navigation}
-          transactions={transactionsInfo}
-        />
-      )}
-
-      {/* eslint-disable indent */
-      isByron(walletMeta.walletImplementationId) &&
-        showWarning && (
-          <WarningBanner
-            title={intl
-              .formatMessage(warningBannerMessages.title)
-              .toUpperCase()}
-            icon={infoIcon}
-            message={intl.formatMessage(warningBannerMessages.message)}
-            showCloseIcon
-            onRequestClose={() => setShowWarning(false)}
-            style={styles.warningNoteStyles}
+  useEffect(
+    () =>
+      navigation.addListener('beforeRemove', (e) => {
+        navigation.dispatch(e.data.action)
+        if (routes.length === 1) {
+          // this is the last and only route in the stack, wallet should close
+          walletManager.closeWallet()
+        }
+      }),
+    [navigation],
+  )
+  return (
+    <SafeAreaView style={styles.scrollView}>
+      <StatusBar type="dark" />
+      <View style={styles.container}>
+        {isFlawedWallet === true && (
+          <FlawedWalletModal
+            visible={isFlawedWallet === true}
+            disableButtons={false}
+            onPress={() =>
+              navigation.navigate(WALLET_ROOT_ROUTES.WALLET_SELECTION)
+            }
+            onRequestClose={() =>
+              navigation.navigate(WALLET_ROOT_ROUTES.WALLET_SELECTION)
+            }
           />
-        )
-      /* eslint-enable indent */
-      }
-    </View>
-  </SafeAreaView>
-)
+        )}
+
+        <OfflineBanner />
+        {isOnline &&
+          lastSyncError && <SyncErrorBanner showRefresh={!isSyncing} />}
+
+        <AvailableAmountBanner
+          amount={tokenBalance.getDefault()}
+          amountAssetMetaData={availableAssets[tokenBalance.getDefaultId()]}
+        />
+
+        {_.isEmpty(transactionsInfo) ? (
+          <ScrollView
+            refreshControl={
+              <RefreshControl onRefresh={updateHistory} refreshing={isSyncing} />
+            }
+          >
+            <NoTxHistory />
+          </ScrollView>
+        ) : (
+          <TxHistoryList
+            refreshing={isSyncing}
+            onRefresh={updateHistory}
+            navigation={navigation}
+            transactions={transactionsInfo}
+          />
+        )}
+
+        {/* eslint-disable indent */
+        isByron(walletMeta.walletImplementationId) &&
+          showWarning && (
+            <WarningBanner
+              title={intl
+                .formatMessage(warningBannerMessages.title)
+                .toUpperCase()}
+              icon={infoIcon}
+              message={intl.formatMessage(warningBannerMessages.message)}
+              showCloseIcon
+              onRequestClose={() => setShowWarning(false)}
+              style={styles.warningNoteStyles}
+            />
+          )
+        /* eslint-enable indent */
+        }
+      </View>
+    </SafeAreaView>
+  )
+}
 
 type ExternalProps = {|
   navigation: Navigation,

--- a/src/components/WalletNavigator.js
+++ b/src/components/WalletNavigator.js
@@ -122,6 +122,7 @@ const WalletTabNavigator = injectIntl(
         activeTintColor: DEFAULT_THEME_COLORS.NAVIGATION_ACTIVE,
         inactiveTintColor: DEFAULT_THEME_COLORS.NAVIGATION_INACTIVE,
       }}
+      backBehavior="initialRoute"
     >
       <Tab.Screen
         name={WALLET_ROUTES.TX_HISTORY}

--- a/src/crypto/walletManager.js
+++ b/src/crypto/walletManager.js
@@ -520,10 +520,11 @@ class WalletManager {
 
   closeWallet(): Promise<void> {
     if (!this._wallet) return Promise.resolve()
+    Logger.debug('closing wallet...')
     assert.assert(this._closeReject, 'close: should have _closeReject')
     /* :: if (!this._closeReject) throw 'assert' */
     // Abort all async interactions with the wallet
-    // const reject = this._closeReject
+    const reject = this._closeReject
     this._closePromise = null
     this._closeReject = null
     this._wallet = null
@@ -533,9 +534,7 @@ class WalletManager {
     // closeWallet would throw if some rejection
     // handler does not catch
     return Promise.resolve().then(() => {
-      // TODO: Check why Shelley path crash when this is active
-      //  and figure out why this is actually necessary
-      // reject(new WalletClosed())
+      reject(new WalletClosed())
     })
   }
 

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -10,7 +10,12 @@ import {
 } from './types/HistoryTransaction'
 import {ObjectValues} from './utils/flow'
 import {MultiToken, getDefaultNetworkTokenEntry} from './crypto/MultiToken'
-import {getDefaultAssets, getDefaultAssetByNetworkId} from './config/config'
+import {
+  getDefaultAssets,
+  getDefaultAssetByNetworkId,
+  getCardanoDefaultAsset,
+} from './config/config'
+import {NETWORK_REGISTRY} from './config/types'
 
 import type {State, WalletMeta} from './state'
 import type {
@@ -68,6 +73,12 @@ export const availableAssetsSelector: (
   transactionsInfoSelector,
   (state) => state.wallet.networkId,
   (txs, networkId) => {
+    if (networkId === NETWORK_REGISTRY.UNDEFINED) {
+      const defaultAsset = getCardanoDefaultAsset()
+      return {
+        [defaultAsset.identifier]: defaultAsset,
+      }
+    }
     const tokens: Dict<Token> = fromPairs(
       ObjectValues(_initAssetsRegistry(networkId)).map((asset) => [
         asset.identifier,
@@ -95,7 +106,12 @@ export const defaultNetworkAssetSelector: (
   state: State,
 ) => DefaultAsset = createSelector(
   (state) => state.wallet.networkId,
-  (networkId) => getDefaultAssetByNetworkId(networkId),
+  (networkId) => {
+    if (networkId === NETWORK_REGISTRY.UNDEFINED) {
+      return getCardanoDefaultAsset()
+    }
+    return getDefaultAssetByNetworkId(networkId)
+  },
 )
 
 export const internalAddressIndexSelector: (
@@ -143,6 +159,13 @@ export const tokenBalanceSelector: (
   transactionsInfoSelector,
   walletMetaSelector,
   (transactions, walletMeta) => {
+    if (walletMeta.networkId === NETWORK_REGISTRY.UNDEFINED) {
+      const defaultAsset = getCardanoDefaultAsset()
+      return new MultiToken([], {
+        defaultNetworkId: defaultAsset.networkId,
+        defaultIdentifier: defaultAsset.identifier,
+      })
+    }
     const processed = ObjectValues(transactions).filter(
       (tx) => tx.status === TRANSACTION_STATUS.SUCCESSFUL,
     )


### PR DESCRIPTION
This is one of those tickets that's been pending for a while. I thought it was supposed to be easier to solve with react navigation 5.x but it turns out it isn't.

This solution should work in theory but there is a crash that occurs when the send screen was visited before going back to the "my wallets" list. This means that for some reason the send screen is not completely unmounted. After some investigation I believe the issue is that the `connect` HOC creates a new component that remains mounted, while the inner send screen is unmounted (note: unmounting occurs when navigating back). A workaround for this needs to be found before this can actually be merged.

Another important thing to note is that the close wallet function need to be called from the initial wallet route, which now is the transaction history but will soon be changed to the dashboard.

UPDATE: After more debugging it looks like all screens in the bottom tab navigator remain mounted even after a go back event is triggered. Also, navigating back to "my wallets", also keeps all visited screens in the bottom tab navigator mounted. I couldn't found the root cause of this so I just avoid throwing the exceptions when trying to get the default network asset after the wallet is disconnected (just default to ADA).