### PR TITLE
fix wallet creation for small screens

### DIFF
--- a/src/components/WalletInit/CreateWallet/MnemonicCheckScreen.js
+++ b/src/components/WalletInit/CreateWallet/MnemonicCheckScreen.js
@@ -143,55 +143,64 @@ const MnemonicCheckScreen = ({
   const last = _.last(partialPhrase)
 
   return (
-    <SafeAreaView style={styles.safeAreaView}>
-      <View style={styles.container}>
-        <StatusBar type="dark" />
+    <SafeAreaView
+      edges={['left', 'right', 'bottom']}
+      style={styles.safeAreaView}
+    >
+      <StatusBar type="dark" />
+
+      <View style={styles.content}>
         <ScrollView
+          contentContainerStyle={styles.scrollViewContentContainer}
           automaticallyAdjustContentInsets={shouldScreenScroll()}
           bounces={shouldScreenScroll()}
         >
-          <View style={styles.content}>
+          <View style={styles.instructions}>
             <Text>{intl.formatMessage(messages.instructions)}</Text>
-            <View
-              style={[
-                styles.recoveryPhrase,
-                !isPhraseValid &&
-                  isPhraseComplete &&
-                  styles.recoveryPhraseError,
-              ]}
-            >
-              {initial.map((id) => (
-                <Text style={styles.wordText} key={id}>
-                  {words[id]}
-                </Text>
-              ))}
-              {last != null && (
-                <WordBadge
-                  value={last}
-                  selected={false}
-                  word={words[last]}
-                  onPress={deselectWord}
-                />
-              )}
-            </View>
-            {!(isPhraseValid || !isPhraseComplete) && (
-              <Text style={styles.error}>
+          </View>
+
+          <View
+            style={[
+              styles.recoveryPhrase,
+              !isPhraseValid && isPhraseComplete && styles.recoveryPhraseError,
+            ]}
+          >
+            {initial.map((id) => (
+              <Text style={styles.wordText} key={id}>
+                {words[id]}
+              </Text>
+            ))}
+            {last != null && (
+              <WordBadge
+                value={last}
+                selected={false}
+                word={words[last]}
+                onPress={deselectWord}
+              />
+            )}
+          </View>
+
+          {!(isPhraseValid || !isPhraseComplete) && (
+            <View style={styles.error}>
+              <Text style={styles.errorMessage}>
                 {intl.formatMessage(messages.mnemonicWordsInputInvalidPhrase)}
               </Text>
-            )}
-            <View style={styles.words}>
-              {words.map((word, index) => (
-                <WordBadge
-                  key={index}
-                  value={index}
-                  selected={partialPhrase.includes(index)}
-                  onPress={selectWord}
-                  word={word}
-                />
-              ))}
             </View>
+          )}
+
+          <View style={styles.words}>
+            {words.map((word, index) => (
+              <WordBadge
+                key={index}
+                value={index}
+                selected={partialPhrase.includes(index)}
+                onPress={selectWord}
+                word={word}
+              />
+            ))}
           </View>
         </ScrollView>
+
         <View style={styles.buttons}>
           <Button
             block

--- a/src/components/WalletInit/CreateWallet/MnemonicShowScreen.js
+++ b/src/components/WalletInit/CreateWallet/MnemonicShowScreen.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import {View, Image, Dimensions} from 'react-native'
+import {View, Image, ScrollView, Dimensions} from 'react-native'
 import {compose} from 'redux'
 import {withHandlers, withStateHandlers, withProps} from 'recompose'
 import {SafeAreaView} from 'react-native-safe-area-context'
@@ -49,12 +49,19 @@ const MnemonicShowScreen = ({
   showModal,
   hideModal,
 }) => (
-  <SafeAreaView style={styles.safeAreaView}>
+  <SafeAreaView edges={['left', 'right', 'bottom']} style={styles.safeAreaView}>
     <StatusBar type="dark" />
-    <View style={styles.contentContainer}>
-      <View>
-        <Text>{intl.formatMessage(messages.mnemonicNote)}</Text>
-        <View style={styles.mnemonicWordsContainer}>
+
+    <View style={styles.content}>
+      <ScrollView
+        contentContainerStyle={styles.scrollViewContentContainer}
+        bounces={false}
+      >
+        <View style={styles.mnemonicNote}>
+          <Text>{intl.formatMessage(messages.mnemonicNote)}</Text>
+        </View>
+
+        <View style={styles.mnemonicWords}>
           {mnemonic.split(' ').map((word, index) => (
             <Text
               key={index}
@@ -65,29 +72,31 @@ const MnemonicShowScreen = ({
             </Text>
           ))}
         </View>
-      </View>
-      {/* If screen is small hide image */}
-      {Dimensions.get('window').height > 480 && (
-        <View style={styles.image}>
-          <Image source={recoveryPhrase} />
-        </View>
-      )}
-      <View>
+
+        {/* If screen is small hide image */}
+        {Dimensions.get('window').height > 480 && (
+          <View style={styles.image}>
+            <Image source={recoveryPhrase} />
+          </View>
+        )}
+      </ScrollView>
+
+      <View style={styles.button}>
         <Button
           onPress={showModal}
           title={intl.formatMessage(messages.confirmationButton)}
           testID="mnemonicShowScreen::confirm"
         />
       </View>
-    </View>
 
-    {modal && (
-      <MnemonicBackupImportanceModal
-        visible={modal}
-        onConfirm={navigateToMnemonicCheck}
-        onRequestClose={hideModal}
-      />
-    )}
+      {modal && (
+        <MnemonicBackupImportanceModal
+          visible={modal}
+          onConfirm={navigateToMnemonicCheck}
+          onRequestClose={hideModal}
+        />
+      )}
+    </View>
   </SafeAreaView>
 )
 

--- a/src/components/WalletInit/CreateWallet/styles/MnemonicCheckScreen.style.js
+++ b/src/components/WalletInit/CreateWallet/styles/MnemonicCheckScreen.style.js
@@ -9,11 +9,19 @@ export default StyleSheet.create({
     flex: 1,
   },
   content: {
-    flexGrow: 1,
+    flex: 1,
+  },
+  scrollViewContentContainer: {
+    paddingTop: 32,
+    paddingHorizontal: 16,
+    paddingBottom: 16,
+  },
+  instructions: {
+    paddingBottom: 16,
   },
   buttons: {
     flexDirection: 'row',
-    marginTop: 12,
+    padding: 16,
   },
   clearButton: {
     marginRight: 12,
@@ -26,8 +34,10 @@ export default StyleSheet.create({
     padding: 16,
   },
   error: {
-    color: COLORS.RED,
     paddingLeft: 16,
+  },
+  errorMessage: {
+    color: COLORS.RED,
   },
   inputLabel: {
     color: COLORS.PRIMARY,
@@ -39,7 +49,6 @@ export default StyleSheet.create({
     flexDirection: 'row',
     flexWrap: 'wrap',
     paddingBottom: 0,
-    marginTop: 16,
     height: 26 * 6,
     paddingHorizontal: 6,
   },
@@ -65,9 +74,7 @@ export default StyleSheet.create({
   words: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    marginTop: 12,
-    marginBottom: 12,
-    height: 26 * 7,
+    paddingVertical: 12,
   },
   selected: {
     opacity: 0,

--- a/src/components/WalletInit/CreateWallet/styles/MnemonicShowScreen.style.js
+++ b/src/components/WalletInit/CreateWallet/styles/MnemonicShowScreen.style.js
@@ -1,27 +1,29 @@
 // @flow
 import {StyleSheet} from 'react-native'
 
-import {screenPadding} from '../../../Screen'
-
 export default StyleSheet.create({
-  screen: {
-    padding: 0,
-  },
   safeAreaView: {
     backgroundColor: '#fff',
     flex: 1,
   },
-  mnemonicNoteContainer: {
-    padding: screenPadding,
+  content: {
+    flex: 1,
   },
-  mnemonicWordsContainer: {
+  scrollViewContentContainer: {
+    paddingTop: 32,
+    paddingHorizontal: 16,
+    paddingBottom: 16,
+  },
+  mnemonicNote: {
+    paddingBottom: 16,
+  },
+  mnemonicWords: {
     backgroundColor: '#fff',
     borderColor: '#9B9B9B',
     borderWidth: 1,
     borderRadius: 8,
     paddingHorizontal: 16,
     paddingVertical: 8,
-    marginTop: 30,
     flexDirection: 'row',
     flexWrap: 'wrap',
   },
@@ -29,13 +31,11 @@ export default StyleSheet.create({
     lineHeight: 30,
     marginRight: 24,
   },
-  contentContainer: {
-    flexGrow: 1,
-    padding: 16,
-    justifyContent: 'space-between',
-  },
   image: {
+    paddingTop: 24,
     alignItems: 'center',
-    marginBottom: 24,
+  },
+  button: {
+    padding: 16,
   },
 })


### PR DESCRIPTION
remove unnecessary `SafeAreaView`s
add `ScrollView` to accommodate smaller screens
remove fixed height for mnemonic words

tested on ipod Touch (simulator) and Galaxy Nexus (emulator), both with text and display at max and at default

closes #1155 