### PR TITLE
Fix wallet navigator not showing up

### DIFF
--- a/src/AppNavigator.js
+++ b/src/AppNavigator.js
@@ -163,7 +163,6 @@ const NavigatorSwitch = compose(
     if (!hasAnyWallet) {
       return (
         <Stack.Navigator
-          initialRouteName={ROOT_ROUTES.NEW_WALLET}
           screenOptions={{headerShown: false}}
         >
           <Stack.Screen
@@ -176,7 +175,6 @@ const NavigatorSwitch = compose(
     }
     return (
       <Stack.Navigator
-        initialRouteName={ROOT_ROUTES.WALLET}
         screenOptions={{headerShown: false}}
       >
         <Stack.Screen name={ROOT_ROUTES.WALLET} component={WalletNavigator} />

--- a/src/AppNavigator.js
+++ b/src/AppNavigator.js
@@ -162,9 +162,7 @@ const NavigatorSwitch = compose(
     // following two cases, but that didn't work (probably bug in react-navigation)
     if (!hasAnyWallet) {
       return (
-        <Stack.Navigator
-          screenOptions={{headerShown: false}}
-        >
+        <Stack.Navigator screenOptions={{headerShown: false}}>
           <Stack.Screen
             name={ROOT_ROUTES.NEW_WALLET}
             component={WalletInitNavigator}
@@ -174,9 +172,7 @@ const NavigatorSwitch = compose(
       )
     }
     return (
-      <Stack.Navigator
-        screenOptions={{headerShown: false}}
-      >
+      <Stack.Navigator screenOptions={{headerShown: false}}>
         <Stack.Screen name={ROOT_ROUTES.WALLET} component={WalletNavigator} />
         <Stack.Screen
           name={ROOT_ROUTES.NEW_WALLET}


### PR DESCRIPTION
Once the initial setup (selecting language, accepting ToS) is done there are two possibilities:

- Yoroi displays "Create new wallet" screen, if user does not have any wallet created.
- Yoroi displays "My wallets" screen, if user already has one or more wallets in storage.

Under the hoods, this requires two navigators to be rendered simultaneously. The problem is that, once a user creates a wallet, the order in which the nested navigators are displayed must be inverted, and this is not working properly.

This trick seems to fix the issue.

Closes #1329 