### PR TITLE
reset send screen after send transaction

### DIFF
--- a/src/components/Send/ConfirmScreen.js
+++ b/src/components/Send/ConfirmScreen.js
@@ -53,6 +53,7 @@ import type {CreateUnsignedTxResponse} from '../../crypto/shelley/transactionUti
 import type {TokenEntry} from '../../crypto/MultiToken'
 
 import styles from './styles/ConfirmScreen.style'
+import {CommonActions} from '@react-navigation/routers'
 
 const messages = defineMessages({
   title: {
@@ -95,6 +96,13 @@ const handleOnConfirm = async (
           await submitSignedTx(tx)
         }
 
+        navigation.dispatch(
+          CommonActions.reset({
+            key: null,
+            index: 0,
+            routes: [{name: SEND_ROUTES.MAIN}],
+          }),
+        )
         navigation.navigate(WALLET_ROUTES.TX_HISTORY)
       } catch (e) {
         if (e instanceof NetworkError) {

--- a/src/components/Send/SendScreen.js
+++ b/src/components/Send/SendScreen.js
@@ -6,7 +6,7 @@ import {compose} from 'redux'
 import {connect} from 'react-redux'
 import {ScrollView, View, ActivityIndicator} from 'react-native'
 import _ from 'lodash'
-import SafeAreaView from 'react-native-safe-area-view'
+import {SafeAreaView} from 'react-native-safe-area-context'
 import {injectIntl, defineMessages} from 'react-intl'
 /* eslint-disable-next-line camelcase */
 import {min_ada_required, BigNum} from '@emurgo/react-native-haskell-shelley'
@@ -869,7 +869,7 @@ class SendScreen extends Component<Props, State> {
     )
 
     return (
-      <SafeAreaView style={styles.container}>
+      <SafeAreaView edges={['left', 'right']} style={styles.container}>
         <StatusBar type="dark" />
 
         <UtxoAutoRefresher />


### PR DESCRIPTION
reset the send stack before navigating back to tx history [(react navigation docs)](https://reactnavigation.org/docs/navigation-actions/#reset)
replace react native safe area view with react native safe area context
* it is deprecated
* has a bug that this ran into

verified on iPhone 12 simulator, pixel 3xl emulator