### PR TITLE
Enable screenshots in Catalyst step 6 

### DIFF
--- a/android/app/src/main/java/com/emurgo/FlagSecure.java
+++ b/android/app/src/main/java/com/emurgo/FlagSecure.java
@@ -1,0 +1,51 @@
+package com.emurgo;
+
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import java.util.Map;
+import java.util.HashMap;
+
+import android.app.Activity;
+import android.view.WindowManager;
+
+public class FlagSecure extends ReactContextBaseJavaModule {
+    FlagSecure(ReactApplicationContext context) {
+        super(context);
+    }
+
+    @Override
+    public String getName() {
+        return "FlagSecure";
+    }
+
+    @ReactMethod
+    public void activate() {
+        final Activity activity = getCurrentActivity();
+
+        if (activity != null) {
+            activity.runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
+                }
+            });
+        }
+    }
+
+    @ReactMethod
+    public void deactivate() {
+        final Activity activity = getCurrentActivity();
+
+        if (activity != null) {
+            activity.runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
+                }
+            });
+        }
+    }
+}

--- a/android/app/src/main/java/com/emurgo/FlagSecurePackage.java
+++ b/android/app/src/main/java/com/emurgo/FlagSecurePackage.java
@@ -1,0 +1,28 @@
+package com.emurgo;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+
+public class FlagSecurePackage implements ReactPackage {
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<NativeModule> createNativeModules(
+            ReactApplicationContext reactContext) {
+        List<NativeModule> modules = new ArrayList<>();
+
+        modules.add(new FlagSecure(reactContext));
+
+        return modules;
+    }
+}

--- a/android/app/src/main/java/com/emurgo/MainApplication.java
+++ b/android/app/src/main/java/com/emurgo/MainApplication.java
@@ -29,6 +29,7 @@ public class MainApplication extends Application implements ReactApplication {
       // packages.add(new ChainLibsPackage());
       // packages.add(new CardanoPackage());
       packages.add(new KeyStorePackage());
+      packages.add(new FlagSecurePackage());
       return packages;
     }
 

--- a/src/components/Catalyst/Step6.js
+++ b/src/components/Catalyst/Step6.js
@@ -12,9 +12,11 @@ import {
   Clipboard,
   TouchableOpacity,
   Image,
+  NativeModules,
 } from 'react-native'
 import {injectIntl, defineMessages} from 'react-intl'
 import {connect} from 'react-redux'
+import {useFocusEffect} from '@react-navigation/native'
 
 import {Text, Button, ProgressStep} from '../UiKit'
 import {withTitle} from '../../utils/renderUtils'
@@ -52,7 +54,9 @@ const messages = defineMessages({
   },
 })
 
-const Step1 = ({intl, navigation, encryptedKey}) => {
+const {FlagSecure} = NativeModules
+
+const Step6 = ({intl, navigation, encryptedKey}) => {
   const [countDown, setCountDown] = useState(5)
 
   useEffect(
@@ -60,6 +64,20 @@ const Step1 = ({intl, navigation, encryptedKey}) => {
       countDown > 0 && setTimeout(() => setCountDown(countDown - 1), 1000)
     },
     [countDown],
+  )
+
+  useFocusEffect(
+    React.useCallback(() => {
+      // enable screenshots
+      FlagSecure.deactivate()
+
+      return () => {
+        // disable screenshots
+        // recall: this clean up function returned by useFocusEffect is run
+        // automatically by react on blur
+        FlagSecure.activate()
+      }
+    }, []),
   )
 
   const _copyKey = () => {
@@ -139,7 +157,7 @@ export default injectIntl(
     }),
     {},
   )(
-    withTitle((Step1: ComponentType<ExternalProps>), ({intl}) =>
+    withTitle((Step6: ComponentType<ExternalProps>), ({intl}) =>
       intl.formatMessage(globalMessages.votingTitle),
     ),
   ),


### PR DESCRIPTION
This trick should allow Android users save the QR code. Recall: iOS screenshots are already enabled everywhere since AFAIK there is no way to disable them.