### PR TITLE
Add support for testnet in nightly builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ translations/messages
 android/app/src/main/assets/index.android.bundle
 .env.production
 .env.staging
+.env.nightly
 .env.e2e
 .env.storybook
 sentry.properties

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -85,7 +85,7 @@ project.ext.react = [
 project.ext.envConfigFiles = [
   dev: '.env.staging',
   main: '.env.production',
-  nightly: '.env.production',
+  nightly: '.env.nightly',
   storybook: '.env.storybook'
 ]
 

--- a/check_env_variables.sh
+++ b/check_env_variables.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+# TODO: check variables for nightly builds too
+
 BASE_DIR="$(dirname ${BASH_SOURCE[0]})"
 cd $BASE_DIR
 PROD_ENV_FILE=".env.production"

--- a/check_env_variables.sh
+++ b/check_env_variables.sh
@@ -1,10 +1,13 @@
 #!/bin/sh
 
-# TODO: check variables for nightly builds too
-
 BASE_DIR="$(dirname ${BASH_SOURCE[0]})"
 cd $BASE_DIR
-PROD_ENV_FILE=".env.production"
+
+PROD_ENV_FILE=${1}
+if [ -z "$PROD_ENV_FILE" ]; then
+  echo "WARN: .env file name not provided, defaulting to .env.production"
+  PROD_ENV_FILE=".env.production"
+fi
 
 echo "Checking env variables in file $PROD_ENV_FILE"
 

--- a/get_commit.sh
+++ b/get_commit.sh
@@ -3,10 +3,11 @@
 BASE_DIR="$(dirname ${BASH_SOURCE[0]})"
 cd $BASE_DIR
 PROD_ENV_FILE=".env.production"
+NIGHTLY_ENV_FILE=".env.nightly"
 STAGING_ENV_FILE=".env.staging"
 STORYBOOK_ENV_FILE=".env.storybook"
 
-declare -a FILES=($PROD_ENV_FILE $STAGING_ENV_FILE $STORYBOOK_ENV_FILE)
+declare -a FILES=($PROD_ENV_FILE $NIGHTLY_ENV_FILE $STAGING_ENV_FILE $STORYBOOK_ENV_FILE)
 LAST_COMMIT=$(git rev-parse --short HEAD)
 if [ -z "$LAST_COMMIT" ]; then
   echo "ERROR: Couldn't get last commit hash"

--- a/ios/emurgo.xcodeproj/project.pbxproj
+++ b/ios/emurgo.xcodeproj/project.pbxproj
@@ -742,7 +742,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# check env variables\n${PROJECT_DIR}/../check_env_variables.sh\n";
+			shellScript = "# check env variables\n${PROJECT_DIR}/../check_env_variables.sh \".env.production\"\n";
 		};
 		E9A1C7DA24185CCA00151CFA /* Check env variables */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -760,7 +760,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# check env variables\n${PROJECT_DIR}/../check_env_variables.sh\n";
+			shellScript = "# check env variables\n${PROJECT_DIR}/../check_env_variables.sh \".env.nightly\"\n";
 		};
 		E9A1C80324185CCA00151CFA /* Bundle React Native code and images */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/ios/emurgo.xcodeproj/xcshareddata/xcschemes/emurgo-nightly.xcscheme
+++ b/ios/emurgo.xcodeproj/xcshareddata/xcschemes/emurgo-nightly.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "echo &quot;.env.production&quot; &gt; /tmp/envfile&#10;&#10;${PROJECT_DIR}/../get_commit.sh&#10;">
+               scriptText = "echo &quot;.env.nightly&quot; &gt; /tmp/envfile&#10;&#10;${PROJECT_DIR}/../get_commit.sh&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/src/actions.js
+++ b/src/actions.js
@@ -43,6 +43,8 @@ import {
 import assert from './utils/assert'
 import KeyStore from './crypto/KeyStore'
 import * as api from './api/shelley/api'
+import {getNetworkConfig} from './crypto/shelley/utils'
+
 import {ISignRequest} from './crypto/ISignRequest'
 import {CONFIG} from './config/config'
 
@@ -235,7 +237,11 @@ const _setServerStatus = (serverStatus: ServerStatusCache) => (
 
 export const initApp = () => async (dispatch: Dispatch<any>, getState: any) => {
   try {
-    const status = await api.checkServerStatus()
+    // check status of default network
+    const backendConfig = getNetworkConfig(
+      CONFIG.NETWORKS.HASKELL_SHELLEY.NETWORK_ID,
+    ).BACKEND
+    const status = await api.checkServerStatus(backendConfig)
     dispatch(
       _setServerStatus({
         isServerOk: status.isServerOk,

--- a/src/actions.js
+++ b/src/actions.js
@@ -43,10 +43,9 @@ import {
 import assert from './utils/assert'
 import KeyStore from './crypto/KeyStore'
 import * as api from './api/shelley/api'
-import {getNetworkConfig} from './crypto/shelley/utils'
-
 import {ISignRequest} from './crypto/ISignRequest'
 import {CONFIG} from './config/config'
+import {getCardanoNetworkConfigById} from './config/networks'
 
 import {type Dispatch} from 'redux'
 import type {State, ServerStatusCache} from './state'
@@ -238,7 +237,7 @@ const _setServerStatus = (serverStatus: ServerStatusCache) => (
 export const initApp = () => async (dispatch: Dispatch<any>, getState: any) => {
   try {
     // check status of default network
-    const backendConfig = getNetworkConfig(
+    const backendConfig = getCardanoNetworkConfigById(
       CONFIG.NETWORKS.HASKELL_SHELLEY.NETWORK_ID,
     ).BACKEND
     const status = await api.checkServerStatus(backendConfig)

--- a/src/api/shelley/api.js
+++ b/src/api/shelley/api.js
@@ -3,11 +3,11 @@ import _ from 'lodash'
 import {BigNumber} from 'bignumber.js'
 
 import checkedFetch from '../fetch'
-import {CONFIG} from '../../config/config'
 import assert from '../../utils/assert'
 import {checkAndFacadeTransactionAsync} from './facade'
 
 import type {Transaction} from '../../types/HistoryTransaction'
+import type {BackendConfig} from '../../config/types'
 
 import type {
   RawUtxo,
@@ -23,38 +23,41 @@ import type {
   FundInfoResponse,
 } from '../types'
 
-const NETWORK_CONFIG = CONFIG.NETWORKS.HASKELL_SHELLEY.BACKEND
-
 type Addresses = Array<string>
 
-export const checkServerStatus = (): Promise<ServerStatusResponse> =>
-  checkedFetch('status', null, NETWORK_CONFIG, 'GET')
+export const checkServerStatus = (
+  config: BackendConfig,
+): Promise<ServerStatusResponse> => checkedFetch('status', null, config, 'GET')
 
-export const getBestBlock = (): Promise<BestblockResponse> =>
-  checkedFetch('v2/bestblock', null, NETWORK_CONFIG, 'GET')
+export const getBestBlock = (
+  config: BackendConfig,
+): Promise<BestblockResponse> =>
+  checkedFetch('v2/bestblock', null, config, 'GET')
 
 export const fetchNewTxHistory = async (
   request: TxHistoryRequest,
+  config: BackendConfig,
 ): Promise<{isLast: boolean, transactions: Array<Transaction>}> => {
   assert.preconditionCheck(
-    request.addresses.length <= NETWORK_CONFIG.TX_HISTORY_MAX_ADDRESSES,
+    request.addresses.length <= config.TX_HISTORY_MAX_ADDRESSES,
     'fetchNewTxHistory: too many addresses',
   )
-  const response = await checkedFetch('v2/txs/history', request, NETWORK_CONFIG)
+  const response = await checkedFetch('v2/txs/history', request, config)
   const transactions = await Promise.all(
     response.map(checkAndFacadeTransactionAsync),
   )
   return {
     transactions,
-    isLast: response.length < NETWORK_CONFIG.TX_HISTORY_RESPONSE_LIMIT,
+    isLast: response.length < config.TX_HISTORY_RESPONSE_LIMIT,
   }
 }
 
 export const filterUsedAddresses = async (
   addresses: Addresses,
+  config: BackendConfig,
 ): Promise<Addresses> => {
   assert.preconditionCheck(
-    addresses.length <= NETWORK_CONFIG.FILTER_USED_MAX_ADDRESSES,
+    addresses.length <= config.FILTER_USED_MAX_ADDRESSES,
     'filterUsedAddresses: too many addresses',
   )
   // Take a copy in case underlying data mutates during await
@@ -62,52 +65,58 @@ export const filterUsedAddresses = async (
   const used = await checkedFetch(
     'v2/addresses/filterUsed',
     {addresses: copy},
-    NETWORK_CONFIG,
+    config,
   )
   // We need to do this so that we keep original order of addresses
   return copy.filter((addr) => used.includes(addr))
 }
 
-export const fetchUTXOsForAddresses = (addresses: Addresses) => {
+export const fetchUTXOsForAddresses = (
+  addresses: Addresses,
+  config: BackendConfig,
+) => {
   assert.preconditionCheck(
-    addresses.length <= NETWORK_CONFIG.FETCH_UTXOS_MAX_ADDRESSES,
-    'fetchNewTxHistory: too many addresses',
+    addresses.length <= config.FETCH_UTXOS_MAX_ADDRESSES,
+    'fetchUTXOsForAddresses: too many addresses',
   )
-  return checkedFetch('txs/utxoForAddresses', {addresses}, NETWORK_CONFIG)
+  return checkedFetch('txs/utxoForAddresses', {addresses}, config)
 }
 
 export const bulkFetchUTXOsForAddresses = async (
   addresses: Addresses,
+  config: BackendConfig,
 ): Promise<Array<RawUtxo>> => {
-  const chunks = _.chunk(addresses, NETWORK_CONFIG.FETCH_UTXOS_MAX_ADDRESSES)
+  const chunks = _.chunk(addresses, config.FETCH_UTXOS_MAX_ADDRESSES)
 
   const responses = await Promise.all(
-    chunks.map((addrs) => fetchUTXOsForAddresses(addrs)),
+    chunks.map((addrs) => fetchUTXOsForAddresses(addrs, config)),
   )
   return _.flatten(responses)
 }
 
-export const submitTransaction = (signedTx: string) => {
-  return checkedFetch('txs/signed', {signedTx}, NETWORK_CONFIG)
+export const submitTransaction = (signedTx: string, config: BackendConfig) => {
+  return checkedFetch('txs/signed', {signedTx}, config)
 }
 
 export const fetchUTXOSumForAddresses = (
   addresses: Addresses,
+  config: BackendConfig,
 ): Promise<{sum: string}> => {
   assert.preconditionCheck(
-    addresses.length <= NETWORK_CONFIG.FETCH_UTXOS_MAX_ADDRESSES,
+    addresses.length <= config.FETCH_UTXOS_MAX_ADDRESSES,
     'fetchUTXOSumForAddresses: too many addresses',
   )
-  return checkedFetch('txs/utxoSumForAddresses', {addresses}, NETWORK_CONFIG)
+  return checkedFetch('txs/utxoSumForAddresses', {addresses}, config)
 }
 
 export const bulkFetchUTXOSumForAddresses = async (
   addresses: Addresses,
+  config: BackendConfig,
 ): Promise<{fundedAddresses: Array<string>, sum: BigNumber}> => {
-  const chunks = _.chunk(addresses, NETWORK_CONFIG.FETCH_UTXOS_MAX_ADDRESSES)
+  const chunks = _.chunk(addresses, config.FETCH_UTXOS_MAX_ADDRESSES)
 
   const responses = await Promise.all(
-    chunks.map((addrs) => fetchUTXOSumForAddresses(addrs)),
+    chunks.map((addrs) => fetchUTXOSumForAddresses(addrs, config)),
   )
   const sum = responses.reduce(
     (x: BigNumber, y) => x.plus(new BigNumber(y.sum || 0)),
@@ -115,7 +124,7 @@ export const bulkFetchUTXOSumForAddresses = async (
   )
 
   const responseUTXOAddresses = await Promise.all(
-    chunks.map((addrs) => fetchUTXOsForAddresses(addrs)),
+    chunks.map((addrs) => fetchUTXOsForAddresses(addrs, config)),
   )
 
   const fundedAddresses = _.flatten(responseUTXOAddresses).map(
@@ -130,43 +139,50 @@ export const bulkFetchUTXOSumForAddresses = async (
 
 export const getTxsBodiesForUTXOs = (
   request: TxBodiesRequest,
+  config: BackendConfig,
 ): Promise<TxBodiesResponse> => {
-  return checkedFetch('txs/txBodies', request, NETWORK_CONFIG)
+  return checkedFetch('txs/txBodies', request, config)
 }
 
 export const getAccountState = async (
   request: AccountStateRequest,
+  config: BackendConfig,
 ): Promise<AccountStateResponse> => {
   assert.preconditionCheck(
-    request.addresses.length <= NETWORK_CONFIG.FETCH_UTXOS_MAX_ADDRESSES,
+    request.addresses.length <= config.FETCH_UTXOS_MAX_ADDRESSES,
     'getAccountState: too many addresses',
   )
-  return await checkedFetch('getAccountState', request, NETWORK_CONFIG)
+  return await checkedFetch('getAccountState', request, config)
 }
 
 export const bulkGetAccountState = async (
   addresses: Addresses,
+  config: BackendConfig,
 ): Promise<AccountStateResponse> => {
-  const chunks = _.chunk(addresses, NETWORK_CONFIG.FETCH_UTXOS_MAX_ADDRESSES)
+  const chunks = _.chunk(addresses, config.FETCH_UTXOS_MAX_ADDRESSES)
 
   const responses = await Promise.all(
-    chunks.map((addrs) => getAccountState({addresses: addrs})),
+    chunks.map((addrs) => getAccountState({addresses: addrs}, config)),
   )
   return Object.assign({}, ...responses)
 }
 
 export const getPoolInfo = async (
   request: PoolInfoRequest,
+  config: BackendConfig,
 ): Promise<PoolInfoResponse> => {
-  return await checkedFetch('getPoolInfo', request, NETWORK_CONFIG)
+  return await checkedFetch('getPoolInfo', request, config)
 }
 
-export const getFundInfo = async (): Promise<FundInfoResponse> => {
-  const prefix = CONFIG.NETWORKS.HASKELL_SHELLEY.IS_MAINNET ? '' : 'api/'
+export const getFundInfo = async (
+  config: BackendConfig,
+  isMainnet: boolean,
+): Promise<FundInfoResponse> => {
+  const prefix = isMainnet ? '' : 'api/'
   return await checkedFetch(
-    `${prefix}v0/catalyst/fundInfo`,
+    `${prefix}v0/catalyst/fundInfo/`,
     null,
-    NETWORK_CONFIG,
+    config,
     'GET',
   )
 }

--- a/src/api/shelley/api.test.js
+++ b/src/api/shelley/api.test.js
@@ -4,13 +4,18 @@ import jestSetup from '../../jestSetup'
 
 import * as api from './api'
 import {ApiError, ApiHistoryError} from '../errors'
+import {NETWORKS} from '../../config/networks'
+import {getNetworkConfig} from '../../crypto/shelley/utils'
 
 jestSetup.setup()
 jest.setTimeout(30 * 1000)
 
+const networkConfig = getNetworkConfig(NETWORKS.HASKELL_SHELLEY.NETWORK_ID)
+const backendConfig = networkConfig.BACKEND
+
 describe('History API', () => {
   it('can fetch history', async () => {
-    const bestBlock = await api.getBestBlock()
+    const bestBlock = await api.getBestBlock(backendConfig)
     const addresses = [
       'Ae2tdPwUPEZKAx4zt8YLTGxrhX9L6R8QPWNeefZsPgwaigWab4mEw1ECUZ7',
     ]
@@ -21,7 +26,7 @@ describe('History API', () => {
 
     // We are async
     expect.assertions(1)
-    const result = await api.fetchNewTxHistory(request)
+    const result = await api.fetchNewTxHistory(request, backendConfig)
 
     expect(result.transactions[0]).toMatchSnapshot({
       blockNum: expect.any(Number),
@@ -40,7 +45,9 @@ describe('History API', () => {
     // We are async
     expect.assertions(1)
 
-    await expect(api.fetchNewTxHistory(request)).rejects.toThrow(ApiError)
+    await expect(api.fetchNewTxHistory(request, backendConfig)).rejects.toThrow(
+      ApiError,
+    )
   })
 
   it('throws ApiHistoryError on bad request', async () => {
@@ -62,7 +69,7 @@ describe('History API', () => {
     // We are async
     expect.assertions(1)
 
-    await expect(api.fetchNewTxHistory(request)).rejects.toThrow(
+    await expect(api.fetchNewTxHistory(request, backendConfig)).rejects.toThrow(
       ApiHistoryError,
     )
   })
@@ -92,7 +99,7 @@ describe('History API', () => {
     ]
 
     expect.assertions(1)
-    const result = await api.filterUsedAddresses(addresses)
+    const result = await api.filterUsedAddresses(addresses, backendConfig)
     expect(result).toEqual(used)
   })
 
@@ -109,12 +116,12 @@ describe('History API', () => {
 
     expect.assertions(2)
 
-    const result1 = await api.filterUsedAddresses(addresses)
+    const result1 = await api.filterUsedAddresses(addresses, backendConfig)
     expect(result1).toEqual(addresses)
 
     addresses.reverse()
 
-    const result2 = await api.filterUsedAddresses(addresses)
+    const result2 = await api.filterUsedAddresses(addresses, backendConfig)
     expect(result2).toEqual(addresses)
   })
 })

--- a/src/api/shelley/api.test.js
+++ b/src/api/shelley/api.test.js
@@ -4,13 +4,14 @@ import jestSetup from '../../jestSetup'
 
 import * as api from './api'
 import {ApiError, ApiHistoryError} from '../errors'
-import {NETWORKS} from '../../config/networks'
-import {getNetworkConfig} from '../../crypto/shelley/utils'
+import {NETWORKS, getCardanoNetworkConfigById} from '../../config/networks'
 
 jestSetup.setup()
 jest.setTimeout(30 * 1000)
 
-const networkConfig = getNetworkConfig(NETWORKS.HASKELL_SHELLEY.NETWORK_ID)
+const networkConfig = getCardanoNetworkConfigById(
+  NETWORKS.HASKELL_SHELLEY.NETWORK_ID,
+)
 const backendConfig = networkConfig.BACKEND
 
 describe('History API', () => {

--- a/src/components/Delegation/StakingDashboard.js
+++ b/src/components/Delegation/StakingDashboard.js
@@ -79,9 +79,9 @@ import walletManager, {SystemAuthDisabled} from '../../crypto/walletManager'
 import globalMessages, {errorMessages} from '../../i18n/global-messages'
 import FlawedWalletScreen from './FlawedWalletScreen'
 import {CONFIG, getCardanoBaseConfig} from '../../config/config'
+import {getCardanoNetworkConfigById} from '../../config/networks'
 import {WITHDRAWAL_DIALOG_STEPS, type WithdrawalDialogSteps} from './types'
 import {HaskellShelleyTxSignRequest} from '../../crypto/shelley/HaskellShelleyTxSignRequest'
-import {getNetworkConfig} from '../../crypto/shelley/utils'
 import KeyStore from '../../crypto/KeyStore'
 import {MultiToken} from '../../crypto/MultiToken'
 import {ISignRequest} from '../../crypto/ISignRequest'
@@ -554,8 +554,9 @@ class StakingDashboard extends React.Component<Props, State> {
       walletMeta,
     } = this.props
 
-    // TODO: shouldn't be haskell-shelley specific
-    const config = getCardanoBaseConfig(getNetworkConfig(walletMeta.networkId))
+    const config = getCardanoBaseConfig(
+      getCardanoNetworkConfigById(walletMeta.networkId),
+    )
 
     const toRelativeSlotNumberFn = genToRelativeSlotNumber(config)
     const timeToSlotFn = genTimeToSlot(config)

--- a/src/components/Delegation/StakingDashboard.js
+++ b/src/components/Delegation/StakingDashboard.js
@@ -45,6 +45,7 @@ import {
   hwDeviceInfoSelector,
   defaultNetworkAssetSelector,
   serverStatusSelector,
+  walletMetaSelector,
 } from '../../selectors'
 import DelegationNavigationButtons from './DelegationNavigationButtons'
 import UtxoAutoRefresher from '../Send/UtxoAutoRefresher'
@@ -80,13 +81,14 @@ import FlawedWalletScreen from './FlawedWalletScreen'
 import {CONFIG, getCardanoBaseConfig} from '../../config/config'
 import {WITHDRAWAL_DIALOG_STEPS, type WithdrawalDialogSteps} from './types'
 import {HaskellShelleyTxSignRequest} from '../../crypto/shelley/HaskellShelleyTxSignRequest'
+import {getNetworkConfig} from '../../crypto/shelley/utils'
 import KeyStore from '../../crypto/KeyStore'
 import {MultiToken} from '../../crypto/MultiToken'
 import {ISignRequest} from '../../crypto/ISignRequest'
 
 import styles from './styles/DelegationSummary.style'
 
-import type {ServerStatusCache} from '../../state'
+import type {ServerStatusCache, WalletMeta} from '../../state'
 import type {Navigation} from '../../types/navigation'
 import type {DefaultAsset} from '../../types/HistoryTransaction'
 import type {RemotePoolMetaSuccess, RawUtxo} from '../../api/types'
@@ -137,6 +139,7 @@ type Props = {|
   submitSignedTx: (string) => Promise<void>,
   defaultAsset: DefaultAsset,
   serverStatus: ServerStatusCache,
+  walletMeta: $Diff<WalletMeta, {id: string}>,
 |}
 
 type State = {|
@@ -548,10 +551,11 @@ class StakingDashboard extends React.Component<Props, State> {
       isFetchingUtxos,
       isFlawedWallet,
       navigation,
+      walletMeta,
     } = this.props
 
     // TODO: shouldn't be haskell-shelley specific
-    const config = getCardanoBaseConfig()
+    const config = getCardanoBaseConfig(getNetworkConfig(walletMeta.networkId))
 
     const toRelativeSlotNumberFn = genToRelativeSlotNumber(config)
     const timeToSlotFn = genTimeToSlot(config)
@@ -731,6 +735,7 @@ export default injectIntl(
         hwDeviceInfo: hwDeviceInfoSelector(state),
         defaultAsset: defaultNetworkAssetSelector(state),
         serverStatus: serverStatusSelector(state),
+        walletMeta: walletMetaSelector(state),
       }),
       {
         fetchPoolInfo,

--- a/src/components/Receive/AddressView.js
+++ b/src/components/Receive/AddressView.js
@@ -58,6 +58,7 @@ const _handleOnVerifyAddress = async (
       }
       await verifyAddress(
         walletMeta.walletImplementationId,
+        walletMeta.networkId,
         address,
         addressingInfo,
         hwDeviceInfo,
@@ -99,7 +100,7 @@ type Props = {|
   index: number,
   address: string,
   isUsed: boolean,
-  walletMeta: WalletMeta,
+  walletMeta: $Diff<WalletMeta, {id: string}>,
   openDetails: () => void,
   closeDetails: () => void,
   onVerifyAddress: () => void,

--- a/src/components/Send/SendScreen.js
+++ b/src/components/Send/SendScreen.js
@@ -249,6 +249,7 @@ const getMinAda = async (selectedToken: Token, defaultAsset: DefaultAsset) => {
   )
   const minAmount = await min_ada_required(
     await cardanoValueFromMultiToken(fakeMultitoken),
+    // TODO
     await BigNum.from_str(CONFIG.NETWORKS.HASKELL_SHELLEY.MINIMUM_UTXO_VAL),
   )
   // if the user is sending a token, we need to make sure the resulting utxo
@@ -414,6 +415,7 @@ const getAmountErrorText = (
     if (
       amountErrors.invalidAmount === InvalidAssetAmount.ERROR_CODES.LT_MIN_UTXO
     ) {
+      // TODO
       const amount = new BigNumber(
         CONFIG.NETWORKS.HASKELL_SHELLEY.MINIMUM_UTXO_VAL,
       )

--- a/src/components/TxHistory/TxHistory.js
+++ b/src/components/TxHistory/TxHistory.js
@@ -40,7 +40,7 @@ import {Logger} from '../../utils/logging'
 import FlawedWalletModal from './FlawedWalletModal'
 import StandardModal from '../Common/StandardModal'
 import {WALLET_ROOT_ROUTES, CATALYST_ROUTES} from '../../RoutesList'
-import {CONFIG, isByron, isHaskellShelley} from '../../config/config'
+import {CONFIG, isByron, isHaskellShelley, isNightly} from '../../config/config'
 
 import {formatTokenWithText} from '../../utils/format'
 import image from '../../assets/img/no_transactions.png'
@@ -174,7 +174,9 @@ const TxHistory = ({
         Logger.debug('Could not get Catalyst fund info from server', e)
       }
     }
-    setShowCatalystBanner((canVote && isRegistrationOpen(fundInfo)) || __DEV__)
+    setShowCatalystBanner(
+      (canVote && isRegistrationOpen(fundInfo)) || isNightly() || __DEV__,
+    )
   }
 
   useEffect(() => {

--- a/src/components/WalletInit/RestoreWallet/ImportReadOnlyWalletScreen.js
+++ b/src/components/WalletInit/RestoreWallet/ImportReadOnlyWalletScreen.js
@@ -58,6 +58,7 @@ let firstFocus = true
 const handleOnRead = async (
   event: Object,
   navigation: Navigation,
+  route: Object,
   intl: intlShape,
 ): Promise<void> => {
   try {
@@ -70,6 +71,8 @@ const handleOnRead = async (
       navigation.navigate(WALLET_INIT_ROUTES.SAVE_READ_ONLY_WALLET, {
         publicKeyHex,
         path,
+        networkId: route.params.networkId,
+        walletImplementationId: route.params.walletImplementationId,
       })
     } else {
       throw new Error('invalid QR code')
@@ -120,7 +123,7 @@ const ImportReadOnlyWalletScreen = ({intl, onRead}) => (
 export default injectIntl(
   (compose(
     withNavigationTitle(({intl}) => intl.formatMessage(messages.title)),
-    onDidMount(async ({navigation, intl}) => {
+    onDidMount(async ({navigation, route, intl}) => {
       navigation.addListener('focus', () => {
         // re-enable QR code scanning
         if (
@@ -138,12 +141,12 @@ export default injectIntl(
             CONFIG.DEBUG.PUB_KEY
           }", "path": [1852,1815,0]}`,
         }
-        await handleOnRead(event, navigation, intl)
+        await handleOnRead(event, navigation, route, intl)
       }
     }),
     withHandlers({
-      onRead: ({navigation, intl}) => async (event) => {
-        await handleOnRead(event, navigation, intl)
+      onRead: ({navigation, route, intl}) => async (event) => {
+        await handleOnRead(event, navigation, route, intl)
       },
     }),
   )(ImportReadOnlyWalletScreen): ComponentType<{

--- a/src/components/WalletInit/RestoreWallet/SaveReadOnlyWalletScreen.js
+++ b/src/components/WalletInit/RestoreWallet/SaveReadOnlyWalletScreen.js
@@ -29,6 +29,7 @@ import styles from './styles/SaveReadOnlyWalletScreen.style'
 
 import type {ComponentType} from 'react'
 import type {Navigation} from '../../../types/navigation'
+import type {NetworkId} from '../../../config/types'
 
 const messages = defineMessages({
   title: {
@@ -76,6 +77,7 @@ type WalletInfoProps = {|
   },
   normalizedPath: Array<number>,
   publicKeyHex: string,
+  networkId: NetworkId,
 |}
 
 const WalletInfoView = ({
@@ -83,6 +85,7 @@ const WalletInfoView = ({
   plate,
   normalizedPath,
   publicKeyHex,
+  networkId,
 }: WalletInfoProps) => (
   <View style={styles.walletInfoContainer}>
     <ScrollView style={styles.scrollView}>
@@ -104,7 +107,7 @@ const WalletInfoView = ({
           renderItem={({item}) => (
             <WalletAddress
               addressHash={item}
-              networkId={CONFIG.NETWORKS.HASKELL_SHELLEY.NETWORK_ID}
+              networkId={networkId}
             />
           )}
         />
@@ -175,6 +178,7 @@ const SaveReadOnlyWalletScreen = ({onSubmit, isWaiting, route, intl}) => {
             plate={plate}
             normalizedPath={normalizedPath}
             publicKeyHex={publicKeyHex}
+            networkId={networkId}
           />
         }
         buttonStyle={styles.walletFormButtonStyle}

--- a/src/components/WalletInit/RestoreWallet/SaveReadOnlyWalletScreen.js
+++ b/src/components/WalletInit/RestoreWallet/SaveReadOnlyWalletScreen.js
@@ -105,10 +105,7 @@ const WalletInfoView = ({
           data={plate.addresses}
           keyExtractor={(item) => item}
           renderItem={({item}) => (
-            <WalletAddress
-              addressHash={item}
-              networkId={networkId}
-            />
+            <WalletAddress addressHash={item} networkId={networkId} />
           )}
         />
       </View>

--- a/src/components/WalletInit/RestoreWallet/SaveReadOnlyWalletScreen.js
+++ b/src/components/WalletInit/RestoreWallet/SaveReadOnlyWalletScreen.js
@@ -140,7 +140,7 @@ const SaveReadOnlyWalletScreen = ({onSubmit, isWaiting, route, intl}) => {
     addresses: [],
   })
 
-  const {publicKeyHex, path} = route.params
+  const {publicKeyHex, path, networkId} = route.params
 
   const normalizedPath = path.map((i) => {
     if (i >= CONFIG.NUMBERS.HARD_DERIVATION_START) {
@@ -153,6 +153,7 @@ const SaveReadOnlyWalletScreen = ({onSubmit, isWaiting, route, intl}) => {
     const {addresses, accountPlate} = await generateShelleyPlateFromKey(
       publicKeyHex,
       1,
+      networkId,
     )
     setPlate({addresses, accountPlate})
   }
@@ -228,19 +229,25 @@ export default injectIntl(
           route,
         }) => async ({name}) => {
           try {
-            const {publicKeyHex} = route.params
+            const {
+              publicKeyHex,
+              networkId,
+              walletImplementationId,
+            } = route.params
             assert.assert(
               publicKeyHex != null,
               'SaveReadOnlyWalletScreen::onPress publicKeyHex',
             )
+            assert.assert(networkId != null, 'networkId')
+            assert.assert(!!walletImplementationId, 'walletImplementationId')
 
             await withActivityIndicator(
               async () =>
                 await createWalletWithBip44Account(
                   name,
                   publicKeyHex,
-                  CONFIG.NETWORKS.HASKELL_SHELLEY.NETWORK_ID,
-                  CONFIG.WALLETS.HASKELL_SHELLEY.WALLET_IMPLEMENTATION_ID,
+                  networkId,
+                  walletImplementationId,
                   null,
                   true, // important: read-only flag
                 ),

--- a/src/components/WalletInit/RestoreWallet/VerifyRestoredWallet.js
+++ b/src/components/WalletInit/RestoreWallet/VerifyRestoredWallet.js
@@ -22,7 +22,7 @@ import styles from './styles/VerifyRestoredWallet.style'
 
 import type {ComponentType} from 'react'
 import type {Navigation} from '../../../types/navigation'
-import type {WalletImplementationId} from '../../../config/types'
+import type {WalletImplementationId, NetworkId} from '../../../config/types'
 
 const messages = defineMessages({
   title: {
@@ -65,13 +65,14 @@ const messages = defineMessages({
 
 const _getPlate = async (
   walletImplId: WalletImplementationId,
+  networkId: NetworkId,
   phrase: string,
   count: number,
 ) => {
   switch (walletImplId) {
     case WALLET_IMPLEMENTATION_REGISTRY.HASKELL_SHELLEY:
     case WALLET_IMPLEMENTATION_REGISTRY.HASKELL_SHELLEY_24:
-      return await generateShelleyPlateFromMnemonics(phrase, count)
+      return await generateShelleyPlateFromMnemonics(phrase, count, networkId)
     case WALLET_IMPLEMENTATION_REGISTRY.HASKELL_BYRON:
       return generateByronPlateFromMnemonics(phrase, count)
     default:
@@ -107,6 +108,7 @@ const VerifyWalletScreen = ({navigateToWalletCredentials, intl, route}) => {
   const generatePlates = async () => {
     const {addresses, accountPlate} = await _getPlate(
       walletImplementationId,
+      networkId,
       phrase,
       1,
     )

--- a/src/components/WalletInit/WalletFreshInitScreen.js
+++ b/src/components/WalletInit/WalletFreshInitScreen.js
@@ -13,7 +13,7 @@ import {Button, StatusBar, ScreenBackground} from '../UiKit'
 // uses same styles as WalletInitScreen
 import styles from './styles/WalletInitScreen.style'
 import {WALLET_INIT_ROUTES} from '../../RoutesList'
-import {CONFIG} from '../../config/config'
+import {CONFIG, isNightly} from '../../config/config'
 
 import type {State} from '../../state'
 import type {Navigation} from '../../types/navigation'
@@ -62,6 +62,24 @@ const WalletInitScreen = ({intl, navigateInitWallet}: Props) => {
             style={styles.createButton}
             testID="addWalletOnHaskellShelleyButton"
           />
+
+          {isNightly() && (
+            <Button
+              onPress={(event) =>
+                // note: assume wallet implementation = yoroi haskell shelley
+                // (15 words), but user may choose 24 words in next screen
+                navigateInitWallet(
+                  event,
+                  CONFIG.NETWORKS.HASKELL_SHELLEY_TESTNET.NETWORK_ID,
+                  CONFIG.WALLETS.HASKELL_SHELLEY.WALLET_IMPLEMENTATION_ID,
+                )
+              }
+              title={`${intl.formatMessage(
+                messages.addWalletButton,
+              )} on TESTNET (Shelley-era)`}
+              style={styles.createButton}
+            />
+          )}
 
           <Button
             onPress={(event) =>

--- a/src/components/WalletInit/WalletInitScreen.js
+++ b/src/components/WalletInit/WalletInitScreen.js
@@ -78,7 +78,11 @@ type ModalState = $Values<typeof MODAL_STATES>
 type Props = {
   navigateRestoreWallet: (Object, NetworkId, WalletImplementationId) => void,
   navigateCreateWallet: (Object, NetworkId, WalletImplementationId) => void,
-  navigateImportReadOnlyWallet: (Object) => void,
+  navigateImportReadOnlyWallet: (
+    Object,
+    NetworkId,
+    WalletImplementationId,
+  ) => void,
   navigateCheckNanoX: (
     Object,
     NetworkId,
@@ -212,7 +216,13 @@ const WalletInitScreen = ({
               />
               <Button
                 outlineOnLight
-                onPress={navigateImportReadOnlyWallet}
+                onPress={(event) =>
+                  navigateImportReadOnlyWallet(
+                    event,
+                    networkId,
+                    implementationId,
+                  )
+                }
                 title={intl.formatMessage(messages.importReadOnlyWalletLabel)}
                 style={styles.mnemonicDialogButton}
                 testID="importReadOnlyWalletButton"
@@ -274,8 +284,15 @@ export default injectIntl(
           walletImplementationId,
           useUSB,
         }),
-      navigateImportReadOnlyWallet: ({navigation}) => (_event: Object) =>
-        navigation.navigate(WALLET_INIT_ROUTES.IMPORT_READ_ONLY_WALLET),
+      navigateImportReadOnlyWallet: ({navigation}) => (
+        _event: Object,
+        networkId: NetworkId,
+        walletImplementationId: WalletImplementationId,
+      ) =>
+        navigation.navigate(WALLET_INIT_ROUTES.IMPORT_READ_ONLY_WALLET, {
+          networkId,
+          walletImplementationId,
+        }),
     }),
   )(WalletInitScreen),
 )

--- a/src/components/WalletSelection/WalletSelectionScreen.js
+++ b/src/components/WalletSelection/WalletSelectionScreen.js
@@ -89,21 +89,6 @@ const WalletListScreen = ({wallets, navigateInitWallet, openWallet, intl}) => (
           style={styles.topButton}
         />
 
-        <Button
-          outline
-          onPress={(event) =>
-            navigateInitWallet(
-              event,
-              CONFIG.NETWORKS.HASKELL_SHELLEY.NETWORK_ID,
-              CONFIG.WALLETS.HASKELL_BYRON.WALLET_IMPLEMENTATION_ID,
-            )
-          }
-          title={`${intl.formatMessage(
-            messages.addWalletButton,
-          )} (Byron-era - ${intl.formatMessage(globalMessages.deprecated)})`}
-          style={styles.button}
-        />
-
         {isNightly() && (
           <Button
             onPress={(event) =>
@@ -118,9 +103,24 @@ const WalletListScreen = ({wallets, navigateInitWallet, openWallet, intl}) => (
             title={`${intl.formatMessage(
               messages.addWalletButton,
             )} on TESTNET (Shelley-era)`}
-            style={styles.topButton}
+            style={styles.button}
           />
         )}
+
+        <Button
+          outline
+          onPress={(event) =>
+            navigateInitWallet(
+              event,
+              CONFIG.NETWORKS.HASKELL_SHELLEY.NETWORK_ID,
+              CONFIG.WALLETS.HASKELL_BYRON.WALLET_IMPLEMENTATION_ID,
+            )
+          }
+          title={`${intl.formatMessage(
+            messages.addWalletButton,
+          )} (Byron-era - ${intl.formatMessage(globalMessages.deprecated)})`}
+          style={styles.button}
+        />
 
         {CONFIG.NETWORKS.JORMUNGANDR.ENABLED && (
           <Button

--- a/src/components/WalletSelection/WalletSelectionScreen.js
+++ b/src/components/WalletSelection/WalletSelectionScreen.js
@@ -26,7 +26,7 @@ import {showErrorDialog, updateVersion} from '../../actions'
 import globalMessages, {errorMessages} from '../../i18n/global-messages'
 import {currentVersionSelector} from '../../selectors'
 import {onDidMount} from '../../utils/renderUtils'
-import {CONFIG} from '../../config/config'
+import {CONFIG, isNightly} from '../../config/config'
 import {isJormungandr} from '../../config/networks'
 
 import styles from './styles/WalletSelectionScreen.style'
@@ -103,6 +103,24 @@ const WalletListScreen = ({wallets, navigateInitWallet, openWallet, intl}) => (
           )} (Byron-era - ${intl.formatMessage(globalMessages.deprecated)})`}
           style={styles.button}
         />
+
+        {isNightly() && (
+          <Button
+            onPress={(event) =>
+              // note: assume wallet implementation = yoroi haskell shelley
+              // (15 words), but user may choose 24 words in next screen
+              navigateInitWallet(
+                event,
+                CONFIG.NETWORKS.HASKELL_SHELLEY_TESTNET.NETWORK_ID,
+                CONFIG.WALLETS.HASKELL_SHELLEY.WALLET_IMPLEMENTATION_ID,
+              )
+            }
+            title={`${intl.formatMessage(
+              messages.addWalletButton,
+            )} on TESTNET (Shelley-era)`}
+            style={styles.topButton}
+          />
+        )}
 
         {CONFIG.NETWORKS.JORMUNGANDR.ENABLED && (
           <Button

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -28,7 +28,6 @@ const IS_DEBUG = __DEV__
 const _BUILD_VARIANT = env.getString('BUILD_VARIANT')
 const _SHOW_INIT_DEBUG_SCREEN = env.getBoolean('SHOW_INIT_DEBUG_SCREEN', false)
 const _PREFILL_WALLET_INFO = env.getBoolean('PREFILL_WALLET_INFO', false)
-const _IS_TESTING = env.getBoolean('IS_TESTING', false) // e2e testing
 const _USE_TESTNET = env.getBoolean('USE_TESTNET', false)
 
 // TODO(v-almonacid): consider adding 'ENABLE' as an env variable
@@ -145,10 +144,10 @@ export const CONFIG = {
   E2E: {
     // WARNING: NEVER change these flags here, use .env.e2e
     // we test release configurations so we allow this flag when __DEV__=false
-    IS_TESTING: _IS_TESTING, // TODO: use BUILD_VARIANT instead (or wrapper around it)
+    IS_TESTING: _BUILD_VARIANT === 'E2E',
   },
   BUILD_VARIANT: _BUILD_VARIANT,
-  IS_TESTNET_BUILD: _USE_TESTNET, // TODO: use BUILD_VARIANT instead
+  IS_TESTNET_BUILD: _BUILD_VARIANT === 'STAGING',
   MAX_CONCURRENT_REQUESTS: 5,
   SENTRY: _SENTRY,
   MNEMONIC_STRENGTH: 160,
@@ -250,6 +249,10 @@ const _asToken = (asset): DefaultAsset => ({
 export const getDefaultAssets = (): Array<DefaultAsset> =>
   DEFAULT_ASSETS.map((asset) => _asToken(asset))
 
+/**
+ * note: this returns the default asset according to the build variant, ie.
+ * ADA for production builds, including nightly, and TADA for staing
+ */
 export const getCardanoDefaultAsset = (): DefaultAsset => {
   const assetData = DEFAULT_ASSETS.filter((network) => {
     const config = getNetworkConfigById(network.NETWORK_ID)

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -16,18 +16,19 @@ import type {
   WalletImplementationId,
   NetworkId,
 } from './types'
+import type {CardanoHaskellShelleyNetwork} from './networks'
 import type {DefaultAsset} from '../types/HistoryTransaction'
 
 const IS_DEBUG = __DEV__
-/** debugging flags
+/** env variables & debugging flags
  *
  * WARNING: NEVER change these flags direclty here.
  * ALWAYS use the corresponding .env files.
  */
+const _BUILD_VARIANT = env.getString('BUILD_VARIANT')
 const _SHOW_INIT_DEBUG_SCREEN = env.getBoolean('SHOW_INIT_DEBUG_SCREEN', false)
 const _PREFILL_WALLET_INFO = env.getBoolean('PREFILL_WALLET_INFO', false)
-// e2e testing
-const _IS_TESTING = env.getBoolean('IS_TESTING', false)
+const _IS_TESTING = env.getBoolean('IS_TESTING', false) // e2e testing
 const _USE_TESTNET = env.getBoolean('USE_TESTNET', false)
 
 // TODO(v-almonacid): consider adding 'ENABLE' as an env variable
@@ -35,11 +36,10 @@ const _SENTRY = {
   DSN: env.getString('SENTRY'),
   ENABLE: false,
 }
+const _COMMIT = env.getString('COMMIT')
 
 const _LOG_LEVEL = IS_DEBUG ? LogLevel.Debug : LogLevel.Warn
 const _ASSURANCE_STRICT = false
-
-const _COMMIT = env.getString('COMMIT')
 
 export const ASSURANCE_LEVELS = {
   NORMAL: {
@@ -145,9 +145,10 @@ export const CONFIG = {
   E2E: {
     // WARNING: NEVER change these flags here, use .env.e2e
     // we test release configurations so we allow this flag when __DEV__=false
-    IS_TESTING: _IS_TESTING,
+    IS_TESTING: _IS_TESTING, // TODO: use BUILD_VARIANT instead (or wrapper around it)
   },
-  IS_TESTNET_BUILD: _USE_TESTNET,
+  BUILD_VARIANT: _BUILD_VARIANT,
+  IS_TESTNET_BUILD: _USE_TESTNET, // TODO: use BUILD_VARIANT instead
   MAX_CONCURRENT_REQUESTS: 5,
   SENTRY: _SENTRY,
   MNEMONIC_STRENGTH: 160,
@@ -206,26 +207,28 @@ export const getWalletConfigById = (
   throw new Error('invalid walletImplementationId')
 }
 
+export const isNightly = () => CONFIG.BUILD_VARIANT === 'NIGHTLY'
+
 // need to accomodate base config parameters as required by certain API shared
 // by yoroi extension and yoroi mobile
-export const getCardanoBaseConfig = (): Array<{
+export const getCardanoBaseConfig = (
+  networkConfig: CardanoHaskellShelleyNetwork,
+): Array<{
   StartAt?: number,
   GenesisDate?: string,
   SlotsPerEpoch?: number,
   SlotDuration?: number,
 }> => [
   {
-    StartAt: CONFIG.NETWORKS.HASKELL_SHELLEY.BASE_CONFIG[0].START_AT,
-    GenesisDate: CONFIG.NETWORKS.HASKELL_SHELLEY.BASE_CONFIG[0].GENESIS_DATE,
-    SlotsPerEpoch:
-      CONFIG.NETWORKS.HASKELL_SHELLEY.BASE_CONFIG[0].SLOTS_PER_EPOCH,
-    SlotDuration: CONFIG.NETWORKS.HASKELL_SHELLEY.BASE_CONFIG[0].SLOT_DURATION,
+    StartAt: networkConfig.BASE_CONFIG[0].START_AT,
+    GenesisDate: networkConfig.BASE_CONFIG[0].GENESIS_DATE,
+    SlotsPerEpoch: networkConfig.BASE_CONFIG[0].SLOTS_PER_EPOCH,
+    SlotDuration: networkConfig.BASE_CONFIG[0].SLOT_DURATION,
   },
   {
-    StartAt: CONFIG.NETWORKS.HASKELL_SHELLEY.BASE_CONFIG[1].START_AT,
-    SlotsPerEpoch:
-      CONFIG.NETWORKS.HASKELL_SHELLEY.BASE_CONFIG[1].SLOTS_PER_EPOCH,
-    SlotDuration: CONFIG.NETWORKS.HASKELL_SHELLEY.BASE_CONFIG[1].SLOT_DURATION,
+    StartAt: networkConfig.BASE_CONFIG[1].START_AT,
+    SlotsPerEpoch: networkConfig.BASE_CONFIG[1].SLOTS_PER_EPOCH,
+    SlotDuration: networkConfig.BASE_CONFIG[1].SLOT_DURATION,
   },
 ]
 

--- a/src/config/networks.js
+++ b/src/config/networks.js
@@ -183,6 +183,10 @@ export const isHaskellShelleyNetwork = (networkId: NetworkId): boolean =>
 
 export const getCardanoByronConfig = () => NETWORKS.BYRON_MAINNET
 
+export type CardanoHaskellShelleyNetwork =
+  | typeof NETWORKS.HASKELL_SHELLEY
+  | typeof NETWORKS.HASKELL_SHELLEY_TESTNET
+
 type NetworkConfig =
   | typeof NETWORKS.BYRON_MAINNET
   | typeof NETWORKS.HASKELL_SHELLEY

--- a/src/config/networks.js
+++ b/src/config/networks.js
@@ -183,10 +183,6 @@ export const isHaskellShelleyNetwork = (networkId: NetworkId): boolean =>
 
 export const getCardanoByronConfig = () => NETWORKS.BYRON_MAINNET
 
-export type CardanoHaskellShelleyNetwork =
-  | typeof NETWORKS.HASKELL_SHELLEY
-  | typeof NETWORKS.HASKELL_SHELLEY_TESTNET
-
 type NetworkConfig =
   | typeof NETWORKS.BYRON_MAINNET
   | typeof NETWORKS.HASKELL_SHELLEY
@@ -199,6 +195,22 @@ export const getNetworkConfigById = (id: NetworkId): NetworkConfig => {
     return NETWORKS[network]
   }
   throw new Error('invalid networkId')
+}
+
+export type CardanoHaskellShelleyNetwork =
+  | typeof NETWORKS.HASKELL_SHELLEY
+  | typeof NETWORKS.HASKELL_SHELLEY_TESTNET
+export const getCardanoNetworkConfigById: (NetworkId) => CardanoHaskellShelleyNetwork = (
+  networkId,
+) => {
+  switch (networkId) {
+    case NETWORKS.HASKELL_SHELLEY.NETWORK_ID:
+      return NETWORKS.HASKELL_SHELLEY
+    case NETWORKS.HASKELL_SHELLEY_TESTNET.NETWORK_ID:
+      return NETWORKS.HASKELL_SHELLEY_TESTNET
+    default:
+      throw new Error('network id is not a valid Haskell Shelley id')
+  }
 }
 
 export const PRIMARY_ASSET_CONSTANTS = {

--- a/src/crypto/Wallet.js
+++ b/src/crypto/Wallet.js
@@ -10,7 +10,7 @@ import KeyStore from './KeyStore'
 import {AddressChain} from './shelley/chain'
 import * as api from '../api/shelley/api'
 import {CONFIG} from '../config/config'
-import {isJormungandr} from '../config/networks'
+import {isJormungandr, getCardanoNetworkConfigById} from '../config/networks'
 import assert from '../utils/assert'
 import {Logger} from '../utils/logging'
 import {
@@ -19,7 +19,6 @@ import {
   IsLockedError,
 } from '../utils/promise'
 import {TransactionCache} from './shelley/transactionCache'
-import {getNetworkConfig} from './shelley/utils'
 import {validatePassword} from '../utils/validators'
 
 import type {EncryptionMethod} from './types'
@@ -215,7 +214,8 @@ export default class Wallet {
   async _doFullSync() {
     Logger.info('Do full sync')
     assert.assert(this.isInitialized, 'doFullSync: isInitialized')
-    const backendConfig = getNetworkConfig(this.networkId).BACKEND
+    // TODO: multi-network support
+    const backendConfig = getCardanoNetworkConfigById(this.networkId).BACKEND
     const filterFn = (addrs) => api.filterUsedAddresses(addrs, backendConfig)
     await Promise.all([
       this.internalChain.sync(filterFn),

--- a/src/crypto/shelley/ShelleyWallet.js
+++ b/src/crypto/shelley/ShelleyWallet.js
@@ -131,12 +131,22 @@ export default class ShelleyWallet extends Wallet implements WalletInterface {
     // initialize address chains
     const _walletConfig = getWalletConfigById(implementationId)
     this.internalChain = new AddressChain(
-      new AddressGenerator(accountPubKeyHex, 'Internal', implementationId),
+      new AddressGenerator(
+        accountPubKeyHex,
+        'Internal',
+        implementationId,
+        networkId,
+      ),
       _walletConfig.DISCOVERY_BLOCK_SIZE,
       _walletConfig.DISCOVERY_GAP_SIZE,
     )
     this.externalChain = new AddressChain(
-      new AddressGenerator(accountPubKeyHex, 'External', implementationId),
+      new AddressGenerator(
+        accountPubKeyHex,
+        'External',
+        implementationId,
+        networkId,
+      ),
       _walletConfig.DISCOVERY_BLOCK_SIZE,
       _walletConfig.DISCOVERY_GAP_SIZE,
     )
@@ -380,7 +390,7 @@ export default class ShelleyWallet extends Wallet implements WalletInterface {
   }
 
   _getBackendConfig(): BackendConfig {
-    return this._getNetworkConfig.BACKEND
+    return this._getNetworkConfig().BACKEND
   }
 
   _getPurpose(): number {

--- a/src/crypto/shelley/chain.js
+++ b/src/crypto/shelley/chain.js
@@ -39,9 +39,8 @@ export class AddressGenerator {
   constructor(
     accountPubKeyHex: string,
     type: AddressType,
-    walletImplementationId: WalletImplementationId = CONFIG.WALLETS
-      .HASKELL_SHELLEY.WALLET_IMPLEMENTATION_ID,
-    networkId: NetworkId = CONFIG.NETWORKS.HASKELL_SHELLEY.NETWORK_ID,
+    walletImplementationId: WalletImplementationId,
+    networkId: NetworkId,
   ) {
     this.accountPubKeyHex = accountPubKeyHex
     this.type = type

--- a/src/crypto/shelley/chain.js
+++ b/src/crypto/shelley/chain.js
@@ -307,8 +307,6 @@ export class AddressChain {
     )
   }
 
-  // TODO: consider removing the filterFn parameter (since it's called from
-  // a generic wallet class). Add filterFn as class member and pass it in constructor?
   async sync(filterFn: AsyncAddressFilter) {
     let keepSyncing = true
     while (keepSyncing) {

--- a/src/crypto/shelley/chain.js
+++ b/src/crypto/shelley/chain.js
@@ -14,6 +14,7 @@ import {
 } from '@emurgo/react-native-haskell-shelley'
 
 import {CONFIG, isByron, isHaskellShelley} from '../../config/config'
+import {getNetworkConfigById} from '../../config/networks'
 import assert from '../../utils/assert'
 import {defaultMemoize} from 'reselect'
 import {Logger} from '../../utils/logging'
@@ -22,7 +23,7 @@ import {ADDRESS_TYPE_TO_CHANGE} from '../commonUtils'
 
 import type {CryptoAccount} from '../byron/util'
 import type {AddressType} from '../commonUtils'
-import type {WalletImplementationId} from '../../config/types'
+import type {WalletImplementationId, NetworkId} from '../../config/types'
 
 export type AddressBlock = [number, Moment, Array<string>]
 
@@ -30,6 +31,7 @@ export class AddressGenerator {
   accountPubKeyHex: string
   type: AddressType
   walletImplementationId: WalletImplementationId
+  networkId: NetworkId
 
   _accountPubKeyPtr: Bip32PublicKey
   _rewardAddressHex: string
@@ -39,10 +41,12 @@ export class AddressGenerator {
     type: AddressType,
     walletImplementationId: WalletImplementationId = CONFIG.WALLETS
       .HASKELL_SHELLEY.WALLET_IMPLEMENTATION_ID,
+    networkId: NetworkId = CONFIG.NETWORKS.HASKELL_SHELLEY.NETWORK_ID,
   ) {
     this.accountPubKeyHex = accountPubKeyHex
     this.type = type
     this.walletImplementationId = walletImplementationId
+    this.networkId = networkId
   }
 
   get byronAccount(): CryptoAccount {
@@ -60,6 +64,11 @@ export class AddressGenerator {
     if (!isHaskellShelley(this.walletImplementationId)) {
       return null
     }
+    let chainNetworkId = CONFIG.NETWORKS.HASKELL_SHELLEY.CHAIN_NETWORK_ID
+    const config = getNetworkConfigById(this.networkId)
+    if (config.CHAIN_NETWORK_ID != null) {
+      chainNetworkId = config.CHAIN_NETWORK_ID
+    }
     if (this._rewardAddressHex != null) return this._rewardAddressHex
     // cache account public key
     if (this._accountPubKeyPtr == null) {
@@ -76,7 +85,7 @@ export class AddressGenerator {
       await stakingKey.hash(),
     )
     const rewardAddr = await RewardAddress.new(
-      parseInt(CONFIG.NETWORKS.HASKELL_SHELLEY.CHAIN_NETWORK_ID, 10),
+      parseInt(chainNetworkId, 10),
       credential,
     )
     const rewardAddrAsAddr = await rewardAddr.to_address()
@@ -89,6 +98,12 @@ export class AddressGenerator {
 
   async generate(idxs: Array<number>): Promise<Array<string>> {
     if (isHaskellShelley(this.walletImplementationId)) {
+      // assume mainnet by default
+      let chainNetworkId = CONFIG.NETWORKS.HASKELL_SHELLEY.CHAIN_NETWORK_ID
+      const config = getNetworkConfigById(this.networkId)
+      if (config.CHAIN_NETWORK_ID != null) {
+        chainNetworkId = config.CHAIN_NETWORK_ID
+      }
       // cache account public key
       if (this._accountPubKeyPtr == null) {
         this._accountPubKeyPtr = await Bip32PublicKey.from_bytes(
@@ -106,7 +121,7 @@ export class AddressGenerator {
         idxs.map(async (idx) => {
           const addrKey = await (await chainKey.derive(idx)).to_raw_key()
           const addr = await BaseAddress.new(
-            parseInt(CONFIG.NETWORKS.HASKELL_SHELLEY.CHAIN_NETWORK_ID, 10),
+            parseInt(chainNetworkId, 10),
             await StakeCredential.from_keyhash(await addrKey.hash()),
             await StakeCredential.from_keyhash(await stakingKey.hash()),
           )
@@ -129,7 +144,7 @@ export class AddressGenerator {
   // note: byron-era wallets (ie. wallets created before the shelley
   // hardfork), stored the account-level publick key as a CryptoAccount object.
   // From v3.0.2 on, we simply store it as a plain hex string)
-  static fromJSON(data: any) {
+  static fromJSON(data: any, networkId: NetworkId) {
     const {accountPubKeyHex, type, walletImplementationId} = data
 
     let _accountPubKeyHex
@@ -158,6 +173,7 @@ export class AddressGenerator {
       _accountPubKeyHex,
       type,
       _walletImplementationId,
+      networkId,
     )
   }
 }
@@ -201,10 +217,10 @@ export class AddressChain {
     }
   }
 
-  static fromJSON(data: any) {
+  static fromJSON(data: any, networkId: NetworkId) {
     const {gapLimit, blockSize, addresses, addressGenerator} = data
     const chain = new AddressChain(
-      AddressGenerator.fromJSON(addressGenerator),
+      AddressGenerator.fromJSON(addressGenerator, networkId),
       blockSize,
       gapLimit,
     )
@@ -292,6 +308,8 @@ export class AddressChain {
     )
   }
 
+  // TODO: consider removing the filterFn parameter (since it's called from
+  // a generic wallet class). Add filterFn as class member and pass it in constructor?
   async sync(filterFn: AsyncAddressFilter) {
     let keepSyncing = true
     while (keepSyncing) {

--- a/src/crypto/shelley/chain.test.js
+++ b/src/crypto/shelley/chain.test.js
@@ -83,6 +83,7 @@ describe('AddressChain', () => {
   })
 
   it('can continue after rehydrating', async () => {
+    const networkId = 1 // haskell shelley mainnet
     const account: CryptoAccount = {
       derivation_scheme: 'V2',
       root_cached_key:
@@ -94,6 +95,7 @@ describe('AddressChain', () => {
         account.root_cached_key,
         'Internal',
         'haskell-byron',
+        networkId,
       ),
       5,
       2,
@@ -104,7 +106,7 @@ describe('AddressChain', () => {
     await chain.initialize()
 
     const data = chain.toJSON()
-    const chain2 = AddressChain.fromJSON(data)
+    const chain2 = AddressChain.fromJSON(data, networkId)
 
     const used = [
       // '2cWKMJemoBaiAKW7iBFgK3prZAK3gAEgkndCUTkGpUAoRofmXJcbmie2qe6JTN44dQ2Ag', // byron testnet

--- a/src/crypto/shelley/plate.js
+++ b/src/crypto/shelley/plate.js
@@ -8,10 +8,12 @@ import {CONFIG} from '../../config/config'
 
 import type {AddressType} from '../commonUtils'
 import type {PlateResponse} from '../types'
+import type {NetworkId} from '../../config/types'
 
 export const generateShelleyPlateFromKey = async (
   key: string,
   count: number,
+  networkId: NetworkId,
   isJormungandr?: boolean = false,
 ): Promise<PlateResponse> => {
   const addrType: AddressType = 'External'
@@ -19,6 +21,7 @@ export const generateShelleyPlateFromKey = async (
     key,
     addrType,
     CONFIG.WALLETS.HASKELL_SHELLEY.WALLET_IMPLEMENTATION_ID,
+    networkId,
   )
   const accountPlate = isJormungandr
     ? legacyWalletChecksum(key)
@@ -30,6 +33,7 @@ export const generateShelleyPlateFromKey = async (
 export const generateShelleyPlateFromMnemonics = async (
   phrase: string,
   count: number,
+  networkId: NetworkId,
   isJormungandr?: boolean = false,
 ): Promise<PlateResponse> => {
   const masterKey = await getMasterKeyFromMnemonic(phrase)
@@ -49,6 +53,7 @@ export const generateShelleyPlateFromMnemonics = async (
   return await generateShelleyPlateFromKey(
     accountPubKeyHex,
     count,
+    networkId,
     isJormungandr,
   )
 }

--- a/src/crypto/shelley/transactionCache.js
+++ b/src/crypto/shelley/transactionCache.js
@@ -7,9 +7,9 @@ import {ObjectValues} from '../../utils/flow'
 import {limitConcurrency} from '../../utils/promise'
 import {Logger} from '../../utils/logging'
 import * as api from '../../api/shelley/api'
-import {getNetworkConfig} from '../../crypto/shelley/utils'
 import {ApiHistoryError} from '../../api/errors'
 import {CONFIG} from '../../config/config'
+import {getCardanoNetworkConfigById} from '../../config/networks'
 import {CERTIFICATE_KIND} from '../../api/types'
 
 import type {Transaction} from '../../types/HistoryTransaction'
@@ -309,7 +309,7 @@ export class TransactionCache {
     let wasPaginated = false
     const errors = []
     const currentBestBlock = await api.getBestBlock(
-      getNetworkConfig(networkId).BACKEND,
+      getCardanoNetworkConfigById(networkId).BACKEND,
     )
 
     const tasks = blocks.map((addrs) => {
@@ -324,7 +324,7 @@ export class TransactionCache {
         api
           .fetchNewTxHistory(
             historyRequest,
-            getNetworkConfig(networkId).BACKEND,
+            getCardanoNetworkConfigById(networkId).BACKEND,
           )
           .then((response) => [addrs, response])
     })

--- a/src/crypto/shelley/transactionUtils.js
+++ b/src/crypto/shelley/transactionUtils.js
@@ -10,12 +10,12 @@ import {HaskellShelleyTxSignRequest} from './HaskellShelleyTxSignRequest'
 import {sendAllUnsignedTx, newAdaUnsignedTx} from './transactions'
 import {hasSendAllDefault, builtSendTokenList} from '../commonUtils'
 import {multiTokenFromRemote} from './utils'
-import {CONFIG} from '../../config/config'
 import {CardanoError, InsufficientFunds, NoOutputsError} from '../errors'
 import {Logger} from '../../utils/logging'
 import assert from '../../utils/assert'
 
 import type {Addressing, AddressedUtxo, SendTokenList} from '../types'
+import type {CardanoHaskellShelleyNetwork} from '../../config/networks'
 import type {DefaultTokenEntry} from '../MultiToken'
 
 export type CreateUnsignedTxRequest = {|
@@ -29,6 +29,7 @@ export type CreateUnsignedTxRequest = {|
   defaultToken: DefaultTokenEntry,
   tokens: SendTokenList,
   metadata: TransactionMetadata | void,
+  networkConfig: CardanoHaskellShelleyNetwork,
 |}
 
 export type CreateUnsignedTxResponse = HaskellShelleyTxSignRequest
@@ -43,16 +44,15 @@ export const createUnsignedTx = async (
     addressedUtxos,
     absSlotNumber,
     metadata,
+    networkConfig,
   } = request
   try {
-    const NETWORK_CONFIG = CONFIG.NETWORKS.HASKELL_SHELLEY
-
-    const KEY_DEPOSIT = NETWORK_CONFIG.KEY_DEPOSIT
-    const POOL_DEPOSIT = NETWORK_CONFIG.POOL_DEPOSIT
-    const LINEAR_FEE = NETWORK_CONFIG.LINEAR_FEE
-    const MINIMUM_UTXO_VAL = NETWORK_CONFIG.MINIMUM_UTXO_VAL
-    const NETWORK_ID = NETWORK_CONFIG.NETWORK_ID
-    const CHAIN_NETWORK_ID = NETWORK_CONFIG.CHAIN_NETWORK_ID
+    const KEY_DEPOSIT = networkConfig.KEY_DEPOSIT
+    const POOL_DEPOSIT = networkConfig.POOL_DEPOSIT
+    const LINEAR_FEE = networkConfig.LINEAR_FEE
+    const MINIMUM_UTXO_VAL = networkConfig.MINIMUM_UTXO_VAL
+    const NETWORK_ID = networkConfig.NETWORK_ID
+    const CHAIN_NETWORK_ID = networkConfig.CHAIN_NETWORK_ID
 
     const protocolParams = {
       keyDeposit: await BigNum.from_str(KEY_DEPOSIT),

--- a/src/crypto/shelley/utils.js
+++ b/src/crypto/shelley/utils.js
@@ -21,30 +21,16 @@ import {
 } from '@emurgo/react-native-haskell-shelley'
 
 import {CONFIG} from '../../config/config'
-import {getNetworkConfigById, NETWORKS} from '../../config/networks'
+import {getNetworkConfigById} from '../../config/networks'
 import {MultiToken} from '../MultiToken'
 
 import type {NetworkId} from '../../config/types'
-import type {CardanoHaskellShelleyNetwork} from '../../config/networks'
 import type {Addressing} from '../types'
 import type {BaseAsset} from '../../types/HistoryTransaction'
 import type {RawUtxo} from '../../api/types'
 import type {DefaultTokenEntry} from '../MultiToken'
 
 const PRIMARY_ASSET_CONSTANTS = CONFIG.PRIMARY_ASSET_CONSTANTS
-
-export const getNetworkConfig: (NetworkId) => CardanoHaskellShelleyNetwork = (
-  networkId,
-) => {
-  switch (networkId) {
-    case NETWORKS.HASKELL_SHELLEY.NETWORK_ID:
-      return NETWORKS.HASKELL_SHELLEY
-    case NETWORKS.HASKELL_SHELLEY_TESTNET.NETWORK_ID:
-      return NETWORKS.HASKELL_SHELLEY_TESTNET
-    default:
-      throw new Error('network id is not a valid Haskell Shelley id')
-  }
-}
 
 export const getCardanoAddrKeyHash = async (
   addr: Address,

--- a/src/crypto/shelley/utils.js
+++ b/src/crypto/shelley/utils.js
@@ -21,14 +21,30 @@ import {
 } from '@emurgo/react-native-haskell-shelley'
 
 import {CONFIG} from '../../config/config'
+import {getNetworkConfigById, NETWORKS} from '../../config/networks'
 import {MultiToken} from '../MultiToken'
 
+import type {NetworkId} from '../../config/types'
+import type {CardanoHaskellShelleyNetwork} from '../../config/networks'
 import type {Addressing} from '../types'
 import type {BaseAsset} from '../../types/HistoryTransaction'
 import type {RawUtxo} from '../../api/types'
 import type {DefaultTokenEntry} from '../MultiToken'
 
 const PRIMARY_ASSET_CONSTANTS = CONFIG.PRIMARY_ASSET_CONSTANTS
+
+export const getNetworkConfig: (NetworkId) => CardanoHaskellShelleyNetwork = (
+  networkId,
+) => {
+  switch (networkId) {
+    case NETWORKS.HASKELL_SHELLEY.NETWORK_ID:
+      return NETWORKS.HASKELL_SHELLEY
+    case NETWORKS.HASKELL_SHELLEY_TESTNET.NETWORK_ID:
+      return NETWORKS.HASKELL_SHELLEY_TESTNET
+    default:
+      throw new Error('network id is not a valid Haskell Shelley id')
+  }
+}
 
 export const getCardanoAddrKeyHash = async (
   addr: Address,
@@ -158,6 +174,7 @@ export const verifyFromBip44Root = (
 
 export const deriveRewardAddressHex = async (
   accountPubKeyHex: string,
+  networkId: NetworkId,
 ): Promise<string> => {
   const accountPubKeyPtr = await Bip32PublicKey.from_bytes(
     Buffer.from(accountPubKeyHex, 'hex'),
@@ -169,8 +186,14 @@ export const deriveRewardAddressHex = async (
 
   const credential = await StakeCredential.from_keyhash(await stakingKey.hash())
 
+  let chainNetworkId = CONFIG.NETWORKS.HASKELL_SHELLEY.CHAIN_NETWORK_ID
+  const config = getNetworkConfigById(networkId)
+  if (config.CHAIN_NETWORK_ID != null) {
+    chainNetworkId = config.CHAIN_NETWORK_ID
+  }
+
   const rewardAddr = await RewardAddress.new(
-    parseInt(CONFIG.NETWORKS.HASKELL_SHELLEY.CHAIN_NETWORK_ID, 10),
+    parseInt(chainNetworkId, 10),
     credential,
   )
   const rewardAddrAsAddr = await rewardAddr.to_address()

--- a/src/utils/parsing.js
+++ b/src/utils/parsing.js
@@ -25,10 +25,7 @@ export class InvalidAssetAmount extends ExtendableError {
 }
 
 // expects an amount in regular currency units (eg ADA, not Lovelace)
-export const parseAmountDecimal = (
-  amount: string,
-  token: ?Token,
-): BigNumber => {
+export const parseAmountDecimal = (amount: string, token: Token): BigNumber => {
   const assetMeta = token ?? getCardanoDefaultAsset()
 
   // note: maxSupply can be null

--- a/src/utils/parsing.test.js
+++ b/src/utils/parsing.test.js
@@ -7,11 +7,14 @@ import {CONFIG, getCardanoDefaultAsset} from '../config/config'
 jestSetup.setup()
 
 describe('parseAdaDecimal', () => {
+  // recall: tests run on mainnet (default network)
+  const defaultAsset = getCardanoDefaultAsset()
+
   it('throw exception on amount equal to 0', () => {
     const zeroValues = ['0', '0.0', '0.000000']
     for (const value of zeroValues) {
       expect(() => {
-        parseAmountDecimal(value)
+        parseAmountDecimal(value, defaultAsset)
       }).toThrow()
     }
   })
@@ -21,7 +24,7 @@ describe('parseAdaDecimal', () => {
       CONFIG.NETWORKS.HASKELL_SHELLEY.MINIMUM_UTXO_VAL,
       10,
     )
-    const numberOfDecimals = getCardanoDefaultAsset().metadata.numberOfDecimals
+    const numberOfDecimals = defaultAsset.metadata.numberOfDecimals
     const values = [
       '0.1',
       `${minUtxoVal / numberOfDecimals - 0.1}`,
@@ -29,7 +32,7 @@ describe('parseAdaDecimal', () => {
     ]
     for (const value of values) {
       expect(() => {
-        parseAmountDecimal(value)
+        parseAmountDecimal(value, defaultAsset)
       }).toThrow(InvalidAssetAmount)
     }
   })
@@ -37,7 +40,7 @@ describe('parseAdaDecimal', () => {
   it('throw exception on ADA amount too big', () => {
     const value = '45 000 000 000 000001'.replace(/ /g, '')
     expect(() => {
-      parseAmountDecimal(value)
+      parseAmountDecimal(value, defaultAsset)
     }).toThrow(InvalidAssetAmount)
   })
 })

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -133,7 +133,7 @@ export const validateAddressAsync = async (
 
 export const validateAmount = (
   value: string,
-  token: ?Token,
+  token: Token,
 ): AmountValidationErrors => {
   if (!value) {
     return {amountIsRequired: true}


### PR DESCRIPTION
This PR allows to create wallets on different networks, within the same build. For now, it's only enabled on nightly builds.

## Background
Prior to this PR there was a "nightly" build variant which used the same .env configuration that production builds. This PR now introduces a specific `.env.nightly` for nightly builds.

Also, before we could only build the app either on testnet or mainnet as the default network, according to the `USE_TESNET` flag in the `.env` file, but many functions already required a network ID, so no significant changes were needed in order to support both mainnet/testnet in the same build.

One must be careful with functions like `getCardanoDefaultAsset()` which don't make much sense when both `ADA` or `TADA` are supported, though they are still needed to work around an issue when the network ID is undefined during some navigation transitions.