### PR TITLE
resync wallet state for next version

### DIFF
--- a/src/crypto/Wallet.js
+++ b/src/crypto/Wallet.js
@@ -57,7 +57,7 @@ export default class Wallet {
 
   rewardAddressHex: ?string = null
 
-  // last known version the wallet has been created/restored
+  // last known version the wallet has been opened on
   version: ?string
 
   checksum: WalletChecksum

--- a/src/crypto/WalletInterface.js
+++ b/src/crypto/WalletInterface.js
@@ -48,13 +48,18 @@ export interface WalletInterface {
 
   externalChain: AddressChain;
 
-  // note: currently not exposed to redux's state
+  // note: currently not exposed to redux's store
   publicKeyHex: string;
 
-  // note: exposed to redux's state but not in storage (as it can be derived)
+  // note: exposed to redux's store but not in storage (as it can be derived)
   rewardAddressHex: ?string;
 
-  // last known version the wallet has been created/restored
+  // last known version the wallet has been opened on
+  // note: Prior to v4.1.0, `version` was set upon wallet creation/restoration
+  // and was never updated. Starting from v4.1.0, we instead store the
+  // last version the wallet has been *opened* on, since this is the actual
+  // relevant information we need to decide on whether migrations are needed.
+  // Saved in storage but not exposed to redux's store.
   version: ?string;
 
   state: WalletState;

--- a/src/crypto/shelley/ShelleyWallet.js
+++ b/src/crypto/shelley/ShelleyWallet.js
@@ -254,7 +254,12 @@ export default class ShelleyWallet extends Wallet implements WalletInterface {
     this.isHW = data.isHW ?? false
     this.hwDeviceInfo = data.hwDeviceInfo
     this.isReadOnly = data.isReadOnly ?? false
+
     this.version = DeviceInfo.getVersion()
+    if (this.version !== lastSeenVersion) {
+      Logger.debug(`updated version from ${lastSeenVersion} to ${this.version}`)
+    }
+
     this.internalChain = AddressChain.fromJSON(data.internalChain)
     this.externalChain = AddressChain.fromJSON(data.externalChain)
     // can be null for versions < 3.0.2, in which case we can just retrieve

--- a/src/crypto/walletManager.js
+++ b/src/crypto/walletManager.js
@@ -503,11 +503,15 @@ class WalletManager {
     this._wallet = wallet
     this._id = walletMeta.id
 
+    // wallet state might have changed after restore due to migrations, so we
+    // update the data in storage immediately
+    await this._saveState(wallet)
+
     wallet.subscribe(this._notify)
     this._closePromise = new Promise((resolve, reject) => {
       this._closeReject = reject
     })
-    this._notify()
+    this._notify() // update redux store
 
     if (wallet.isEasyConfirmationEnabled) {
       await this.ensureKeysValidity()

--- a/src/crypto/walletManager.js
+++ b/src/crypto/walletManager.js
@@ -66,7 +66,7 @@ class WalletManager {
   // storage. Unfortunately, as new metadata is added over time (eg. networkId),
   // we need to infer some values for wallets created in older versions,
   // which may induce errors and leave us with this ugly method.
-  // The responsability to check data consistency is left to the each wallet
+  // The responsibility to check data consistency is left to the each wallet
   // implementation.
   async initialize() {
     const _wallets = await this._listWallets()
@@ -575,7 +575,7 @@ class WalletManager {
 
   // TODO(ppershing): how should we deal with race conditions?
   async _updateMetadata(id, newMeta) {
-    assert.assert(this._wallets[id], '_updateWalletInfo id')
+    assert.assert(this._wallets[id], '_updateMetadata id')
     const merged = {
       ...this._wallets[id],
       ...newMeta,
@@ -593,7 +593,7 @@ class WalletManager {
 
     await this._updateMetadata(id, {name: newName})
 
-    this._notify()
+    this._notify() // update redux Store
   }
 
   // =================== create =================== //

--- a/src/state.js
+++ b/src/state.js
@@ -30,7 +30,7 @@ export type WalletMeta = {
 export type State = {
   wallets: Dict<WalletMeta>,
   wallet: {
-    name: string,
+    name: string, // note: comes from WalletMeta, exposed by walletManager only
     isInitialized: boolean,
     networkId: NetworkId,
     walletImplementationId: WalletImplementationId,

--- a/src/utils/versioning.js
+++ b/src/utils/versioning.js
@@ -1,0 +1,34 @@
+// @flow
+
+/**
+ * expects version strings following the usual semantic versioning,
+ * i.e.: major.minor.patch
+ * e.g.: '1.10.1'
+ * Does not allow variations like 1.0.0-rc.
+ * returns
+ *   1 if A > B,
+ *   0 if A = B,
+ *  -1 if A < B
+ */
+export const versionCompare = (versionA: string, versionB: string): number => {
+  for (const s of [versionA, versionB]) {
+    const re = /^\d+(.\d+){0,2}$/ // only accept numbers and dots
+    if (!(typeof s === 'string' || s instanceof String) || !s.match(re)) {
+      throw new Error(`versionCompare: invalid argument ${s}`)
+    }
+  }
+  const chunksA = versionA.split(/\./g, 3)
+  const chunksB = versionB.split(/\./g, 3)
+
+  while (chunksA.length < chunksB.length) chunksA.push('0')
+  while (chunksB.length < chunksA.length) chunksB.push('0')
+
+  const chunksAint = chunksA.map((i) => parseInt(i, 10))
+  const chunksBint = chunksB.map((i) => parseInt(i, 10))
+  for (let i = 0; i < chunksA.length; i++) {
+    if (chunksAint[i] !== chunksBint[i]) {
+      return chunksAint[i] > chunksBint[i] ? 1 : -1
+    }
+  }
+  return 0
+}

--- a/src/utils/versioning.test.js
+++ b/src/utils/versioning.test.js
@@ -7,8 +7,6 @@ jestSetup.setup()
 
 describe('versionCompare: arguments', () => {
   it('should throw with invalid arguments', () => {
-    expect(() => versionCompare(10, '1.1')).toThrow()
-    expect(() => versionCompare(10, 1.1)).toThrow()
     expect(() => versionCompare('1.0', '1.0.0b')).toThrow()
     expect(() => versionCompare('1.0.0.0', '1.0.0')).toThrow()
     expect(() => versionCompare('1..0', '1.0.0')).toThrow()
@@ -31,6 +29,8 @@ describe('versionCompare: compare valid versions', () => {
   it('should return -1 on A < B', () => {
     expect(versionCompare('2.200.1', '2.200.2')).toBe(-1)
     expect(versionCompare('0', '0.0.1')).toBe(-1)
+    expect(versionCompare('3.1', '3.4.0')).toBe(-1)
+    expect(versionCompare('3.3.9', '3.4')).toBe(-1)
   })
 
   it('should work on truncated versions', () => {

--- a/src/utils/versioning.test.js
+++ b/src/utils/versioning.test.js
@@ -1,0 +1,39 @@
+// @flow
+import jestSetup from '../jestSetup'
+
+import {versionCompare} from './versioning'
+
+jestSetup.setup()
+
+describe('versionCompare: arguments', () => {
+  it('should throw with invalid arguments', () => {
+    expect(() => versionCompare(10, '1.1')).toThrow()
+    expect(() => versionCompare(10, 1.1)).toThrow()
+    expect(() => versionCompare('1.0', '1.0.0b')).toThrow()
+    expect(() => versionCompare('1.0.0.0', '1.0.0')).toThrow()
+    expect(() => versionCompare('1..0', '1.0.0')).toThrow()
+    expect(() => versionCompare('1.0.0-rc', '1.0.0')).toThrow()
+  })
+})
+
+describe('versionCompare: compare valid versions', () => {
+  it('should return 1 on A > B', () => {
+    expect(versionCompare('1.0.1', '1.0.0')).toEqual(1)
+    expect(versionCompare('1.0.1', '0.10.10')).toBe(1)
+  })
+  it('should return 0 on A == B', () => {
+    expect(versionCompare('1.0.1', '1.0.1')).toBe(0)
+    expect(versionCompare('0', '0')).toBe(0)
+    expect(versionCompare('0.0.0', '0')).toBe(0)
+    expect(versionCompare('0.0.1', '0.0.1')).toBe(0)
+  })
+
+  it('should return -1 on A < B', () => {
+    expect(versionCompare('2.200.1', '2.200.2')).toBe(-1)
+    expect(versionCompare('0', '0.0.1')).toBe(-1)
+  })
+
+  it('should work on truncated versions', () => {
+    expect(versionCompare('1.0', '0.1000.1')).toBe(1)
+  })
+})


### PR DESCRIPTION
force resync on versions < 4.1.0 and change the meaning of the `version` wallet attribute that is kept in storage. More details:

- Prior to version 4.1.0 (next release), `version` was set during wallet creation/restoration and was not updated afterwards.
- Now it will store the last app version on which the wallet was opened
- This allows us to handle migrations in a better way
- No breaking changes in the stored data structure