### PR TITLE
build storybook as a separate android flavor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ android/app/src/main/res/drawable*
 .env.production
 .env.staging
 .env.e2e
+.env.storybook
 sentry.properties
 app-mainnet-release.apk
 output.json

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -83,7 +83,8 @@ project.ext.react = [
 project.ext.envConfigFiles = [
   dev: '.env.staging',
   main: '.env.production',
-  nightly: '.env.production'
+  nightly: '.env.production',
+  storybook: '.env.storybook'
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"
@@ -195,6 +196,15 @@ android {
         nightly {
             dimension "version"
             applicationIdSuffix ".nightly"
+            applicationId 'com.emurgo'
+            minSdkVersion 21
+            compileSdkVersion = 29
+            targetSdkVersion 29
+            resValue "string", "build_config_package", "com.emurgo"
+        }
+        storybook {
+            dimension "version"
+            applicationIdSuffix ".storybook"
             applicationId 'com.emurgo'
             minSdkVersion 21
             compileSdkVersion = 29

--- a/get_commit.sh
+++ b/get_commit.sh
@@ -4,8 +4,9 @@ BASE_DIR="$(dirname ${BASH_SOURCE[0]})"
 cd $BASE_DIR
 PROD_ENV_FILE=".env.production"
 STAGING_ENV_FILE=".env.staging"
+STORYBOOK_ENV_FILE=".env.storybook"
 
-declare -a FILES=($PROD_ENV_FILE $STAGING_ENV_FILE)
+declare -a FILES=($PROD_ENV_FILE $STAGING_ENV_FILE $STORYBOOK_ENV_FILE)
 LAST_COMMIT=$(git rev-parse --short HEAD)
 if [ -z "$LAST_COMMIT" ]; then
   echo "ERROR: Couldn't get last commit hash"

--- a/src/AppNavigator.js
+++ b/src/AppNavigator.js
@@ -193,10 +193,7 @@ const NavigatorSwitch = compose(
 
 const StoryBook = () => (
   <Stack.Navigator>
-    <Stack.Screen
-      name={ROOT_ROUTES.STORYBOOK}
-      component={StorybookScreen}
-    />
+    <Stack.Screen name={ROOT_ROUTES.STORYBOOK} component={StorybookScreen} />
   </Stack.Navigator>
 )
 

--- a/src/AppNavigator.js
+++ b/src/AppNavigator.js
@@ -35,9 +35,12 @@ import {
   canBiometricEncryptionBeEnabled,
 } from './helpers/deviceSettings'
 import {errorMessages} from './i18n/global-messages'
+import env from './env'
 import KeyStore from './crypto/KeyStore'
 
 import type {State} from './state'
+
+const IS_STORYBOOK = env.getBoolean('IS_STORYBOOK', false)
 
 const hasAnyWalletSelector = (state: State): boolean => !isEmpty(state.wallets)
 
@@ -188,10 +191,19 @@ const NavigatorSwitch = compose(
   },
 )
 
+const StoryBook = () => (
+  <Stack.Navigator>
+    <Stack.Screen
+      name={ROOT_ROUTES.STORYBOOK}
+      component={StorybookScreen}
+    />
+  </Stack.Navigator>
+)
+
 const AppNavigator = () => {
   return (
     <NavigationContainer>
-      <NavigatorSwitch />
+      {IS_STORYBOOK ? <StoryBook /> : <NavigatorSwitch />}
     </NavigationContainer>
   )
 }


### PR DESCRIPTION
This might be useful eventually if we succeed at building the app through react native web.

Basically instead of embedding the storybook in some route accessible only in debug builds, we can just have a special build that only displays the storybook.