### PR TITLE
add flow types for react-navigation

### DIFF
--- a/flow-typed/npm/@react-navigation/bottom-tabs_v5.x.x.js
+++ b/flow-typed/npm/@react-navigation/bottom-tabs_v5.x.x.js
@@ -1,0 +1,2074 @@
+// flow-typed signature: 0e1afa527faab379886b48a48c7993bb
+// flow-typed version: 510a06cce0/@react-navigation/bottom-tabs_v5.x.x/flow_>=v0.104.x
+
+declare module '@react-navigation/bottom-tabs' {
+
+  //---------------------------------------------------------------------------
+  // SECTION 1: IDENTICAL TYPE DEFINITIONS
+  // This section is identical across all React Navigation libdefs and contains
+  // shared definitions. We wish we could make it DRY and import from a shared
+  // definition, but that isn't yet possible.
+  //---------------------------------------------------------------------------
+
+  /**
+   * We start with some definitions that we have copy-pasted from React Native
+   * source files.
+   */
+
+  // This is a bastardization of the true StyleObj type located in
+  // react-native/Libraries/StyleSheet/StyleSheetTypes. We unfortunately can't
+  // import that here, and it's too lengthy (and consequently too brittle) to
+  // copy-paste here either.
+  declare type StyleObj =
+    | null
+    | void
+    | number
+    | false
+    | ''
+    | $ReadOnlyArray<StyleObj>
+    | { [name: string]: any, ... };
+  declare type ViewStyleProp = StyleObj;
+  declare type TextStyleProp = StyleObj;
+  declare type AnimatedViewStyleProp = StyleObj;
+  declare type AnimatedTextStyleProp = StyleObj;
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/animations/Animation.js
+  declare type EndResult = { finished: boolean, ... };
+  declare type EndCallback = (result: EndResult) => void;
+  declare interface Animation {
+    start(
+      fromValue: number,
+      onUpdate: (value: number) => void,
+      onEnd: ?EndCallback,
+      previousAnimation: ?Animation,
+      animatedValue: AnimatedValue,
+    ): void;
+    stop(): void;
+  }
+  declare type AnimationConfig = {
+    isInteraction?: boolean,
+    useNativeDriver: boolean,
+    onComplete?: ?EndCallback,
+    iterations?: number,
+    ...
+  };
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedTracking.js
+  declare interface AnimatedTracking {
+    constructor(
+      value: AnimatedValue,
+      parent: any,
+      animationClass: any,
+      animationConfig: Object,
+      callback?: ?EndCallback,
+    ): void;
+    update(): void;
+  }
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedValue.js
+  declare type ValueListenerCallback = (state: { value: number, ... }) => void;
+  declare interface AnimatedValue {
+    constructor(value: number): void;
+    setValue(value: number): void;
+    setOffset(offset: number): void;
+    flattenOffset(): void;
+    extractOffset(): void;
+    addListener(callback: ValueListenerCallback): string;
+    removeListener(id: string): void;
+    removeAllListeners(): void;
+    stopAnimation(callback?: ?(value: number) => void): void;
+    resetAnimation(callback?: ?(value: number) => void): void;
+    interpolate(config: InterpolationConfigType): AnimatedInterpolation;
+    animate(animation: Animation, callback: ?EndCallback): void;
+    stopTracking(): void;
+    track(tracking: AnimatedTracking): void;
+  }
+
+  // Copied from
+  // react-native/Libraries/Animated/src/animations/TimingAnimation.js
+  declare type TimingAnimationConfigSingle = AnimationConfig & {
+    toValue: number | AnimatedValue,
+    easing?: (value: number) => number,
+    duration?: number,
+    delay?: number,
+    ...
+  };
+
+  // Copied from
+  // react-native/Libraries/Animated/src/animations/SpringAnimation.js
+  declare type SpringAnimationConfigSingle = AnimationConfig & {
+    toValue: number | AnimatedValue,
+    overshootClamping?: boolean,
+    restDisplacementThreshold?: number,
+    restSpeedThreshold?: number,
+    velocity?: number,
+    bounciness?: number,
+    speed?: number,
+    tension?: number,
+    friction?: number,
+    stiffness?: number,
+    damping?: number,
+    mass?: number,
+    delay?: number,
+    ...
+  };
+
+  // Copied from react-native/Libraries/Types/CoreEventTypes.js
+  declare type SyntheticEvent<T> = $ReadOnly<{|
+    bubbles: ?boolean,
+    cancelable: ?boolean,
+    currentTarget: number,
+    defaultPrevented: ?boolean,
+    dispatchConfig: $ReadOnly<{|
+      registrationName: string,
+    |}>,
+    eventPhase: ?number,
+    preventDefault: () => void,
+    isDefaultPrevented: () => boolean,
+    stopPropagation: () => void,
+    isPropagationStopped: () => boolean,
+    isTrusted: ?boolean,
+    nativeEvent: T,
+    persist: () => void,
+    target: ?number,
+    timeStamp: number,
+    type: ?string,
+  |}>;
+  declare type Layout = $ReadOnly<{|
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+  |}>;
+  declare type LayoutEvent = SyntheticEvent<
+    $ReadOnly<{|
+      layout: Layout,
+    |}>,
+  >;
+  declare type BlurEvent = SyntheticEvent<
+    $ReadOnly<{|
+      target: number,
+    |}>,
+  >;
+  declare type FocusEvent = SyntheticEvent<
+    $ReadOnly<{|
+      target: number,
+    |}>,
+  >;
+  declare type ResponderSyntheticEvent<T> = $ReadOnly<{|
+    ...SyntheticEvent<T>,
+    touchHistory: $ReadOnly<{|
+      indexOfSingleActiveTouch: number,
+      mostRecentTimeStamp: number,
+      numberActiveTouches: number,
+      touchBank: $ReadOnlyArray<
+        $ReadOnly<{|
+          touchActive: boolean,
+          startPageX: number,
+          startPageY: number,
+          startTimeStamp: number,
+          currentPageX: number,
+          currentPageY: number,
+          currentTimeStamp: number,
+          previousPageX: number,
+          previousPageY: number,
+          previousTimeStamp: number,
+        |}>,
+      >,
+    |}>,
+  |}>;
+  declare type PressEvent = ResponderSyntheticEvent<
+    $ReadOnly<{|
+      changedTouches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
+      force: number,
+      identifier: number,
+      locationX: number,
+      locationY: number,
+      pageX: number,
+      pageY: number,
+      target: ?number,
+      timestamp: number,
+      touches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
+    |}>,
+  >;
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedInterpolation.js
+  declare type ExtrapolateType = 'extend' | 'identity' | 'clamp';
+  declare type InterpolationConfigType = {
+    inputRange: Array<number>,
+    outputRange: Array<number> | Array<string>,
+    easing?: (input: number) => number,
+    extrapolate?: ExtrapolateType,
+    extrapolateLeft?: ExtrapolateType,
+    extrapolateRight?: ExtrapolateType,
+    ...
+  };
+  declare interface AnimatedInterpolation {
+    interpolate(config: InterpolationConfigType): AnimatedInterpolation;
+  }
+
+  // Copied from react-native/Libraries/Components/View/ViewAccessibility.js
+  declare type AccessibilityRole =
+    | 'none'
+    | 'button'
+    | 'link'
+    | 'search'
+    | 'image'
+    | 'keyboardkey'
+    | 'text'
+    | 'adjustable'
+    | 'imagebutton'
+    | 'header'
+    | 'summary'
+    | 'alert'
+    | 'checkbox'
+    | 'combobox'
+    | 'menu'
+    | 'menubar'
+    | 'menuitem'
+    | 'progressbar'
+    | 'radio'
+    | 'radiogroup'
+    | 'scrollbar'
+    | 'spinbutton'
+    | 'switch'
+    | 'tab'
+    | 'tablist'
+    | 'timer'
+    | 'toolbar';
+  declare type AccessibilityActionInfo = $ReadOnly<{
+    name: string,
+    label?: string,
+    ...
+  }>;
+  declare type AccessibilityActionEvent = SyntheticEvent<
+    $ReadOnly<{actionName: string, ...}>,
+  >;
+  declare type AccessibilityState = {
+    disabled?: boolean,
+    selected?: boolean,
+    checked?: ?boolean | 'mixed',
+    busy?: boolean,
+    expanded?: boolean,
+    ...
+  };
+  declare type AccessibilityValue = $ReadOnly<{|
+    min?: number,
+    max?: number,
+    now?: number,
+    text?: string,
+  |}>;
+
+  // Copied from
+  // react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+  declare type Stringish = string;
+  declare type EdgeInsetsProp = $ReadOnly<$Partial<EdgeInsets>>;
+  declare type TouchableWithoutFeedbackProps = $ReadOnly<{|
+    accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
+    accessibilityElementsHidden?: ?boolean,
+    accessibilityHint?: ?Stringish,
+    accessibilityIgnoresInvertColors?: ?boolean,
+    accessibilityLabel?: ?Stringish,
+    accessibilityLiveRegion?: ?('none' | 'polite' | 'assertive'),
+    accessibilityRole?: ?AccessibilityRole,
+    accessibilityState?: ?AccessibilityState,
+    accessibilityValue?: ?AccessibilityValue,
+    accessibilityViewIsModal?: ?boolean,
+    accessible?: ?boolean,
+    children?: ?React$Node,
+    delayLongPress?: ?number,
+    delayPressIn?: ?number,
+    delayPressOut?: ?number,
+    disabled?: ?boolean,
+    focusable?: ?boolean,
+    hitSlop?: ?EdgeInsetsProp,
+    importantForAccessibility?: ?('auto' | 'yes' | 'no' | 'no-hide-descendants'),
+    nativeID?: ?string,
+    onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
+    onBlur?: ?(event: BlurEvent) => mixed,
+    onFocus?: ?(event: FocusEvent) => mixed,
+    onLayout?: ?(event: LayoutEvent) => mixed,
+    onLongPress?: ?(event: PressEvent) => mixed,
+    onPress?: ?(event: PressEvent) => mixed,
+    onPressIn?: ?(event: PressEvent) => mixed,
+    onPressOut?: ?(event: PressEvent) => mixed,
+    pressRetentionOffset?: ?EdgeInsetsProp,
+    rejectResponderTermination?: ?boolean,
+    testID?: ?string,
+    touchSoundDisabled?: ?boolean,
+  |}>;
+
+  // Copied from react-native/Libraries/Image/ImageSource.js
+  declare type ImageURISource = $ReadOnly<{
+    uri?: ?string,
+    bundle?: ?string,
+    method?: ?string,
+    headers?: ?Object,
+    body?: ?string,
+    cache?: ?('default' | 'reload' | 'force-cache' | 'only-if-cached'),
+    width?: ?number,
+    height?: ?number,
+    scale?: ?number,
+    ...
+  }>;
+
+  /**
+   * The following is copied from react-native-gesture-handler's libdef
+   */
+
+  declare type $EventHandlers<ExtraProps: {...}> = {|
+    onGestureEvent?: ($Event<ExtraProps>) => mixed,
+    onHandlerStateChange?: ($Event<ExtraProps>) => mixed,
+    onBegan?: ($Event<ExtraProps>) => mixed,
+    onFailed?: ($Event<ExtraProps>) => mixed,
+    onCancelled?: ($Event<ExtraProps>) => mixed,
+    onActivated?: ($Event<ExtraProps>) => mixed,
+    onEnded?: ($Event<ExtraProps>) => mixed,
+  |};
+
+  declare type HitSlop =
+    | number
+    | {|
+        left?: number,
+        top?: number,
+        right?: number,
+        bottom?: number,
+        vertical?: number,
+        horizontal?: number,
+        width?: number,
+        height?: number,
+      |}
+    | {|
+        width: number,
+        left: number,
+      |}
+    | {|
+        width: number,
+        right: number,
+      |}
+    | {|
+        height: number,
+        top: number,
+      |}
+    | {|
+        height: number,
+        bottom: number,
+      |};
+
+  declare type $GestureHandlerProps<
+    AdditionalProps: {...},
+    ExtraEventsProps: {...}
+  > = $ReadOnly<{|
+    ...$Exact<AdditionalProps>,
+    ...$EventHandlers<ExtraEventsProps>,
+    id?: string,
+    enabled?: boolean,
+    waitFor?: React$Ref<any> | Array<React$Ref<any>>,
+    simultaneousHandlers?: React$Ref<any> | Array<React$Ref<any>>,
+    shouldCancelWhenOutside?: boolean,
+    minPointers?: number,
+    hitSlop?: HitSlop,
+    children?: React$Node,
+  |}>;
+
+  declare type PanGestureHandlerProps = $GestureHandlerProps<
+    {
+      activeOffsetY?: number | [number, number],
+      activeOffsetX?: number | [number, number],
+      failOffsetY?: number | [number, number],
+      failOffsetX?: number | [number, number],
+      minDist?: number,
+      minVelocity?: number,
+      minVelocityX?: number,
+      minVelocityY?: number,
+      minPointers?: number,
+      maxPointers?: number,
+      avgTouches?: boolean,
+      ...
+    },
+    {
+      x: number,
+      y: number,
+      absoluteX: number,
+      absoluteY: number,
+      translationX: number,
+      translationY: number,
+      velocityX: number,
+      velocityY: number,
+      ...
+    }
+  >;
+
+  /**
+   * MAGIC
+   */
+
+  declare type $If<Test: boolean, Then, Else = empty> = $Call<
+    ((true, Then, Else) => Then) & ((false, Then, Else) => Else),
+    Test,
+    Then,
+    Else,
+  >;
+  declare type $IsA<X, Y> = $Call<
+    (Y => true) & (mixed => false),
+    X,
+  >;
+  declare type $IsUndefined<X> = $IsA<X, void>;
+
+  declare type $Partial<T> = $ReadOnly<$Rest<T, {...}>>;
+
+  /**
+   * Actions, state, etc.
+   */
+
+  declare export type ScreenParams = { +[key: string]: mixed, ... };
+
+  declare export type BackAction = {|
+    +type: 'GO_BACK',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type NavigateAction = {|
+    +type: 'NAVIGATE',
+    +payload:
+      | {| +key: string, +params?: ScreenParams |}
+      | {| +name: string, +key?: string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type ResetAction = {|
+    +type: 'RESET',
+    +payload: StaleNavigationState,
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type SetParamsAction = {|
+    +type: 'SET_PARAMS',
+    +payload: {| +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type CommonAction =
+    | BackAction
+    | NavigateAction
+    | ResetAction
+    | SetParamsAction;
+
+  declare type NavigateActionCreator = {|
+    (routeName: string, params?: ScreenParams): NavigateAction,
+    (
+      | {| +key: string, +params?: ScreenParams |}
+      | {| +name: string, +key?: string, +params?: ScreenParams |},
+    ): NavigateAction,
+  |};
+  declare export type CommonActionsType = {|
+    +navigate: NavigateActionCreator,
+    +goBack: () => BackAction,
+    +reset: (state: PossiblyStaleNavigationState) => ResetAction,
+    +setParams: (params: ScreenParams) => SetParamsAction,
+  |};
+
+  declare export type GenericNavigationAction = {|
+    +type: string,
+    +payload?: { +[key: string]: mixed, ... },
+    +source?: string,
+    +target?: string,
+  |};
+
+  declare export type LeafRoute<RouteName: string = string> = {|
+    +key: string,
+    +name: RouteName,
+    +params?: ScreenParams,
+  |};
+  declare export type StateRoute<RouteName: string = string> = {|
+    ...LeafRoute<RouteName>,
+    +state: NavigationState | StaleNavigationState,
+  |};
+  declare export type Route<RouteName: string = string> =
+    | LeafRoute<RouteName>
+    | StateRoute<RouteName>;
+
+  declare export type NavigationState = {|
+    +key: string,
+    +index: number,
+    +routeNames: $ReadOnlyArray<string>,
+    +history?: $ReadOnlyArray<mixed>,
+    +routes: $ReadOnlyArray<Route<>>,
+    +type: string,
+    +stale: false,
+  |};
+
+  declare export type StaleLeafRoute<RouteName: string = string> = {|
+    +key?: string,
+    +name: RouteName,
+    +params?: ScreenParams,
+  |};
+  declare export type StaleStateRoute<RouteName: string = string> = {|
+    ...StaleLeafRoute<RouteName>,
+    +state: StaleNavigationState,
+  |};
+  declare export type StaleRoute<RouteName: string = string> =
+    | StaleLeafRoute<RouteName>
+    | StaleStateRoute<RouteName>;
+  declare export type StaleNavigationState = {|
+    // It's possible to pass React Nav a StaleNavigationState with an undefined
+    // index, but React Nav will always return one with the index set. This is
+    // the same as for the type property below, but in the case of index we tend
+    // to rely on it being set more...
+    +index: number,
+    +history?: $ReadOnlyArray<mixed>,
+    +routes: $ReadOnlyArray<StaleRoute<>>,
+    +type?: string,
+    +stale?: true,
+  |};
+
+  declare export type PossiblyStaleNavigationState =
+    | NavigationState
+    | StaleNavigationState;
+  declare export type PossiblyStaleRoute<RouteName: string = string> =
+    | Route<RouteName>
+    | StaleRoute<RouteName>;
+
+  /**
+   * Routers
+   */
+
+  declare type ActionCreators<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+  > = {
+    +[key: string]: (...args: any) => (Action | State => Action),
+    ...
+  };
+
+  declare export type DefaultRouterOptions = {
+    +initialRouteName?: string,
+    ...
+  };
+
+  declare export type RouterFactory<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+    RouterOptions: DefaultRouterOptions,
+  > = (options: RouterOptions) => Router<State, Action>;
+
+  declare export type ParamListBase = { +[key: string]: ?ScreenParams, ... };
+
+  declare export type RouterConfigOptions = {|
+    +routeNames: $ReadOnlyArray<string>,
+    +routeParamList: ParamListBase,
+  |};
+
+  declare export type Router<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+  > = {|
+    +type: $PropertyType<State, 'type'>,
+    +getInitialState: (options: RouterConfigOptions) => State,
+    +getRehydratedState: (
+      partialState: PossibleStaleNavigationState,
+      options: RouterConfigOptions,
+    ) => State,
+    +getStateForRouteNamesChange: (
+      state: State,
+      options: RouterConfigOptions,
+    ) => State,
+    +getStateForRouteFocus: (state: State, key: string) => State,
+    +getStateForAction: (
+      state: State,
+      action: Action,
+      options: RouterConfigOptions,
+    ) => ?PossiblyStaleNavigationState;
+    +shouldActionChangeFocus: (action: GenericNavigationAction) => boolean,
+    +actionCreators?: ActionCreators<State, Action>,
+  |};
+
+  /**
+   * Stack actions and router
+   */
+
+  declare export type StackNavigationState = {|
+    ...NavigationState,
+    +type: 'stack',
+  |};
+
+  declare export type ReplaceAction = {|
+    +type: 'REPLACE',
+    +payload: {| +name: string, +key?: ?string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PushAction = {|
+    +type: 'PUSH',
+    +payload: {| +name: string, +key?: ?string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PopAction = {|
+    +type: 'POP',
+    +payload: {| +count: number |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PopToTopAction = {|
+    +type: 'POP_TO_TOP',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type StackAction =
+    | CommonAction
+    | ReplaceAction
+    | PushAction
+    | PopAction
+    | PopToTopAction;
+
+  declare export type StackActionsType = {|
+    +replace: (routeName: string, params?: ScreenParams) => ReplaceAction,
+    +push: (routeName: string, params?: ScreenParams) => PushAction,
+    +pop: (count?: number) => PopAction,
+    +popToTop: () => PopToTopAction,
+  |};
+
+  declare export type StackRouterOptions = $Exact<DefaultRouterOptions>;
+
+  /**
+   * Tab actions and router
+   */
+
+  declare export type TabNavigationState = {|
+    ...NavigationState,
+    +type: 'tab',
+    +history: $ReadOnlyArray<{| type: 'route', key: string |}>,
+  |};
+
+  declare export type JumpToAction = {|
+    +type: 'JUMP_TO',
+    +payload: {| +name: string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type TabAction =
+    | CommonAction
+    | JumpToAction;
+
+  declare export type TabActionsType = {|
+    +jumpTo: string => JumpToAction,
+  |};
+
+  declare export type TabRouterOptions = {|
+    ...$Exact<DefaultRouterOptions>,
+    +backBehavior?: 'initialRoute' | 'order' | 'history' | 'none',
+  |};
+
+  /**
+   * Drawer actions and router
+   */
+
+  declare type DrawerHistoryEntry =
+    | {| +type: 'route', +key: string |}
+    | {| +type: 'drawer' |};
+  declare export type DrawerNavigationState = {|
+    ...NavigationState,
+    +type: 'drawer',
+    +history: $ReadOnlyArray<DrawerHistoryEntry>,
+  |};
+
+  declare export type OpenDrawerAction = {|
+    +type: 'OPEN_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type CloseDrawerAction = {|
+    +type: 'CLOSE_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type ToggleDrawerAction = {|
+    +type: 'TOGGLE_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type DrawerAction =
+    | TabAction
+    | OpenDrawerAction
+    | CloseDrawerAction
+    | ToggleDrawerAction;
+
+  declare export type DrawerActionsType = {|
+    ...TabActionsType,
+    +openDrawer: () => OpenDrawerAction,
+    +closeDrawer: () => CloseDrawerAction,
+    +toggleDrawer: () => ToggleDrawerAction,
+  |};
+
+  declare export type DrawerRouterOptions = {|
+    ...TabRouterOptions,
+    +openByDefault?: boolean,
+  |};
+
+  /**
+   * Events
+   */
+
+  declare export type EventMapBase = {
+    +[name: string]: {|
+      +data?: mixed,
+      +canPreventDefault?: boolean,
+    |},
+    ...
+  };
+  declare type EventPreventDefaultProperties<Test: boolean> = $If<
+    Test,
+    {| +defaultPrevented: boolean, +preventDefault: () => void |},
+    {| |},
+  >;
+  declare type EventDataProperties<Data> = $If<
+    $IsUndefined<Data>,
+    {| |},
+    {| +data: Data |},
+  >;
+  declare type EventArg<
+    EventName: string,
+    CanPreventDefault: ?boolean = false,
+    Data = void,
+  > = {|
+    ...EventPreventDefaultProperties<CanPreventDefault>,
+    ...EventDataProperties<Data>,
+    +type: EventName,
+    +target?: string,
+  |};
+  declare type GlobalEventMap<State: PossiblyStaleNavigationState> = {|
+    +state: {| +data: {| +state: State |}, +canPreventDefault: false |},
+  |};
+  declare type EventMapCore<State: PossiblyStaleNavigationState> = {|
+    ...GlobalEventMap<State>,
+    +focus: {| +data: void, +canPreventDefault: false |},
+    +blur: {| +data: void, +canPreventDefault: false |},
+    +beforeRemove: {|
+      +data: {| +action: GenericNavigationAction |},
+      +canPreventDefault: true,
+    |},
+  |};
+  declare type EventListenerCallback<
+    EventName: string,
+    State: PossiblyStaleNavigationState = NavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = (e: EventArg<
+    EventName,
+    $PropertyType<
+      $ElementType<
+        {| ...EventMap, ...EventMapCore<State> |},
+        EventName,
+      >,
+      'canPreventDefault',
+    >,
+    $PropertyType<
+      $ElementType<
+        {| ...EventMap, ...EventMapCore<State> |},
+        EventName,
+      >,
+      'data',
+    >,
+  >) => mixed;
+
+  /**
+   * Navigation prop
+   */
+
+  declare export type SimpleNavigate<ParamList> =
+    <DestinationRouteName: $Keys<ParamList>>(
+      routeName: DestinationRouteName,
+      params: $ElementType<ParamList, DestinationRouteName>,
+    ) => void;
+
+  declare export type Navigate<ParamList> =
+    & SimpleNavigate<ParamList>
+    & <DestinationRouteName: $Keys<ParamList>>(
+        route:
+          | {|
+              key: string,
+              params?: $ElementType<ParamList, DestinationRouteName>,
+            |}
+          | {|
+              name: DestinationRouteName,
+              key?: string,
+              params?: $ElementType<ParamList, DestinationRouteName>,
+            |},
+      ) => void;
+
+  declare type NavigationHelpers<
+    ParamList: ParamListBase,
+    State: PossiblyStaleNavigationState = PossiblyStaleNavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {
+    +navigate: Navigate<ParamList>,
+    +dispatch: (
+      action:
+        | GenericNavigationAction
+        | (State => GenericNavigationAction),
+    ) => void,
+    +reset: PossiblyStaleNavigationState => void,
+    +goBack: () => void,
+    +isFocused: () => boolean,
+    +canGoBack: () => boolean,
+    +dangerouslyGetParent: <Parent: NavigationProp<ParamListBase>>() => ?Parent,
+    +dangerouslyGetState: () => NavigationState,
+    +addListener: <EventName: $Keys<
+      {| ...EventMap, ...EventMapCore<State> |},
+    >>(
+      name: EventName,
+      callback: EventListenerCallback<EventName, State, EventMap>,
+    ) => () => void,
+    +removeListener: <EventName: $Keys<
+      {| ...EventMap, ...EventMapCore<State> |},
+    >>(
+      name: EventName,
+      callback: EventListenerCallback<EventName, State, EventMap>,
+    ) => void,
+    ...
+  };
+
+  declare export type NavigationProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: PossiblyStaleNavigationState = PossiblyStaleNavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {
+    ...$Exact<NavigationHelpers<
+      ParamList,
+      State,
+      EventMap,
+    >>,
+    +setOptions: (options: $Partial<ScreenOptions>) => void,
+    +setParams: (
+      params: $If<
+        $IsUndefined<$ElementType<ParamList, RouteName>>,
+        empty,
+        $Partial<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
+      >,
+    ) => void,
+    ...
+  };
+
+  /**
+   * CreateNavigator
+   */
+
+  declare export type RouteProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList>,
+  > = {|
+    ...LeafRoute<RouteName>,
+    +params: $ElementType<ParamList, RouteName>,
+  |};
+
+  declare export type ScreenListeners<
+    EventMap: EventMapBase = EventMapCore<State>,
+    State: NavigationState = NavigationState,
+  > = $ObjMapi<
+    {| [name: $Keys<EventMap>]: empty |},
+    <K: $Keys<EventMap>>(K, empty) => EventListenerCallback<K, State, EventMap>,
+  >;
+
+  declare type BaseScreenProps<
+    ParamList: ParamListBase,
+    NavProp,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {|
+    +name: RouteName,
+    +options?:
+      | ScreenOptions
+      | ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => ScreenOptions,
+    +listeners?:
+      | ScreenListeners<EventMap, State>
+      | ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => ScreenListeners<EventMap, State>,
+    +initialParams?: $Partial<$ElementType<ParamList, RouteName>>,
+  |};
+
+  declare export type ScreenProps<
+    ParamList: ParamListBase,
+    NavProp,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > =
+    | {|
+        ...BaseScreenProps<
+          ParamList,
+          NavProp,
+          RouteName,
+          State,
+          ScreenOptions,
+          EventMap,
+        >,
+        +component: React$ComponentType<{|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}>,
+      |}
+    | {|
+        ...BaseScreenProps<
+          ParamList,
+          NavProp,
+          RouteName,
+          State,
+          ScreenOptions,
+          EventMap,
+        >,
+        +children: ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => React$Node,
+      |};
+
+  declare export type ScreenComponent<
+    GlobalParamList: ParamListBase,
+    ParamList: ParamListBase,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = <
+    RouteName: $Keys<ParamList>,
+    NavProp: NavigationProp<
+      GlobalParamList,
+      RouteName,
+      State,
+      ScreenOptions,
+      EventMap,
+    >,
+  >(props: ScreenProps<
+    ParamList,
+    NavProp,
+    RouteName,
+    State,
+    ScreenOptions,
+    EventMap,
+  >) => React$Node;
+
+  declare type ScreenOptionsProp<ScreenOptions: {...}, NavProp> = {|
+    +screenOptions?:
+      | ScreenOptions
+      | ({| route: LeafRoute<>, navigation: NavProp |}) => ScreenOptions,
+  |};
+  declare export type ExtraNavigatorPropsBase = {
+    ...$Exact<DefaultRouterOptions>,
+    +children?: React$Node,
+    ...
+  };
+  declare export type NavigatorPropsBase<ScreenOptions: {...}, NavProp> = {
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    ...
+  };
+
+  declare export type CreateNavigator<
+    State: NavigationState,
+    ScreenOptions: {...},
+    EventMap: EventMapBase,
+    ExtraNavigatorProps: ExtraNavigatorPropsBase,
+  > = <
+    GlobalParamList: ParamListBase,
+    ParamList: ParamListBase,
+    NavProp: NavigationHelpers<
+      GlobalParamList,
+      State,
+      EventMap,
+    >,
+  >() => {|
+    +Screen: ScreenComponent<
+      GlobalParamList,
+      ParamList,
+      State,
+      ScreenOptions,
+      EventMap,
+    >,
+    +Navigator: React$ComponentType<{|
+      ...$Exact<ExtraNavigatorProps>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    |}>,
+  |};
+
+  declare export type CreateNavigatorFactory = <
+    State: NavigationState,
+    ScreenOptions: {...},
+    EventMap: EventMapBase,
+    NavProp: NavigationHelpers<
+      ParamListBase,
+      State,
+      EventMap,
+    >,
+    ExtraNavigatorProps: ExtraNavigatorPropsBase,
+  >(
+    navigator: React$ComponentType<{|
+      ...$Exact<ExtraNavigatorPropsBase>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    |}>,
+  ) => CreateNavigator<State, ScreenOptions, EventMap, ExtraNavigatorProps>;
+
+  /**
+   * useNavigationBuilder
+   */
+
+  declare export type Descriptor<
+    NavProp,
+    ScreenOptions: {...} = {...},
+  > = {|
+    +render: () => React$Node,
+    +options: $ReadOnly<ScreenOptions>,
+    +navigation: NavProp,
+  |};
+
+  declare export type UseNavigationBuilder = <
+    State: NavigationState,
+    Action: GenericNavigationAction,
+    ScreenOptions: {...},
+    RouterOptions: DefaultRouterOptions,
+    NavProp,
+  >(
+    routerFactory: RouterFactory<State, Action, RouterOptions>,
+    options: {|
+      ...$Exact<RouterOptions>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+      +children?: React$Node,
+    |},
+  ) => {|
+    +state: State,
+    +descriptors: {| +[key: string]: Descriptor<NavProp, ScreenOptions> |},
+    +navigation: NavProp,
+  |};
+
+  /**
+   * EdgeInsets
+   */
+
+  declare type EdgeInsets = {|
+    +top: number,
+    +right: number,
+    +bottom: number,
+    +left: number,
+  |};
+
+  /**
+   * TransitionPreset
+   */
+
+  declare export type TransitionSpec =
+    | {|
+        animation: 'spring',
+        config: $Diff<
+          SpringAnimationConfigSingle,
+          { toValue: number | AnimatedValue, ... },
+        >,
+      |}
+    | {|
+        animation: 'timing',
+        config: $Diff<
+          TimingAnimationConfigSingle,
+          { toValue: number | AnimatedValue, ... },
+        >,
+      |};
+
+  declare export type StackCardInterpolationProps = {|
+    +current: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +next?: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +index: number,
+    +closing: AnimatedInterpolation,
+    +swiping: AnimatedInterpolation,
+    +inverted: AnimatedInterpolation,
+    +layouts: {|
+      +screen: {| +width: number, +height: number |},
+    |},
+    +insets: EdgeInsets,
+  |};
+  declare export type StackCardInterpolatedStyle = {|
+    containerStyle?: AnimatedViewStyleProp,
+    cardStyle?: AnimatedViewStyleProp,
+    overlayStyle?: AnimatedViewStyleProp,
+    shadowStyle?: AnimatedViewStyleProp,
+  |};
+  declare export type StackCardStyleInterpolator = (
+    props: StackCardInterpolationProps,
+  ) => StackCardInterpolatedStyle;
+
+  declare export type StackHeaderInterpolationProps = {|
+    +current: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +next?: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +layouts: {|
+      +header: {| +width: number, +height: number |},
+      +screen: {| +width: number, +height: number |},
+      +title?: {| +width: number, +height: number |},
+      +leftLabel?: {| +width: number, +height: number |},
+    |},
+  |};
+  declare export type StackHeaderInterpolatedStyle = {|
+    leftLabelStyle?: AnimatedViewStyleProp,
+    leftButtonStyle?: AnimatedViewStyleProp,
+    rightButtonStyle?: AnimatedViewStyleProp,
+    titleStyle?: AnimatedViewStyleProp,
+    backgroundStyle?: AnimatedViewStyleProp,
+  |};
+  declare export type StackHeaderStyleInterpolator = (
+    props: StackHeaderInterpolationProps,
+  ) => StackHeaderInterpolatedStyle;
+
+  declare type GestureDirection =
+    | 'horizontal'
+    | 'horizontal-inverted'
+    | 'vertical'
+    | 'vertical-inverted';
+
+  declare export type TransitionPreset = {|
+    +gestureDirection: GestureDirection,
+    +transitionSpec: {|
+      +open: TransitionSpec,
+      +close: TransitionSpec,
+    |},
+    +cardStyleInterpolator: StackCardStyleInterpolator,
+    +headerStyleInterpolator: StackHeaderStyleInterpolator,
+  |};
+
+  /**
+   * Stack options
+   */
+
+  declare export type StackDescriptor = Descriptor<
+    StackNavigationProp<>,
+    StackOptions,
+  >;
+
+  declare type Scene<T> = {|
+    +route: T,
+    +descriptor: StackDescriptor,
+    +progress: {|
+      +current: AnimatedInterpolation,
+      +next?: AnimatedInterpolation,
+      +previous?: AnimatedInterpolation,
+    |},
+  |};
+
+  declare export type StackHeaderProps = {|
+    +mode: 'float' | 'screen',
+    +layout: {| +width: number, +height: number |},
+    +insets: EdgeInsets,
+    +scene: Scene<Route<>>,
+    +previous?: Scene<Route<>>,
+    +navigation: StackNavigationProp<ParamListBase>,
+    +styleInterpolator: StackHeaderStyleInterpolator,
+  |};
+
+  declare export type StackHeaderLeftButtonProps = $Partial<{|
+    +onPress: (() => void),
+    +pressColorAndroid: string;
+    +backImage: (props: {| tintColor: string |}) => React$Node,
+    +tintColor: string,
+    +label: string,
+    +truncatedLabel: string,
+    +labelVisible: boolean,
+    +labelStyle: AnimatedTextStyleProp,
+    +allowFontScaling: boolean,
+    +onLabelLayout: LayoutEvent => void,
+    +screenLayout: {| +width: number, +height: number |},
+    +titleLayout: {| +width: number, +height: number |},
+    +canGoBack: boolean,
+  |}>;
+
+  declare type StackHeaderTitleInputBase = {
+    +onLayout: LayoutEvent => void,
+    +children: string,
+    +allowFontScaling: ?boolean,
+    +tintColor: ?string,
+    +style: ?AnimatedTextStyleProp,
+    ...
+  };
+
+  declare export type StackHeaderTitleInputProps =
+    $Exact<StackHeaderTitleInputBase>;
+
+  declare export type StackOptions = $Partial<{|
+    +title: string,
+    +header: StackHeaderProps => React$Node,
+    +headerShown: boolean,
+    +cardShadowEnabled: boolean,
+    +cardOverlayEnabled: boolean,
+    +cardOverlay: {| style: ViewStyleProp |} => React$Node,
+    +cardStyle: ViewStyleProp,
+    +animationEnabled: boolean,
+    +animationTypeForReplace: 'push' | 'pop',
+    +gestureEnabled: boolean,
+    +gestureResponseDistance: {| vertical?: number, horizontal?: number |},
+    +gestureVelocityImpact: number,
+    +safeAreaInsets: $Partial<EdgeInsets>,
+    // Transition
+    ...TransitionPreset,
+    // Header
+    +headerTitle: string | (StackHeaderTitleInputProps => React$Node),
+    +headerTitleAlign: 'left' | 'center',
+    +headerTitleStyle: AnimatedTextStyleProp,
+    +headerTitleContainerStyle: ViewStyleProp,
+    +headerTintColor: string,
+    +headerTitleAllowFontScaling: boolean,
+    +headerBackAllowFontScaling: boolean,
+    +headerBackTitle: string | null,
+    +headerBackTitleStyle: TextStyleProp,
+    +headerBackTitleVisible: boolean,
+    +headerTruncatedBackTitle: string,
+    +headerLeft: StackHeaderLeftButtonProps => React$Node,
+    +headerLeftContainerStyle: ViewStyleProp,
+    +headerRight: {| tintColor?: string |} => React$Node,
+    +headerRightContainerStyle: ViewStyleProp,
+    +headerBackImage: $PropertyType<StackHeaderLeftButtonProps, 'backImage'>,
+    +headerPressColorAndroid: string,
+    +headerBackground: ({| style: ViewStyleProp |}) => React$Node,
+    +headerStyle: ViewStyleProp,
+    +headerTransparent: boolean,
+    +headerStatusBarHeight: number,
+  |}>;
+
+  /**
+   * Stack navigation prop
+   */
+
+  declare export type StackNavigationEventMap = {|
+    ...EventMapCore<StackNavigationState>,
+    +transitionStart: {|
+      +data: {| +closing: boolean |},
+      +canPreventDefault: false,
+    |},
+    +transitionEnd: {|
+      +data: {| +closing: boolean |},
+      +canPreventDefault: false,
+    |},
+    +gestureStart: {| +data: void, +canPreventDefault: false |},
+    +gestureEnd: {| +data: void, +canPreventDefault: false |},
+    +gestureCancel: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare type InexactStackNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = StackOptions,
+    EventMap: EventMapBase = StackNavigationEventMap,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      StackNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +replace: SimpleNavigate<ParamList>,
+    +push: SimpleNavigate<ParamList>,
+    +pop: (count?: number) => void,
+    +popToTop: () => void,
+    ...
+  };
+
+  declare export type StackNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = StackOptions,
+    EventMap: EventMapBase = StackNavigationEventMap,
+  > = $Exact<InexactStackNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous stack exports
+   */
+
+  declare type StackNavigationConfig = {|
+    +mode?: 'card' | 'modal',
+    +headerMode?: 'float' | 'screen' | 'none',
+    +keyboardHandlingEnabled?: boolean,
+    +detachInactiveScreens?: boolean,
+  |};
+
+  declare export type ExtraStackNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...StackRouterOptions,
+    ...StackNavigationConfig,
+  |};
+
+  declare export type StackNavigatorProps<
+    NavProp: InexactStackNavigationProp<> = StackNavigationProp<>,
+  > = {|
+    ...ExtraStackNavigatorProps,
+    ...ScreenOptionsProp<StackOptions, NavProp>,
+  |};
+
+  /**
+   * Bottom tab options
+   */
+
+  declare export type BottomTabBarButtonProps = {|
+    ...$Diff<
+      TouchableWithoutFeedbackProps,
+      {| onPress?: ?(event: PressEvent) => mixed |},
+    >,
+    +to?: string,
+    +children: React$Node,
+    +onPress?: (MouseEvent | PressEvent) => void,
+  |};
+
+  declare export type TabBarVisibilityAnimationConfig =
+    | {|
+        +animation: 'spring',
+        +config?: $Diff<
+          SpringAnimationConfigSingle,
+          { toValue: number | AnimatedValue, useNativeDriver: boolean, ... },
+        >,
+      |}
+    | {|
+        +animation: 'timing',
+        +config?: $Diff<
+          TimingAnimationConfigSingle,
+          { toValue: number | AnimatedValue, useNativeDriver: boolean, ... },
+        >,
+      |};
+
+  declare export type BottomTabOptions = $Partial<{|
+    +title: string,
+    +tabBarLabel:
+      | string
+      | ({| focused: boolean, color: string |}) => React$Node,
+    +tabBarIcon: ({|
+      focused: boolean,
+      color: string,
+      size: number,
+    |}) => React$Node,
+    +tabBarBadge: number | string,
+    +tabBarBadgeStyle: TextStyleProp,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+    +tabBarVisible: boolean,
+    +tabBarVisibilityAnimationConfig: $Partial<{|
+      +show: TabBarVisibilityAnimationConfig,
+      +hide: TabBarVisibilityAnimationConfig,
+    |}>,
+    +tabBarButton: BottomTabBarButtonProps => React$Node,
+    +unmountOnBlur: boolean,
+  |}>;
+
+  /**
+   * Bottom tab navigation prop
+   */
+
+  declare export type BottomTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+    +tabLongPress: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare type InexactTabNavigationProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList>,
+    Options: {...},
+    EventMap: EventMapBase,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      TabNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +jumpTo: SimpleNavigate<ParamList>,
+    ...
+  };
+
+  declare export type InexactBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = BottomTabOptions,
+    EventMap: EventMapBase = BottomTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type BottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = BottomTabOptions,
+    EventMap: EventMapBase = BottomTabNavigationEventMap,
+  > = $Exact<InexactBottomTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous bottom tab exports
+   */
+
+  declare export type BottomTabDescriptor = Descriptor<
+    BottomTabNavigationProp<>,
+    BottomTabOptions,
+  >;
+
+  declare export type BottomTabBarOptions = $Partial<{|
+    +keyboardHidesTabBar: boolean,
+    +activeTintColor: string,
+    +inactiveTintColor: string,
+    +activeBackgroundColor: string,
+    +inactiveBackgroundColor: string,
+    +allowFontScaling: boolean,
+    +showLabel: boolean,
+    +showIcon: boolean,
+    +labelStyle: TextStyleProp,
+    +iconStyle: TextStyleProp,
+    +tabStyle: ViewStyleProp,
+    +labelPosition: 'beside-icon' | 'below-icon',
+    +adaptive: boolean,
+    +safeAreaInsets: $Partial<EdgeInsets>,
+    +style: ViewStyleProp,
+  |}>;
+
+  declare type BottomTabNavigationBuilderResult = {|
+    +state: TabNavigationState,
+    +navigation: BottomTabNavigationProp<>,
+    +descriptors: {| +[key: string]: BottomTabDescriptor |},
+  |};
+
+  declare export type BottomTabBarProps = {|
+    ...BottomTabBarOptions,
+    ...BottomTabNavigationBuilderResult,
+  |}
+
+  declare type BottomTabNavigationConfig = {|
+    +lazy?: boolean,
+    +tabBar?: BottomTabBarProps => React$Node,
+    +tabBarOptions?: BottomTabBarOptions,
+    +detachInactiveScreens?: boolean,
+  |};
+
+  declare export type ExtraBottomTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...BottomTabNavigationConfig,
+  |};
+
+  declare export type BottomTabNavigatorProps<
+    NavProp: InexactBottomTabNavigationProp<> = BottomTabNavigationProp<>,
+  > = {|
+    ...ExtraBottomTabNavigatorProps,
+    ...ScreenOptionsProp<BottomTabOptions, NavProp>,
+  |};
+
+  /**
+   * Material bottom tab options
+   */
+
+  declare export type MaterialBottomTabOptions = $Partial<{|
+    +title: string,
+    +tabBarColor: string,
+    +tabBarLabel: string,
+    +tabBarIcon:
+      | string
+      | ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarBadge: boolean | number | string,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+  |}>;
+
+  /**
+   * Material bottom tab navigation prop
+   */
+
+  declare export type MaterialBottomTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+  |};
+
+  declare export type InexactMaterialBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialBottomTabOptions,
+    EventMap: EventMapBase = MaterialBottomTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type MaterialBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialBottomTabOptions,
+    EventMap: EventMapBase = MaterialBottomTabNavigationEventMap,
+  > = $Exact<InexactMaterialBottomTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous material bottom tab exports
+   */
+
+  declare export type PaperFont = {|
+    +fontFamily: string,
+    +fontWeight?:
+      | 'normal'
+      | 'bold'
+      | '100'
+      | '200'
+      | '300'
+      | '400'
+      | '500'
+      | '600'
+      | '700'
+      | '800'
+      | '900',
+  |};
+
+  declare export type PaperFonts = {|
+    +regular: Font,
+    +medium: Font,
+    +light: Font,
+    +thin: Font,
+  |};
+
+  declare export type PaperTheme = {|
+    +dark: boolean,
+    +mode?: 'adaptive' | 'exact',
+    +roundness: number,
+    +colors: {|
+      +primary: string,
+      +background: string,
+      +surface: string,
+      +accent: string,
+      +error: string,
+      +text: string,
+      +onSurface: string,
+      +onBackground: string,
+      +disabled: string,
+      +placeholder: string,
+      +backdrop: string,
+      +notification: string,
+    |},
+    +fonts: PaperFonts,
+    +animation: {|
+      +scale: number,
+    |},
+  |};
+
+  declare export type PaperRoute = {|
+    +key: string,
+    +title?: string,
+    +icon?: any,
+    +badge?: string | number | boolean,
+    +color?: string,
+    +accessibilityLabel?: string,
+    +testID?: string,
+  |};
+
+  declare export type PaperTouchableProps = {|
+    ...TouchableWithoutFeedbackProps,
+    +key: string,
+    +route: PaperRoute,
+    +children: React$Node,
+    +borderless?: boolean,
+    +centered?: boolean,
+    +rippleColor?: string,
+  |};
+
+  declare export type MaterialBottomTabNavigationConfig = {|
+    +shifting?: boolean,
+    +labeled?: boolean,
+    +renderTouchable?: PaperTouchableProps => React$Node,
+    +activeColor?: string,
+    +inactiveColor?: string,
+    +sceneAnimationEnabled?: boolean,
+    +keyboardHidesNavigationBar?: boolean,
+    +barStyle?: ViewStyleProp,
+    +style?: ViewStyleProp,
+    +theme?: PaperTheme,
+  |};
+
+  declare export type ExtraMaterialBottomTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...MaterialBottomTabNavigationConfig,
+  |};
+
+  declare export type MaterialBottomTabNavigatorProps<
+    NavProp: InexactMaterialBottomTabNavigationProp<> =
+      MaterialBottomTabNavigationProp<>,
+  > = {|
+    ...ExtraMaterialBottomTabNavigatorProps,
+    ...ScreenOptionsProp<MaterialBottomTabOptions, NavProp>,
+  |};
+
+  /**
+   * Material top tab options
+   */
+
+  declare export type MaterialTopTabOptions = $Partial<{|
+    +title: string,
+    +tabBarLabel:
+      | string
+      | ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarIcon: ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+  |}>;
+
+  /**
+   * Material top tab navigation prop
+   */
+
+  declare export type MaterialTopTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+    +tabLongPress: {| +data: void, +canPreventDefault: false |},
+    +swipeStart: {| +data: void, +canPreventDefault: false |},
+    +swipeEnd: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare export type InexactMaterialTopTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialTopTabOptions,
+    EventMap: EventMapBase = MaterialTopTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type MaterialTopTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialTopTabOptions,
+    EventMap: EventMapBase = MaterialTopTabNavigationEventMap,
+  > = $Exact<InexactMaterialTopTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous material top tab exports
+   */
+
+  declare type MaterialTopTabPagerCommonProps = {|
+    +keyboardDismissMode: 'none' | 'on-drag' | 'auto',
+    +swipeEnabled: boolean,
+    +swipeVelocityImpact?: number,
+    +springVelocityScale?: number,
+    +springConfig: $Partial<{|
+      +damping: number,
+      +mass: number,
+      +stiffness: number,
+      +restSpeedThreshold: number,
+      +restDisplacementThreshold: number,
+    |}>,
+    +timingConfig: $Partial<{|
+      +duration: number,
+    |}>,
+  |};
+
+  declare export type MaterialTopTabPagerProps = {|
+    ...MaterialTopTabPagerCommonProps,
+    +onSwipeStart?: () => void,
+    +onSwipeEnd?: () => void,
+    +onIndexChange: (index: number) => void,
+    +navigationState: TabNavigationState,
+    +layout: {| +width: number, +height: number |},
+    +removeClippedSubviews: boolean,
+    +children: ({|
+      +addListener: (type: 'enter', listener: number => void) => void,
+      +removeListener: (type: 'enter', listener: number => void) => void,
+      +position: any, // Reanimated.Node<number>
+      +render: React$Node => React$Node,
+      +jumpTo: string => void,
+    |}) => React$Node,
+    +gestureHandlerProps: PanGestureHandlerProps,
+  |};
+
+  declare export type MaterialTopTabBarIndicatorProps = {|
+    +navigationState: TabNavigationState,
+    +width: string,
+    +style?: ViewStyleProp,
+    +getTabWidth: number => number,
+  |};
+
+  declare export type MaterialTopTabBarOptions = $Partial<{|
+    +scrollEnabled: boolean,
+    +bounces: boolean,
+    +pressColor: string,
+    +pressOpacity: number,
+    +getAccessible: ({| +route: Route<> |}) => boolean,
+    +renderBadge: ({| +route: Route<> |}) => React$Node,
+    +renderIndicator: MaterialTopTabBarIndicatorProps => React$Node,
+    +tabStyle: ViewStyleProp,
+    +indicatorStyle: ViewStyleProp,
+    +indicatorContainerStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+    +contentContainerStyle: ViewStyleProp,
+    +style: ViewStyleProp,
+    +activeTintColor: string,
+    +inactiveTintColor: string,
+    +iconStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+    +showLabel: boolean,
+    +showIcon: boolean,
+    +allowFontScaling: boolean,
+  |}>;
+
+  declare export type MaterialTopTabDescriptor = Descriptor<
+    MaterialBottomTabNavigationProp<>,
+    MaterialBottomTabOptions,
+  >;
+
+  declare type MaterialTopTabNavigationBuilderResult = {|
+    +state: TabNavigationState,
+    +navigation: MaterialTopTabNavigationProp<>,
+    +descriptors: {| +[key: string]: MaterialTopTabDescriptor |},
+  |};
+
+  declare export type MaterialTopTabBarProps = {|
+    ...MaterialTopTabBarOptions,
+    ...MaterialTopTabNavigationBuilderResult,
+    +layout: {| +width: number, +height: number |},
+    +position: any, // Reanimated.Node<number>
+    +jumpTo: string => void,
+  |};
+
+  declare export type MaterialTopTabNavigationConfig = {|
+    ...$Partial<MaterialTopTabPagerCommonProps>,
+    +position?: any, // Reanimated.Value<number>
+    +tabBarPosition?: 'top' | 'bottom',
+    +initialLayout?: $Partial<{| +width: number, +height: number |}>,
+    +lazy?: boolean,
+    +lazyPreloadDistance?: number,
+    +removeClippedSubviews?: boolean,
+    +sceneContainerStyle?: ViewStyleProp,
+    +style?: ViewStyleProp,
+    +gestureHandlerProps?: PanGestureHandlerProps,
+    +pager?: MaterialTopTabPagerProps => React$Node,
+    +lazyPlaceholder?: ({| +route: Route<> |}) => React$Node,
+    +tabBar?: MaterialTopTabBarProps => React$Node,
+    +tabBarOptions?: MaterialTopTabBarOptions,
+  |};
+
+  declare export type ExtraMaterialTopTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...MaterialTopTabNavigationConfig,
+  |};
+
+  declare export type MaterialTopTabNavigatorProps<
+    NavProp: InexactMaterialTopTabNavigationProp<> =
+      MaterialTopTabNavigationProp<>,
+  > = {|
+    ...ExtraMaterialTopTabNavigatorProps,
+    ...ScreenOptionsProp<MaterialTopTabOptions, NavProp>,
+  |};
+
+  /**
+   * Drawer options
+   */
+
+  declare export type DrawerOptions = $Partial<{|
+    title: string,
+    drawerLabel:
+      | string
+      | ({| +color: string, +focused: boolean |}) => React$Node,
+    drawerIcon: ({|
+      +color: string,
+      +size: number,
+      +focused: boolean,
+    |}) => React$Node,
+    gestureEnabled: boolean,
+    swipeEnabled: boolean,
+    unmountOnBlur: boolean,
+  |}>;
+
+  /**
+   * Drawer navigation prop
+   */
+
+  declare export type DrawerNavigationEventMap = {|
+    ...EventMapCore<DrawerNavigationState>,
+    +drawerOpen: {| +data: void, +canPreventDefault: false |},
+    +drawerClose: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare export type InexactDrawerNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = DrawerOptions,
+    EventMap: EventMapBase = DrawerNavigationEventMap,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      DrawerNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +jumpTo: SimpleNavigate<ParamList>,
+    +openDrawer: () => void,
+    +closeDrawer: () => void,
+    +toggleDrawer: () => void,
+    ...
+  };
+
+  declare export type DrawerNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = DrawerOptions,
+    EventMap: EventMapBase = DrawerNavigationEventMap,
+  > = $Exact<InexactDrawerNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous drawer exports
+   */
+
+  declare export type DrawerDescriptor = Descriptor<
+    DrawerNavigationProp<>,
+    DrawerOptions,
+  >;
+
+  declare export type DrawerItemListBaseOptions = $Partial<{|
+    +activeTintColor: string,
+    +activeBackgroundColor: string,
+    +inactiveTintColor: string,
+    +inactiveBackgroundColor: string,
+    +itemStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+  |}>;
+
+  declare export type DrawerContentOptions = $Partial<{|
+    ...DrawerItemListBaseOptions,
+    +contentContainerStyle: ViewStyleProp,
+    +style: ViewStyleProp,
+  |}>;
+
+  declare type DrawerNavigationBuilderResult = {|
+    +state: DrawerNavigationState,
+    +navigation: DrawerNavigationProp<>,
+    +descriptors: {| +[key: string]: DrawerDescriptor |},
+  |};
+
+  declare export type DrawerContentProps = {|
+    ...DrawerContentOptions,
+    ...DrawerNavigationBuilderResult,
+    +progress: any, // Reanimated.Node<number>
+  |};
+
+  declare export type DrawerNavigationConfig = {|
+    +drawerPosition?: 'left' | 'right',
+    +drawerType?: 'front' | 'back' | 'slide' | 'permanent',
+    +edgeWidth?: number,
+    +hideStatusBar?: boolean,
+    +keyboardDismissMode?: 'on-drag' | 'none',
+    +minSwipeDistance?: number,
+    +overlayColor?: string,
+    +statusBarAnimation?: 'slide' | 'none' | 'fade',
+    +gestureHandlerProps?: PanGestureHandlerProps,
+    +lazy?: boolean,
+    +drawerContent?: DrawerContentProps => React$Node,
+    +drawerContentOptions?: DrawerContentOptions,
+    +sceneContainerStyle?: ViewStyleProp,
+    +drawerStyle?: ViewStyleProp,
+    +detachInactiveScreens?: boolean,
+  |};
+
+  declare export type ExtraDrawerNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...DrawerRouterOptions,
+    ...DrawerNavigationConfig,
+  |};
+
+  declare export type DrawerNavigatorProps<
+    NavProp: InexactDrawerNavigationProp<> = DrawerNavigationProp<>,
+  > = {|
+    ...ExtraDrawerNavigatorProps,
+    ...ScreenOptionsProp<DrawerOptions, NavProp>,
+  |};
+
+  /**
+   * BaseNavigationContainer
+   */
+
+  declare export type BaseNavigationContainerProps = {|
+    +children: React$Node,
+    +initialState?: PossiblyStaleNavigationState,
+    +onStateChange?: (state: ?PossiblyStaleNavigationState) => void,
+    +independent?: boolean,
+  |};
+
+  declare export type ContainerEventMap = {|
+    ...GlobalEventMap<PossiblyStaleNavigationState>,
+    +options: {|
+      +data: {| +options: { +[key: string]: mixed, ... } |},
+      +canPreventDefault: false,
+    |},
+    +__unsafe_action__: {|
+      +data: {|
+        +action: GenericNavigationAction,
+        +noop: boolean,
+      |},
+      +canPreventDefault: false,
+    |},
+  |};
+
+  declare export type BaseNavigationContainerInterface = {|
+    ...$Exact<NavigationHelpers<
+      ParamListBase,
+      PossiblyStaleNavigationState,
+      ContainerEventMap,
+    >>,
+    +setParams: (params: ScreenParams) => void,
+    +resetRoot: (state?: ?PossiblyStaleNavigationState) => void,
+    +getRootState: () => PossiblyStaleNavigationState,
+  |};
+
+  /**
+   * State utils
+   */
+
+  declare export type GetStateFromPath = (
+    path: string,
+    options?: LinkingConfig,
+  ) => PossiblyStaleNavigationState;
+
+  declare export type GetPathFromState = (
+    state?: ?PossiblyStaleNavigationState,
+    options?: LinkingConfig,
+  ) => string;
+
+  declare export type GetFocusedRouteNameFromRoute =
+    PossiblyStaleRoute<string> => ?string;
+
+  /**
+   * Linking
+   */
+
+  declare export type ScreenLinkingConfig = {|
+    +path?: string,
+    +exact?: boolean,
+    +parse?: {| +[param: string]: string => mixed |},
+    +stringify?: {| +[param: string]: mixed => string |},
+    +screens?: ScreenLinkingConfigMap,
+    +initialRouteName?: string,
+  |};
+
+  declare export type ScreenLinkingConfigMap = {|
+    +[routeName: string]: string | ScreenLinkingConfig,
+  |};
+
+  declare export type LinkingConfig = {|
+    +initialRouteName?: string,
+    +screens: ScreenLinkingConfigMap,
+  |};
+
+  declare export type LinkingOptions = {|
+    +enabled?: boolean,
+    +prefixes: $ReadOnlyArray<string>,
+    +config?: LinkingConfig,
+    +getStateFromPath?: GetStateFromPath,
+    +getPathFromState?: GetPathFromState,
+  |};
+
+  /**
+   * NavigationContainer
+   */
+
+  declare export type Theme = {|
+    +dark: boolean,
+    +colors: {|
+      +primary: string,
+      +background: string,
+      +card: string,
+      +text: string,
+      +border: string,
+    |},
+  |};
+
+  declare export type NavigationContainerType = React$AbstractComponent<
+    {|
+      ...BaseNavigationContainerProps,
+      +theme?: Theme,
+      +linking?: LinkingOptions,
+      +fallback?: React$Node,
+      +onReady?: () => mixed,
+    |},
+    BaseNavigationContainerInterface,
+  >;
+
+  //---------------------------------------------------------------------------
+  // SECTION 2: EXPORTED MODULE
+  // This section defines the module exports and contains exported types that
+  // are not present in any other React Navigation libdef.
+  //---------------------------------------------------------------------------
+
+  /**
+   * createBottomTabNavigator
+   */
+
+  declare export var createBottomTabNavigator: CreateNavigator<
+    TabNavigationState,
+    BottomTabOptions,
+    BottomTabNavigationEventMap,
+    ExtraBottomTabNavigatorProps,
+  >;
+
+  /**
+   * BottomTabBar
+   */
+
+  declare export var BottomTabBar: React$ComponentType<BottomTabBarProps>;
+
+  /**
+   * BottomTabView
+   */
+
+  declare export type BottomTabViewProps = {|
+    ...BottomTabNavigationConfig,
+    ...BottomTabNavigationBuilderResult,
+  |};
+  declare export var BottomTabView: React$ComponentType<BottomTabViewProps>;
+
+}

--- a/flow-typed/npm/@react-navigation/material-top-tabs_v5.x.x.js
+++ b/flow-typed/npm/@react-navigation/material-top-tabs_v5.x.x.js
@@ -1,0 +1,2078 @@
+// flow-typed signature: add7a9504efc04ec59b85f3eedfad445
+// flow-typed version: 510a06cce0/@react-navigation/material-top-tabs_v5.x.x/flow_>=v0.104.x
+
+declare module '@react-navigation/material-top-tabs' {
+
+  //---------------------------------------------------------------------------
+  // SECTION 1: IDENTICAL TYPE DEFINITIONS
+  // This section is identical across all React Navigation libdefs and contains
+  // shared definitions. We wish we could make it DRY and import from a shared
+  // definition, but that isn't yet possible.
+  //---------------------------------------------------------------------------
+
+  /**
+   * We start with some definitions that we have copy-pasted from React Native
+   * source files.
+   */
+
+  // This is a bastardization of the true StyleObj type located in
+  // react-native/Libraries/StyleSheet/StyleSheetTypes. We unfortunately can't
+  // import that here, and it's too lengthy (and consequently too brittle) to
+  // copy-paste here either.
+  declare type StyleObj =
+    | null
+    | void
+    | number
+    | false
+    | ''
+    | $ReadOnlyArray<StyleObj>
+    | { [name: string]: any, ... };
+  declare type ViewStyleProp = StyleObj;
+  declare type TextStyleProp = StyleObj;
+  declare type AnimatedViewStyleProp = StyleObj;
+  declare type AnimatedTextStyleProp = StyleObj;
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/animations/Animation.js
+  declare type EndResult = { finished: boolean, ... };
+  declare type EndCallback = (result: EndResult) => void;
+  declare interface Animation {
+    start(
+      fromValue: number,
+      onUpdate: (value: number) => void,
+      onEnd: ?EndCallback,
+      previousAnimation: ?Animation,
+      animatedValue: AnimatedValue,
+    ): void;
+    stop(): void;
+  }
+  declare type AnimationConfig = {
+    isInteraction?: boolean,
+    useNativeDriver: boolean,
+    onComplete?: ?EndCallback,
+    iterations?: number,
+    ...
+  };
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedTracking.js
+  declare interface AnimatedTracking {
+    constructor(
+      value: AnimatedValue,
+      parent: any,
+      animationClass: any,
+      animationConfig: Object,
+      callback?: ?EndCallback,
+    ): void;
+    update(): void;
+  }
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedValue.js
+  declare type ValueListenerCallback = (state: { value: number, ... }) => void;
+  declare interface AnimatedValue {
+    constructor(value: number): void;
+    setValue(value: number): void;
+    setOffset(offset: number): void;
+    flattenOffset(): void;
+    extractOffset(): void;
+    addListener(callback: ValueListenerCallback): string;
+    removeListener(id: string): void;
+    removeAllListeners(): void;
+    stopAnimation(callback?: ?(value: number) => void): void;
+    resetAnimation(callback?: ?(value: number) => void): void;
+    interpolate(config: InterpolationConfigType): AnimatedInterpolation;
+    animate(animation: Animation, callback: ?EndCallback): void;
+    stopTracking(): void;
+    track(tracking: AnimatedTracking): void;
+  }
+
+  // Copied from
+  // react-native/Libraries/Animated/src/animations/TimingAnimation.js
+  declare type TimingAnimationConfigSingle = AnimationConfig & {
+    toValue: number | AnimatedValue,
+    easing?: (value: number) => number,
+    duration?: number,
+    delay?: number,
+    ...
+  };
+
+  // Copied from
+  // react-native/Libraries/Animated/src/animations/SpringAnimation.js
+  declare type SpringAnimationConfigSingle = AnimationConfig & {
+    toValue: number | AnimatedValue,
+    overshootClamping?: boolean,
+    restDisplacementThreshold?: number,
+    restSpeedThreshold?: number,
+    velocity?: number,
+    bounciness?: number,
+    speed?: number,
+    tension?: number,
+    friction?: number,
+    stiffness?: number,
+    damping?: number,
+    mass?: number,
+    delay?: number,
+    ...
+  };
+
+  // Copied from react-native/Libraries/Types/CoreEventTypes.js
+  declare type SyntheticEvent<T> = $ReadOnly<{|
+    bubbles: ?boolean,
+    cancelable: ?boolean,
+    currentTarget: number,
+    defaultPrevented: ?boolean,
+    dispatchConfig: $ReadOnly<{|
+      registrationName: string,
+    |}>,
+    eventPhase: ?number,
+    preventDefault: () => void,
+    isDefaultPrevented: () => boolean,
+    stopPropagation: () => void,
+    isPropagationStopped: () => boolean,
+    isTrusted: ?boolean,
+    nativeEvent: T,
+    persist: () => void,
+    target: ?number,
+    timeStamp: number,
+    type: ?string,
+  |}>;
+  declare type Layout = $ReadOnly<{|
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+  |}>;
+  declare type LayoutEvent = SyntheticEvent<
+    $ReadOnly<{|
+      layout: Layout,
+    |}>,
+  >;
+  declare type BlurEvent = SyntheticEvent<
+    $ReadOnly<{|
+      target: number,
+    |}>,
+  >;
+  declare type FocusEvent = SyntheticEvent<
+    $ReadOnly<{|
+      target: number,
+    |}>,
+  >;
+  declare type ResponderSyntheticEvent<T> = $ReadOnly<{|
+    ...SyntheticEvent<T>,
+    touchHistory: $ReadOnly<{|
+      indexOfSingleActiveTouch: number,
+      mostRecentTimeStamp: number,
+      numberActiveTouches: number,
+      touchBank: $ReadOnlyArray<
+        $ReadOnly<{|
+          touchActive: boolean,
+          startPageX: number,
+          startPageY: number,
+          startTimeStamp: number,
+          currentPageX: number,
+          currentPageY: number,
+          currentTimeStamp: number,
+          previousPageX: number,
+          previousPageY: number,
+          previousTimeStamp: number,
+        |}>,
+      >,
+    |}>,
+  |}>;
+  declare type PressEvent = ResponderSyntheticEvent<
+    $ReadOnly<{|
+      changedTouches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
+      force: number,
+      identifier: number,
+      locationX: number,
+      locationY: number,
+      pageX: number,
+      pageY: number,
+      target: ?number,
+      timestamp: number,
+      touches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
+    |}>,
+  >;
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedInterpolation.js
+  declare type ExtrapolateType = 'extend' | 'identity' | 'clamp';
+  declare type InterpolationConfigType = {
+    inputRange: Array<number>,
+    outputRange: Array<number> | Array<string>,
+    easing?: (input: number) => number,
+    extrapolate?: ExtrapolateType,
+    extrapolateLeft?: ExtrapolateType,
+    extrapolateRight?: ExtrapolateType,
+    ...
+  };
+  declare interface AnimatedInterpolation {
+    interpolate(config: InterpolationConfigType): AnimatedInterpolation;
+  }
+
+  // Copied from react-native/Libraries/Components/View/ViewAccessibility.js
+  declare type AccessibilityRole =
+    | 'none'
+    | 'button'
+    | 'link'
+    | 'search'
+    | 'image'
+    | 'keyboardkey'
+    | 'text'
+    | 'adjustable'
+    | 'imagebutton'
+    | 'header'
+    | 'summary'
+    | 'alert'
+    | 'checkbox'
+    | 'combobox'
+    | 'menu'
+    | 'menubar'
+    | 'menuitem'
+    | 'progressbar'
+    | 'radio'
+    | 'radiogroup'
+    | 'scrollbar'
+    | 'spinbutton'
+    | 'switch'
+    | 'tab'
+    | 'tablist'
+    | 'timer'
+    | 'toolbar';
+  declare type AccessibilityActionInfo = $ReadOnly<{
+    name: string,
+    label?: string,
+    ...
+  }>;
+  declare type AccessibilityActionEvent = SyntheticEvent<
+    $ReadOnly<{actionName: string, ...}>,
+  >;
+  declare type AccessibilityState = {
+    disabled?: boolean,
+    selected?: boolean,
+    checked?: ?boolean | 'mixed',
+    busy?: boolean,
+    expanded?: boolean,
+    ...
+  };
+  declare type AccessibilityValue = $ReadOnly<{|
+    min?: number,
+    max?: number,
+    now?: number,
+    text?: string,
+  |}>;
+
+  // Copied from
+  // react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+  declare type Stringish = string;
+  declare type EdgeInsetsProp = $ReadOnly<$Partial<EdgeInsets>>;
+  declare type TouchableWithoutFeedbackProps = $ReadOnly<{|
+    accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
+    accessibilityElementsHidden?: ?boolean,
+    accessibilityHint?: ?Stringish,
+    accessibilityIgnoresInvertColors?: ?boolean,
+    accessibilityLabel?: ?Stringish,
+    accessibilityLiveRegion?: ?('none' | 'polite' | 'assertive'),
+    accessibilityRole?: ?AccessibilityRole,
+    accessibilityState?: ?AccessibilityState,
+    accessibilityValue?: ?AccessibilityValue,
+    accessibilityViewIsModal?: ?boolean,
+    accessible?: ?boolean,
+    children?: ?React$Node,
+    delayLongPress?: ?number,
+    delayPressIn?: ?number,
+    delayPressOut?: ?number,
+    disabled?: ?boolean,
+    focusable?: ?boolean,
+    hitSlop?: ?EdgeInsetsProp,
+    importantForAccessibility?: ?('auto' | 'yes' | 'no' | 'no-hide-descendants'),
+    nativeID?: ?string,
+    onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
+    onBlur?: ?(event: BlurEvent) => mixed,
+    onFocus?: ?(event: FocusEvent) => mixed,
+    onLayout?: ?(event: LayoutEvent) => mixed,
+    onLongPress?: ?(event: PressEvent) => mixed,
+    onPress?: ?(event: PressEvent) => mixed,
+    onPressIn?: ?(event: PressEvent) => mixed,
+    onPressOut?: ?(event: PressEvent) => mixed,
+    pressRetentionOffset?: ?EdgeInsetsProp,
+    rejectResponderTermination?: ?boolean,
+    testID?: ?string,
+    touchSoundDisabled?: ?boolean,
+  |}>;
+
+  // Copied from react-native/Libraries/Image/ImageSource.js
+  declare type ImageURISource = $ReadOnly<{
+    uri?: ?string,
+    bundle?: ?string,
+    method?: ?string,
+    headers?: ?Object,
+    body?: ?string,
+    cache?: ?('default' | 'reload' | 'force-cache' | 'only-if-cached'),
+    width?: ?number,
+    height?: ?number,
+    scale?: ?number,
+    ...
+  }>;
+
+  /**
+   * The following is copied from react-native-gesture-handler's libdef
+   */
+
+  declare type $EventHandlers<ExtraProps: {...}> = {|
+    onGestureEvent?: ($Event<ExtraProps>) => mixed,
+    onHandlerStateChange?: ($Event<ExtraProps>) => mixed,
+    onBegan?: ($Event<ExtraProps>) => mixed,
+    onFailed?: ($Event<ExtraProps>) => mixed,
+    onCancelled?: ($Event<ExtraProps>) => mixed,
+    onActivated?: ($Event<ExtraProps>) => mixed,
+    onEnded?: ($Event<ExtraProps>) => mixed,
+  |};
+
+  declare type HitSlop =
+    | number
+    | {|
+        left?: number,
+        top?: number,
+        right?: number,
+        bottom?: number,
+        vertical?: number,
+        horizontal?: number,
+        width?: number,
+        height?: number,
+      |}
+    | {|
+        width: number,
+        left: number,
+      |}
+    | {|
+        width: number,
+        right: number,
+      |}
+    | {|
+        height: number,
+        top: number,
+      |}
+    | {|
+        height: number,
+        bottom: number,
+      |};
+
+  declare type $GestureHandlerProps<
+    AdditionalProps: {...},
+    ExtraEventsProps: {...}
+  > = $ReadOnly<{|
+    ...$Exact<AdditionalProps>,
+    ...$EventHandlers<ExtraEventsProps>,
+    id?: string,
+    enabled?: boolean,
+    waitFor?: React$Ref<any> | Array<React$Ref<any>>,
+    simultaneousHandlers?: React$Ref<any> | Array<React$Ref<any>>,
+    shouldCancelWhenOutside?: boolean,
+    minPointers?: number,
+    hitSlop?: HitSlop,
+    children?: React$Node,
+  |}>;
+
+  declare type PanGestureHandlerProps = $GestureHandlerProps<
+    {
+      activeOffsetY?: number | [number, number],
+      activeOffsetX?: number | [number, number],
+      failOffsetY?: number | [number, number],
+      failOffsetX?: number | [number, number],
+      minDist?: number,
+      minVelocity?: number,
+      minVelocityX?: number,
+      minVelocityY?: number,
+      minPointers?: number,
+      maxPointers?: number,
+      avgTouches?: boolean,
+      ...
+    },
+    {
+      x: number,
+      y: number,
+      absoluteX: number,
+      absoluteY: number,
+      translationX: number,
+      translationY: number,
+      velocityX: number,
+      velocityY: number,
+      ...
+    }
+  >;
+
+  /**
+   * MAGIC
+   */
+
+  declare type $If<Test: boolean, Then, Else = empty> = $Call<
+    ((true, Then, Else) => Then) & ((false, Then, Else) => Else),
+    Test,
+    Then,
+    Else,
+  >;
+  declare type $IsA<X, Y> = $Call<
+    (Y => true) & (mixed => false),
+    X,
+  >;
+  declare type $IsUndefined<X> = $IsA<X, void>;
+
+  declare type $Partial<T> = $ReadOnly<$Rest<T, {...}>>;
+
+  /**
+   * Actions, state, etc.
+   */
+
+  declare export type ScreenParams = { +[key: string]: mixed, ... };
+
+  declare export type BackAction = {|
+    +type: 'GO_BACK',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type NavigateAction = {|
+    +type: 'NAVIGATE',
+    +payload:
+      | {| +key: string, +params?: ScreenParams |}
+      | {| +name: string, +key?: string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type ResetAction = {|
+    +type: 'RESET',
+    +payload: StaleNavigationState,
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type SetParamsAction = {|
+    +type: 'SET_PARAMS',
+    +payload: {| +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type CommonAction =
+    | BackAction
+    | NavigateAction
+    | ResetAction
+    | SetParamsAction;
+
+  declare type NavigateActionCreator = {|
+    (routeName: string, params?: ScreenParams): NavigateAction,
+    (
+      | {| +key: string, +params?: ScreenParams |}
+      | {| +name: string, +key?: string, +params?: ScreenParams |},
+    ): NavigateAction,
+  |};
+  declare export type CommonActionsType = {|
+    +navigate: NavigateActionCreator,
+    +goBack: () => BackAction,
+    +reset: (state: PossiblyStaleNavigationState) => ResetAction,
+    +setParams: (params: ScreenParams) => SetParamsAction,
+  |};
+
+  declare export type GenericNavigationAction = {|
+    +type: string,
+    +payload?: { +[key: string]: mixed, ... },
+    +source?: string,
+    +target?: string,
+  |};
+
+  declare export type LeafRoute<RouteName: string = string> = {|
+    +key: string,
+    +name: RouteName,
+    +params?: ScreenParams,
+  |};
+  declare export type StateRoute<RouteName: string = string> = {|
+    ...LeafRoute<RouteName>,
+    +state: NavigationState | StaleNavigationState,
+  |};
+  declare export type Route<RouteName: string = string> =
+    | LeafRoute<RouteName>
+    | StateRoute<RouteName>;
+
+  declare export type NavigationState = {|
+    +key: string,
+    +index: number,
+    +routeNames: $ReadOnlyArray<string>,
+    +history?: $ReadOnlyArray<mixed>,
+    +routes: $ReadOnlyArray<Route<>>,
+    +type: string,
+    +stale: false,
+  |};
+
+  declare export type StaleLeafRoute<RouteName: string = string> = {|
+    +key?: string,
+    +name: RouteName,
+    +params?: ScreenParams,
+  |};
+  declare export type StaleStateRoute<RouteName: string = string> = {|
+    ...StaleLeafRoute<RouteName>,
+    +state: StaleNavigationState,
+  |};
+  declare export type StaleRoute<RouteName: string = string> =
+    | StaleLeafRoute<RouteName>
+    | StaleStateRoute<RouteName>;
+  declare export type StaleNavigationState = {|
+    // It's possible to pass React Nav a StaleNavigationState with an undefined
+    // index, but React Nav will always return one with the index set. This is
+    // the same as for the type property below, but in the case of index we tend
+    // to rely on it being set more...
+    +index: number,
+    +history?: $ReadOnlyArray<mixed>,
+    +routes: $ReadOnlyArray<StaleRoute<>>,
+    +type?: string,
+    +stale?: true,
+  |};
+
+  declare export type PossiblyStaleNavigationState =
+    | NavigationState
+    | StaleNavigationState;
+  declare export type PossiblyStaleRoute<RouteName: string = string> =
+    | Route<RouteName>
+    | StaleRoute<RouteName>;
+
+  /**
+   * Routers
+   */
+
+  declare type ActionCreators<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+  > = {
+    +[key: string]: (...args: any) => (Action | State => Action),
+    ...
+  };
+
+  declare export type DefaultRouterOptions = {
+    +initialRouteName?: string,
+    ...
+  };
+
+  declare export type RouterFactory<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+    RouterOptions: DefaultRouterOptions,
+  > = (options: RouterOptions) => Router<State, Action>;
+
+  declare export type ParamListBase = { +[key: string]: ?ScreenParams, ... };
+
+  declare export type RouterConfigOptions = {|
+    +routeNames: $ReadOnlyArray<string>,
+    +routeParamList: ParamListBase,
+  |};
+
+  declare export type Router<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+  > = {|
+    +type: $PropertyType<State, 'type'>,
+    +getInitialState: (options: RouterConfigOptions) => State,
+    +getRehydratedState: (
+      partialState: PossibleStaleNavigationState,
+      options: RouterConfigOptions,
+    ) => State,
+    +getStateForRouteNamesChange: (
+      state: State,
+      options: RouterConfigOptions,
+    ) => State,
+    +getStateForRouteFocus: (state: State, key: string) => State,
+    +getStateForAction: (
+      state: State,
+      action: Action,
+      options: RouterConfigOptions,
+    ) => ?PossiblyStaleNavigationState;
+    +shouldActionChangeFocus: (action: GenericNavigationAction) => boolean,
+    +actionCreators?: ActionCreators<State, Action>,
+  |};
+
+  /**
+   * Stack actions and router
+   */
+
+  declare export type StackNavigationState = {|
+    ...NavigationState,
+    +type: 'stack',
+  |};
+
+  declare export type ReplaceAction = {|
+    +type: 'REPLACE',
+    +payload: {| +name: string, +key?: ?string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PushAction = {|
+    +type: 'PUSH',
+    +payload: {| +name: string, +key?: ?string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PopAction = {|
+    +type: 'POP',
+    +payload: {| +count: number |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PopToTopAction = {|
+    +type: 'POP_TO_TOP',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type StackAction =
+    | CommonAction
+    | ReplaceAction
+    | PushAction
+    | PopAction
+    | PopToTopAction;
+
+  declare export type StackActionsType = {|
+    +replace: (routeName: string, params?: ScreenParams) => ReplaceAction,
+    +push: (routeName: string, params?: ScreenParams) => PushAction,
+    +pop: (count?: number) => PopAction,
+    +popToTop: () => PopToTopAction,
+  |};
+
+  declare export type StackRouterOptions = $Exact<DefaultRouterOptions>;
+
+  /**
+   * Tab actions and router
+   */
+
+  declare export type TabNavigationState = {|
+    ...NavigationState,
+    +type: 'tab',
+    +history: $ReadOnlyArray<{| type: 'route', key: string |}>,
+  |};
+
+  declare export type JumpToAction = {|
+    +type: 'JUMP_TO',
+    +payload: {| +name: string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type TabAction =
+    | CommonAction
+    | JumpToAction;
+
+  declare export type TabActionsType = {|
+    +jumpTo: string => JumpToAction,
+  |};
+
+  declare export type TabRouterOptions = {|
+    ...$Exact<DefaultRouterOptions>,
+    +backBehavior?: 'initialRoute' | 'order' | 'history' | 'none',
+  |};
+
+  /**
+   * Drawer actions and router
+   */
+
+  declare type DrawerHistoryEntry =
+    | {| +type: 'route', +key: string |}
+    | {| +type: 'drawer' |};
+  declare export type DrawerNavigationState = {|
+    ...NavigationState,
+    +type: 'drawer',
+    +history: $ReadOnlyArray<DrawerHistoryEntry>,
+  |};
+
+  declare export type OpenDrawerAction = {|
+    +type: 'OPEN_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type CloseDrawerAction = {|
+    +type: 'CLOSE_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type ToggleDrawerAction = {|
+    +type: 'TOGGLE_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type DrawerAction =
+    | TabAction
+    | OpenDrawerAction
+    | CloseDrawerAction
+    | ToggleDrawerAction;
+
+  declare export type DrawerActionsType = {|
+    ...TabActionsType,
+    +openDrawer: () => OpenDrawerAction,
+    +closeDrawer: () => CloseDrawerAction,
+    +toggleDrawer: () => ToggleDrawerAction,
+  |};
+
+  declare export type DrawerRouterOptions = {|
+    ...TabRouterOptions,
+    +openByDefault?: boolean,
+  |};
+
+  /**
+   * Events
+   */
+
+  declare export type EventMapBase = {
+    +[name: string]: {|
+      +data?: mixed,
+      +canPreventDefault?: boolean,
+    |},
+    ...
+  };
+  declare type EventPreventDefaultProperties<Test: boolean> = $If<
+    Test,
+    {| +defaultPrevented: boolean, +preventDefault: () => void |},
+    {| |},
+  >;
+  declare type EventDataProperties<Data> = $If<
+    $IsUndefined<Data>,
+    {| |},
+    {| +data: Data |},
+  >;
+  declare type EventArg<
+    EventName: string,
+    CanPreventDefault: ?boolean = false,
+    Data = void,
+  > = {|
+    ...EventPreventDefaultProperties<CanPreventDefault>,
+    ...EventDataProperties<Data>,
+    +type: EventName,
+    +target?: string,
+  |};
+  declare type GlobalEventMap<State: PossiblyStaleNavigationState> = {|
+    +state: {| +data: {| +state: State |}, +canPreventDefault: false |},
+  |};
+  declare type EventMapCore<State: PossiblyStaleNavigationState> = {|
+    ...GlobalEventMap<State>,
+    +focus: {| +data: void, +canPreventDefault: false |},
+    +blur: {| +data: void, +canPreventDefault: false |},
+    +beforeRemove: {|
+      +data: {| +action: GenericNavigationAction |},
+      +canPreventDefault: true,
+    |},
+  |};
+  declare type EventListenerCallback<
+    EventName: string,
+    State: PossiblyStaleNavigationState = NavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = (e: EventArg<
+    EventName,
+    $PropertyType<
+      $ElementType<
+        {| ...EventMap, ...EventMapCore<State> |},
+        EventName,
+      >,
+      'canPreventDefault',
+    >,
+    $PropertyType<
+      $ElementType<
+        {| ...EventMap, ...EventMapCore<State> |},
+        EventName,
+      >,
+      'data',
+    >,
+  >) => mixed;
+
+  /**
+   * Navigation prop
+   */
+
+  declare export type SimpleNavigate<ParamList> =
+    <DestinationRouteName: $Keys<ParamList>>(
+      routeName: DestinationRouteName,
+      params: $ElementType<ParamList, DestinationRouteName>,
+    ) => void;
+
+  declare export type Navigate<ParamList> =
+    & SimpleNavigate<ParamList>
+    & <DestinationRouteName: $Keys<ParamList>>(
+        route:
+          | {|
+              key: string,
+              params?: $ElementType<ParamList, DestinationRouteName>,
+            |}
+          | {|
+              name: DestinationRouteName,
+              key?: string,
+              params?: $ElementType<ParamList, DestinationRouteName>,
+            |},
+      ) => void;
+
+  declare type NavigationHelpers<
+    ParamList: ParamListBase,
+    State: PossiblyStaleNavigationState = PossiblyStaleNavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {
+    +navigate: Navigate<ParamList>,
+    +dispatch: (
+      action:
+        | GenericNavigationAction
+        | (State => GenericNavigationAction),
+    ) => void,
+    +reset: PossiblyStaleNavigationState => void,
+    +goBack: () => void,
+    +isFocused: () => boolean,
+    +canGoBack: () => boolean,
+    +dangerouslyGetParent: <Parent: NavigationProp<ParamListBase>>() => ?Parent,
+    +dangerouslyGetState: () => NavigationState,
+    +addListener: <EventName: $Keys<
+      {| ...EventMap, ...EventMapCore<State> |},
+    >>(
+      name: EventName,
+      callback: EventListenerCallback<EventName, State, EventMap>,
+    ) => () => void,
+    +removeListener: <EventName: $Keys<
+      {| ...EventMap, ...EventMapCore<State> |},
+    >>(
+      name: EventName,
+      callback: EventListenerCallback<EventName, State, EventMap>,
+    ) => void,
+    ...
+  };
+
+  declare export type NavigationProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: PossiblyStaleNavigationState = PossiblyStaleNavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {
+    ...$Exact<NavigationHelpers<
+      ParamList,
+      State,
+      EventMap,
+    >>,
+    +setOptions: (options: $Partial<ScreenOptions>) => void,
+    +setParams: (
+      params: $If<
+        $IsUndefined<$ElementType<ParamList, RouteName>>,
+        empty,
+        $Partial<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
+      >,
+    ) => void,
+    ...
+  };
+
+  /**
+   * CreateNavigator
+   */
+
+  declare export type RouteProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList>,
+  > = {|
+    ...LeafRoute<RouteName>,
+    +params: $ElementType<ParamList, RouteName>,
+  |};
+
+  declare export type ScreenListeners<
+    EventMap: EventMapBase = EventMapCore<State>,
+    State: NavigationState = NavigationState,
+  > = $ObjMapi<
+    {| [name: $Keys<EventMap>]: empty |},
+    <K: $Keys<EventMap>>(K, empty) => EventListenerCallback<K, State, EventMap>,
+  >;
+
+  declare type BaseScreenProps<
+    ParamList: ParamListBase,
+    NavProp,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {|
+    +name: RouteName,
+    +options?:
+      | ScreenOptions
+      | ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => ScreenOptions,
+    +listeners?:
+      | ScreenListeners<EventMap, State>
+      | ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => ScreenListeners<EventMap, State>,
+    +initialParams?: $Partial<$ElementType<ParamList, RouteName>>,
+  |};
+
+  declare export type ScreenProps<
+    ParamList: ParamListBase,
+    NavProp,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > =
+    | {|
+        ...BaseScreenProps<
+          ParamList,
+          NavProp,
+          RouteName,
+          State,
+          ScreenOptions,
+          EventMap,
+        >,
+        +component: React$ComponentType<{|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}>,
+      |}
+    | {|
+        ...BaseScreenProps<
+          ParamList,
+          NavProp,
+          RouteName,
+          State,
+          ScreenOptions,
+          EventMap,
+        >,
+        +children: ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => React$Node,
+      |};
+
+  declare export type ScreenComponent<
+    GlobalParamList: ParamListBase,
+    ParamList: ParamListBase,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = <
+    RouteName: $Keys<ParamList>,
+    NavProp: NavigationProp<
+      GlobalParamList,
+      RouteName,
+      State,
+      ScreenOptions,
+      EventMap,
+    >,
+  >(props: ScreenProps<
+    ParamList,
+    NavProp,
+    RouteName,
+    State,
+    ScreenOptions,
+    EventMap,
+  >) => React$Node;
+
+  declare type ScreenOptionsProp<ScreenOptions: {...}, NavProp> = {|
+    +screenOptions?:
+      | ScreenOptions
+      | ({| route: LeafRoute<>, navigation: NavProp |}) => ScreenOptions,
+  |};
+  declare export type ExtraNavigatorPropsBase = {
+    ...$Exact<DefaultRouterOptions>,
+    +children?: React$Node,
+    ...
+  };
+  declare export type NavigatorPropsBase<ScreenOptions: {...}, NavProp> = {
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    ...
+  };
+
+  declare export type CreateNavigator<
+    State: NavigationState,
+    ScreenOptions: {...},
+    EventMap: EventMapBase,
+    ExtraNavigatorProps: ExtraNavigatorPropsBase,
+  > = <
+    GlobalParamList: ParamListBase,
+    ParamList: ParamListBase,
+    NavProp: NavigationHelpers<
+      GlobalParamList,
+      State,
+      EventMap,
+    >,
+  >() => {|
+    +Screen: ScreenComponent<
+      GlobalParamList,
+      ParamList,
+      State,
+      ScreenOptions,
+      EventMap,
+    >,
+    +Navigator: React$ComponentType<{|
+      ...$Exact<ExtraNavigatorProps>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    |}>,
+  |};
+
+  declare export type CreateNavigatorFactory = <
+    State: NavigationState,
+    ScreenOptions: {...},
+    EventMap: EventMapBase,
+    NavProp: NavigationHelpers<
+      ParamListBase,
+      State,
+      EventMap,
+    >,
+    ExtraNavigatorProps: ExtraNavigatorPropsBase,
+  >(
+    navigator: React$ComponentType<{|
+      ...$Exact<ExtraNavigatorPropsBase>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    |}>,
+  ) => CreateNavigator<State, ScreenOptions, EventMap, ExtraNavigatorProps>;
+
+  /**
+   * useNavigationBuilder
+   */
+
+  declare export type Descriptor<
+    NavProp,
+    ScreenOptions: {...} = {...},
+  > = {|
+    +render: () => React$Node,
+    +options: $ReadOnly<ScreenOptions>,
+    +navigation: NavProp,
+  |};
+
+  declare export type UseNavigationBuilder = <
+    State: NavigationState,
+    Action: GenericNavigationAction,
+    ScreenOptions: {...},
+    RouterOptions: DefaultRouterOptions,
+    NavProp,
+  >(
+    routerFactory: RouterFactory<State, Action, RouterOptions>,
+    options: {|
+      ...$Exact<RouterOptions>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+      +children?: React$Node,
+    |},
+  ) => {|
+    +state: State,
+    +descriptors: {| +[key: string]: Descriptor<NavProp, ScreenOptions> |},
+    +navigation: NavProp,
+  |};
+
+  /**
+   * EdgeInsets
+   */
+
+  declare type EdgeInsets = {|
+    +top: number,
+    +right: number,
+    +bottom: number,
+    +left: number,
+  |};
+
+  /**
+   * TransitionPreset
+   */
+
+  declare export type TransitionSpec =
+    | {|
+        animation: 'spring',
+        config: $Diff<
+          SpringAnimationConfigSingle,
+          { toValue: number | AnimatedValue, ... },
+        >,
+      |}
+    | {|
+        animation: 'timing',
+        config: $Diff<
+          TimingAnimationConfigSingle,
+          { toValue: number | AnimatedValue, ... },
+        >,
+      |};
+
+  declare export type StackCardInterpolationProps = {|
+    +current: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +next?: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +index: number,
+    +closing: AnimatedInterpolation,
+    +swiping: AnimatedInterpolation,
+    +inverted: AnimatedInterpolation,
+    +layouts: {|
+      +screen: {| +width: number, +height: number |},
+    |},
+    +insets: EdgeInsets,
+  |};
+  declare export type StackCardInterpolatedStyle = {|
+    containerStyle?: AnimatedViewStyleProp,
+    cardStyle?: AnimatedViewStyleProp,
+    overlayStyle?: AnimatedViewStyleProp,
+    shadowStyle?: AnimatedViewStyleProp,
+  |};
+  declare export type StackCardStyleInterpolator = (
+    props: StackCardInterpolationProps,
+  ) => StackCardInterpolatedStyle;
+
+  declare export type StackHeaderInterpolationProps = {|
+    +current: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +next?: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +layouts: {|
+      +header: {| +width: number, +height: number |},
+      +screen: {| +width: number, +height: number |},
+      +title?: {| +width: number, +height: number |},
+      +leftLabel?: {| +width: number, +height: number |},
+    |},
+  |};
+  declare export type StackHeaderInterpolatedStyle = {|
+    leftLabelStyle?: AnimatedViewStyleProp,
+    leftButtonStyle?: AnimatedViewStyleProp,
+    rightButtonStyle?: AnimatedViewStyleProp,
+    titleStyle?: AnimatedViewStyleProp,
+    backgroundStyle?: AnimatedViewStyleProp,
+  |};
+  declare export type StackHeaderStyleInterpolator = (
+    props: StackHeaderInterpolationProps,
+  ) => StackHeaderInterpolatedStyle;
+
+  declare type GestureDirection =
+    | 'horizontal'
+    | 'horizontal-inverted'
+    | 'vertical'
+    | 'vertical-inverted';
+
+  declare export type TransitionPreset = {|
+    +gestureDirection: GestureDirection,
+    +transitionSpec: {|
+      +open: TransitionSpec,
+      +close: TransitionSpec,
+    |},
+    +cardStyleInterpolator: StackCardStyleInterpolator,
+    +headerStyleInterpolator: StackHeaderStyleInterpolator,
+  |};
+
+  /**
+   * Stack options
+   */
+
+  declare export type StackDescriptor = Descriptor<
+    StackNavigationProp<>,
+    StackOptions,
+  >;
+
+  declare type Scene<T> = {|
+    +route: T,
+    +descriptor: StackDescriptor,
+    +progress: {|
+      +current: AnimatedInterpolation,
+      +next?: AnimatedInterpolation,
+      +previous?: AnimatedInterpolation,
+    |},
+  |};
+
+  declare export type StackHeaderProps = {|
+    +mode: 'float' | 'screen',
+    +layout: {| +width: number, +height: number |},
+    +insets: EdgeInsets,
+    +scene: Scene<Route<>>,
+    +previous?: Scene<Route<>>,
+    +navigation: StackNavigationProp<ParamListBase>,
+    +styleInterpolator: StackHeaderStyleInterpolator,
+  |};
+
+  declare export type StackHeaderLeftButtonProps = $Partial<{|
+    +onPress: (() => void),
+    +pressColorAndroid: string;
+    +backImage: (props: {| tintColor: string |}) => React$Node,
+    +tintColor: string,
+    +label: string,
+    +truncatedLabel: string,
+    +labelVisible: boolean,
+    +labelStyle: AnimatedTextStyleProp,
+    +allowFontScaling: boolean,
+    +onLabelLayout: LayoutEvent => void,
+    +screenLayout: {| +width: number, +height: number |},
+    +titleLayout: {| +width: number, +height: number |},
+    +canGoBack: boolean,
+  |}>;
+
+  declare type StackHeaderTitleInputBase = {
+    +onLayout: LayoutEvent => void,
+    +children: string,
+    +allowFontScaling: ?boolean,
+    +tintColor: ?string,
+    +style: ?AnimatedTextStyleProp,
+    ...
+  };
+
+  declare export type StackHeaderTitleInputProps =
+    $Exact<StackHeaderTitleInputBase>;
+
+  declare export type StackOptions = $Partial<{|
+    +title: string,
+    +header: StackHeaderProps => React$Node,
+    +headerShown: boolean,
+    +cardShadowEnabled: boolean,
+    +cardOverlayEnabled: boolean,
+    +cardOverlay: {| style: ViewStyleProp |} => React$Node,
+    +cardStyle: ViewStyleProp,
+    +animationEnabled: boolean,
+    +animationTypeForReplace: 'push' | 'pop',
+    +gestureEnabled: boolean,
+    +gestureResponseDistance: {| vertical?: number, horizontal?: number |},
+    +gestureVelocityImpact: number,
+    +safeAreaInsets: $Partial<EdgeInsets>,
+    // Transition
+    ...TransitionPreset,
+    // Header
+    +headerTitle: string | (StackHeaderTitleInputProps => React$Node),
+    +headerTitleAlign: 'left' | 'center',
+    +headerTitleStyle: AnimatedTextStyleProp,
+    +headerTitleContainerStyle: ViewStyleProp,
+    +headerTintColor: string,
+    +headerTitleAllowFontScaling: boolean,
+    +headerBackAllowFontScaling: boolean,
+    +headerBackTitle: string | null,
+    +headerBackTitleStyle: TextStyleProp,
+    +headerBackTitleVisible: boolean,
+    +headerTruncatedBackTitle: string,
+    +headerLeft: StackHeaderLeftButtonProps => React$Node,
+    +headerLeftContainerStyle: ViewStyleProp,
+    +headerRight: {| tintColor?: string |} => React$Node,
+    +headerRightContainerStyle: ViewStyleProp,
+    +headerBackImage: $PropertyType<StackHeaderLeftButtonProps, 'backImage'>,
+    +headerPressColorAndroid: string,
+    +headerBackground: ({| style: ViewStyleProp |}) => React$Node,
+    +headerStyle: ViewStyleProp,
+    +headerTransparent: boolean,
+    +headerStatusBarHeight: number,
+  |}>;
+
+  /**
+   * Stack navigation prop
+   */
+
+  declare export type StackNavigationEventMap = {|
+    ...EventMapCore<StackNavigationState>,
+    +transitionStart: {|
+      +data: {| +closing: boolean |},
+      +canPreventDefault: false,
+    |},
+    +transitionEnd: {|
+      +data: {| +closing: boolean |},
+      +canPreventDefault: false,
+    |},
+    +gestureStart: {| +data: void, +canPreventDefault: false |},
+    +gestureEnd: {| +data: void, +canPreventDefault: false |},
+    +gestureCancel: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare type InexactStackNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = StackOptions,
+    EventMap: EventMapBase = StackNavigationEventMap,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      StackNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +replace: SimpleNavigate<ParamList>,
+    +push: SimpleNavigate<ParamList>,
+    +pop: (count?: number) => void,
+    +popToTop: () => void,
+    ...
+  };
+
+  declare export type StackNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = StackOptions,
+    EventMap: EventMapBase = StackNavigationEventMap,
+  > = $Exact<InexactStackNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous stack exports
+   */
+
+  declare type StackNavigationConfig = {|
+    +mode?: 'card' | 'modal',
+    +headerMode?: 'float' | 'screen' | 'none',
+    +keyboardHandlingEnabled?: boolean,
+    +detachInactiveScreens?: boolean,
+  |};
+
+  declare export type ExtraStackNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...StackRouterOptions,
+    ...StackNavigationConfig,
+  |};
+
+  declare export type StackNavigatorProps<
+    NavProp: InexactStackNavigationProp<> = StackNavigationProp<>,
+  > = {|
+    ...ExtraStackNavigatorProps,
+    ...ScreenOptionsProp<StackOptions, NavProp>,
+  |};
+
+  /**
+   * Bottom tab options
+   */
+
+  declare export type BottomTabBarButtonProps = {|
+    ...$Diff<
+      TouchableWithoutFeedbackProps,
+      {| onPress?: ?(event: PressEvent) => mixed |},
+    >,
+    +to?: string,
+    +children: React$Node,
+    +onPress?: (MouseEvent | PressEvent) => void,
+  |};
+
+  declare export type TabBarVisibilityAnimationConfig =
+    | {|
+        +animation: 'spring',
+        +config?: $Diff<
+          SpringAnimationConfigSingle,
+          { toValue: number | AnimatedValue, useNativeDriver: boolean, ... },
+        >,
+      |}
+    | {|
+        +animation: 'timing',
+        +config?: $Diff<
+          TimingAnimationConfigSingle,
+          { toValue: number | AnimatedValue, useNativeDriver: boolean, ... },
+        >,
+      |};
+
+  declare export type BottomTabOptions = $Partial<{|
+    +title: string,
+    +tabBarLabel:
+      | string
+      | ({| focused: boolean, color: string |}) => React$Node,
+    +tabBarIcon: ({|
+      focused: boolean,
+      color: string,
+      size: number,
+    |}) => React$Node,
+    +tabBarBadge: number | string,
+    +tabBarBadgeStyle: TextStyleProp,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+    +tabBarVisible: boolean,
+    +tabBarVisibilityAnimationConfig: $Partial<{|
+      +show: TabBarVisibilityAnimationConfig,
+      +hide: TabBarVisibilityAnimationConfig,
+    |}>,
+    +tabBarButton: BottomTabBarButtonProps => React$Node,
+    +unmountOnBlur: boolean,
+  |}>;
+
+  /**
+   * Bottom tab navigation prop
+   */
+
+  declare export type BottomTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+    +tabLongPress: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare type InexactTabNavigationProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList>,
+    Options: {...},
+    EventMap: EventMapBase,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      TabNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +jumpTo: SimpleNavigate<ParamList>,
+    ...
+  };
+
+  declare export type InexactBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = BottomTabOptions,
+    EventMap: EventMapBase = BottomTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type BottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = BottomTabOptions,
+    EventMap: EventMapBase = BottomTabNavigationEventMap,
+  > = $Exact<InexactBottomTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous bottom tab exports
+   */
+
+  declare export type BottomTabDescriptor = Descriptor<
+    BottomTabNavigationProp<>,
+    BottomTabOptions,
+  >;
+
+  declare export type BottomTabBarOptions = $Partial<{|
+    +keyboardHidesTabBar: boolean,
+    +activeTintColor: string,
+    +inactiveTintColor: string,
+    +activeBackgroundColor: string,
+    +inactiveBackgroundColor: string,
+    +allowFontScaling: boolean,
+    +showLabel: boolean,
+    +showIcon: boolean,
+    +labelStyle: TextStyleProp,
+    +iconStyle: TextStyleProp,
+    +tabStyle: ViewStyleProp,
+    +labelPosition: 'beside-icon' | 'below-icon',
+    +adaptive: boolean,
+    +safeAreaInsets: $Partial<EdgeInsets>,
+    +style: ViewStyleProp,
+  |}>;
+
+  declare type BottomTabNavigationBuilderResult = {|
+    +state: TabNavigationState,
+    +navigation: BottomTabNavigationProp<>,
+    +descriptors: {| +[key: string]: BottomTabDescriptor |},
+  |};
+
+  declare export type BottomTabBarProps = {|
+    ...BottomTabBarOptions,
+    ...BottomTabNavigationBuilderResult,
+  |}
+
+  declare type BottomTabNavigationConfig = {|
+    +lazy?: boolean,
+    +tabBar?: BottomTabBarProps => React$Node,
+    +tabBarOptions?: BottomTabBarOptions,
+    +detachInactiveScreens?: boolean,
+  |};
+
+  declare export type ExtraBottomTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...BottomTabNavigationConfig,
+  |};
+
+  declare export type BottomTabNavigatorProps<
+    NavProp: InexactBottomTabNavigationProp<> = BottomTabNavigationProp<>,
+  > = {|
+    ...ExtraBottomTabNavigatorProps,
+    ...ScreenOptionsProp<BottomTabOptions, NavProp>,
+  |};
+
+  /**
+   * Material bottom tab options
+   */
+
+  declare export type MaterialBottomTabOptions = $Partial<{|
+    +title: string,
+    +tabBarColor: string,
+    +tabBarLabel: string,
+    +tabBarIcon:
+      | string
+      | ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarBadge: boolean | number | string,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+  |}>;
+
+  /**
+   * Material bottom tab navigation prop
+   */
+
+  declare export type MaterialBottomTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+  |};
+
+  declare export type InexactMaterialBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialBottomTabOptions,
+    EventMap: EventMapBase = MaterialBottomTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type MaterialBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialBottomTabOptions,
+    EventMap: EventMapBase = MaterialBottomTabNavigationEventMap,
+  > = $Exact<InexactMaterialBottomTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous material bottom tab exports
+   */
+
+  declare export type PaperFont = {|
+    +fontFamily: string,
+    +fontWeight?:
+      | 'normal'
+      | 'bold'
+      | '100'
+      | '200'
+      | '300'
+      | '400'
+      | '500'
+      | '600'
+      | '700'
+      | '800'
+      | '900',
+  |};
+
+  declare export type PaperFonts = {|
+    +regular: Font,
+    +medium: Font,
+    +light: Font,
+    +thin: Font,
+  |};
+
+  declare export type PaperTheme = {|
+    +dark: boolean,
+    +mode?: 'adaptive' | 'exact',
+    +roundness: number,
+    +colors: {|
+      +primary: string,
+      +background: string,
+      +surface: string,
+      +accent: string,
+      +error: string,
+      +text: string,
+      +onSurface: string,
+      +onBackground: string,
+      +disabled: string,
+      +placeholder: string,
+      +backdrop: string,
+      +notification: string,
+    |},
+    +fonts: PaperFonts,
+    +animation: {|
+      +scale: number,
+    |},
+  |};
+
+  declare export type PaperRoute = {|
+    +key: string,
+    +title?: string,
+    +icon?: any,
+    +badge?: string | number | boolean,
+    +color?: string,
+    +accessibilityLabel?: string,
+    +testID?: string,
+  |};
+
+  declare export type PaperTouchableProps = {|
+    ...TouchableWithoutFeedbackProps,
+    +key: string,
+    +route: PaperRoute,
+    +children: React$Node,
+    +borderless?: boolean,
+    +centered?: boolean,
+    +rippleColor?: string,
+  |};
+
+  declare export type MaterialBottomTabNavigationConfig = {|
+    +shifting?: boolean,
+    +labeled?: boolean,
+    +renderTouchable?: PaperTouchableProps => React$Node,
+    +activeColor?: string,
+    +inactiveColor?: string,
+    +sceneAnimationEnabled?: boolean,
+    +keyboardHidesNavigationBar?: boolean,
+    +barStyle?: ViewStyleProp,
+    +style?: ViewStyleProp,
+    +theme?: PaperTheme,
+  |};
+
+  declare export type ExtraMaterialBottomTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...MaterialBottomTabNavigationConfig,
+  |};
+
+  declare export type MaterialBottomTabNavigatorProps<
+    NavProp: InexactMaterialBottomTabNavigationProp<> =
+      MaterialBottomTabNavigationProp<>,
+  > = {|
+    ...ExtraMaterialBottomTabNavigatorProps,
+    ...ScreenOptionsProp<MaterialBottomTabOptions, NavProp>,
+  |};
+
+  /**
+   * Material top tab options
+   */
+
+  declare export type MaterialTopTabOptions = $Partial<{|
+    +title: string,
+    +tabBarLabel:
+      | string
+      | ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarIcon: ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+  |}>;
+
+  /**
+   * Material top tab navigation prop
+   */
+
+  declare export type MaterialTopTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+    +tabLongPress: {| +data: void, +canPreventDefault: false |},
+    +swipeStart: {| +data: void, +canPreventDefault: false |},
+    +swipeEnd: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare export type InexactMaterialTopTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialTopTabOptions,
+    EventMap: EventMapBase = MaterialTopTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type MaterialTopTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialTopTabOptions,
+    EventMap: EventMapBase = MaterialTopTabNavigationEventMap,
+  > = $Exact<InexactMaterialTopTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous material top tab exports
+   */
+
+  declare type MaterialTopTabPagerCommonProps = {|
+    +keyboardDismissMode: 'none' | 'on-drag' | 'auto',
+    +swipeEnabled: boolean,
+    +swipeVelocityImpact?: number,
+    +springVelocityScale?: number,
+    +springConfig: $Partial<{|
+      +damping: number,
+      +mass: number,
+      +stiffness: number,
+      +restSpeedThreshold: number,
+      +restDisplacementThreshold: number,
+    |}>,
+    +timingConfig: $Partial<{|
+      +duration: number,
+    |}>,
+  |};
+
+  declare export type MaterialTopTabPagerProps = {|
+    ...MaterialTopTabPagerCommonProps,
+    +onSwipeStart?: () => void,
+    +onSwipeEnd?: () => void,
+    +onIndexChange: (index: number) => void,
+    +navigationState: TabNavigationState,
+    +layout: {| +width: number, +height: number |},
+    +removeClippedSubviews: boolean,
+    +children: ({|
+      +addListener: (type: 'enter', listener: number => void) => void,
+      +removeListener: (type: 'enter', listener: number => void) => void,
+      +position: any, // Reanimated.Node<number>
+      +render: React$Node => React$Node,
+      +jumpTo: string => void,
+    |}) => React$Node,
+    +gestureHandlerProps: PanGestureHandlerProps,
+  |};
+
+  declare export type MaterialTopTabBarIndicatorProps = {|
+    +navigationState: TabNavigationState,
+    +width: string,
+    +style?: ViewStyleProp,
+    +getTabWidth: number => number,
+  |};
+
+  declare export type MaterialTopTabBarOptions = $Partial<{|
+    +scrollEnabled: boolean,
+    +bounces: boolean,
+    +pressColor: string,
+    +pressOpacity: number,
+    +getAccessible: ({| +route: Route<> |}) => boolean,
+    +renderBadge: ({| +route: Route<> |}) => React$Node,
+    +renderIndicator: MaterialTopTabBarIndicatorProps => React$Node,
+    +tabStyle: ViewStyleProp,
+    +indicatorStyle: ViewStyleProp,
+    +indicatorContainerStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+    +contentContainerStyle: ViewStyleProp,
+    +style: ViewStyleProp,
+    +activeTintColor: string,
+    +inactiveTintColor: string,
+    +iconStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+    +showLabel: boolean,
+    +showIcon: boolean,
+    +allowFontScaling: boolean,
+  |}>;
+
+  declare export type MaterialTopTabDescriptor = Descriptor<
+    MaterialBottomTabNavigationProp<>,
+    MaterialBottomTabOptions,
+  >;
+
+  declare type MaterialTopTabNavigationBuilderResult = {|
+    +state: TabNavigationState,
+    +navigation: MaterialTopTabNavigationProp<>,
+    +descriptors: {| +[key: string]: MaterialTopTabDescriptor |},
+  |};
+
+  declare export type MaterialTopTabBarProps = {|
+    ...MaterialTopTabBarOptions,
+    ...MaterialTopTabNavigationBuilderResult,
+    +layout: {| +width: number, +height: number |},
+    +position: any, // Reanimated.Node<number>
+    +jumpTo: string => void,
+  |};
+
+  declare export type MaterialTopTabNavigationConfig = {|
+    ...$Partial<MaterialTopTabPagerCommonProps>,
+    +position?: any, // Reanimated.Value<number>
+    +tabBarPosition?: 'top' | 'bottom',
+    +initialLayout?: $Partial<{| +width: number, +height: number |}>,
+    +lazy?: boolean,
+    +lazyPreloadDistance?: number,
+    +removeClippedSubviews?: boolean,
+    +sceneContainerStyle?: ViewStyleProp,
+    +style?: ViewStyleProp,
+    +gestureHandlerProps?: PanGestureHandlerProps,
+    +pager?: MaterialTopTabPagerProps => React$Node,
+    +lazyPlaceholder?: ({| +route: Route<> |}) => React$Node,
+    +tabBar?: MaterialTopTabBarProps => React$Node,
+    +tabBarOptions?: MaterialTopTabBarOptions,
+  |};
+
+  declare export type ExtraMaterialTopTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...MaterialTopTabNavigationConfig,
+  |};
+
+  declare export type MaterialTopTabNavigatorProps<
+    NavProp: InexactMaterialTopTabNavigationProp<> =
+      MaterialTopTabNavigationProp<>,
+  > = {|
+    ...ExtraMaterialTopTabNavigatorProps,
+    ...ScreenOptionsProp<MaterialTopTabOptions, NavProp>,
+  |};
+
+  /**
+   * Drawer options
+   */
+
+  declare export type DrawerOptions = $Partial<{|
+    title: string,
+    drawerLabel:
+      | string
+      | ({| +color: string, +focused: boolean |}) => React$Node,
+    drawerIcon: ({|
+      +color: string,
+      +size: number,
+      +focused: boolean,
+    |}) => React$Node,
+    gestureEnabled: boolean,
+    swipeEnabled: boolean,
+    unmountOnBlur: boolean,
+  |}>;
+
+  /**
+   * Drawer navigation prop
+   */
+
+  declare export type DrawerNavigationEventMap = {|
+    ...EventMapCore<DrawerNavigationState>,
+    +drawerOpen: {| +data: void, +canPreventDefault: false |},
+    +drawerClose: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare export type InexactDrawerNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = DrawerOptions,
+    EventMap: EventMapBase = DrawerNavigationEventMap,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      DrawerNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +jumpTo: SimpleNavigate<ParamList>,
+    +openDrawer: () => void,
+    +closeDrawer: () => void,
+    +toggleDrawer: () => void,
+    ...
+  };
+
+  declare export type DrawerNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = DrawerOptions,
+    EventMap: EventMapBase = DrawerNavigationEventMap,
+  > = $Exact<InexactDrawerNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous drawer exports
+   */
+
+  declare export type DrawerDescriptor = Descriptor<
+    DrawerNavigationProp<>,
+    DrawerOptions,
+  >;
+
+  declare export type DrawerItemListBaseOptions = $Partial<{|
+    +activeTintColor: string,
+    +activeBackgroundColor: string,
+    +inactiveTintColor: string,
+    +inactiveBackgroundColor: string,
+    +itemStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+  |}>;
+
+  declare export type DrawerContentOptions = $Partial<{|
+    ...DrawerItemListBaseOptions,
+    +contentContainerStyle: ViewStyleProp,
+    +style: ViewStyleProp,
+  |}>;
+
+  declare type DrawerNavigationBuilderResult = {|
+    +state: DrawerNavigationState,
+    +navigation: DrawerNavigationProp<>,
+    +descriptors: {| +[key: string]: DrawerDescriptor |},
+  |};
+
+  declare export type DrawerContentProps = {|
+    ...DrawerContentOptions,
+    ...DrawerNavigationBuilderResult,
+    +progress: any, // Reanimated.Node<number>
+  |};
+
+  declare export type DrawerNavigationConfig = {|
+    +drawerPosition?: 'left' | 'right',
+    +drawerType?: 'front' | 'back' | 'slide' | 'permanent',
+    +edgeWidth?: number,
+    +hideStatusBar?: boolean,
+    +keyboardDismissMode?: 'on-drag' | 'none',
+    +minSwipeDistance?: number,
+    +overlayColor?: string,
+    +statusBarAnimation?: 'slide' | 'none' | 'fade',
+    +gestureHandlerProps?: PanGestureHandlerProps,
+    +lazy?: boolean,
+    +drawerContent?: DrawerContentProps => React$Node,
+    +drawerContentOptions?: DrawerContentOptions,
+    +sceneContainerStyle?: ViewStyleProp,
+    +drawerStyle?: ViewStyleProp,
+    +detachInactiveScreens?: boolean,
+  |};
+
+  declare export type ExtraDrawerNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...DrawerRouterOptions,
+    ...DrawerNavigationConfig,
+  |};
+
+  declare export type DrawerNavigatorProps<
+    NavProp: InexactDrawerNavigationProp<> = DrawerNavigationProp<>,
+  > = {|
+    ...ExtraDrawerNavigatorProps,
+    ...ScreenOptionsProp<DrawerOptions, NavProp>,
+  |};
+
+  /**
+   * BaseNavigationContainer
+   */
+
+  declare export type BaseNavigationContainerProps = {|
+    +children: React$Node,
+    +initialState?: PossiblyStaleNavigationState,
+    +onStateChange?: (state: ?PossiblyStaleNavigationState) => void,
+    +independent?: boolean,
+  |};
+
+  declare export type ContainerEventMap = {|
+    ...GlobalEventMap<PossiblyStaleNavigationState>,
+    +options: {|
+      +data: {| +options: { +[key: string]: mixed, ... } |},
+      +canPreventDefault: false,
+    |},
+    +__unsafe_action__: {|
+      +data: {|
+        +action: GenericNavigationAction,
+        +noop: boolean,
+      |},
+      +canPreventDefault: false,
+    |},
+  |};
+
+  declare export type BaseNavigationContainerInterface = {|
+    ...$Exact<NavigationHelpers<
+      ParamListBase,
+      PossiblyStaleNavigationState,
+      ContainerEventMap,
+    >>,
+    +setParams: (params: ScreenParams) => void,
+    +resetRoot: (state?: ?PossiblyStaleNavigationState) => void,
+    +getRootState: () => PossiblyStaleNavigationState,
+  |};
+
+  /**
+   * State utils
+   */
+
+  declare export type GetStateFromPath = (
+    path: string,
+    options?: LinkingConfig,
+  ) => PossiblyStaleNavigationState;
+
+  declare export type GetPathFromState = (
+    state?: ?PossiblyStaleNavigationState,
+    options?: LinkingConfig,
+  ) => string;
+
+  declare export type GetFocusedRouteNameFromRoute =
+    PossiblyStaleRoute<string> => ?string;
+
+  /**
+   * Linking
+   */
+
+  declare export type ScreenLinkingConfig = {|
+    +path?: string,
+    +exact?: boolean,
+    +parse?: {| +[param: string]: string => mixed |},
+    +stringify?: {| +[param: string]: mixed => string |},
+    +screens?: ScreenLinkingConfigMap,
+    +initialRouteName?: string,
+  |};
+
+  declare export type ScreenLinkingConfigMap = {|
+    +[routeName: string]: string | ScreenLinkingConfig,
+  |};
+
+  declare export type LinkingConfig = {|
+    +initialRouteName?: string,
+    +screens: ScreenLinkingConfigMap,
+  |};
+
+  declare export type LinkingOptions = {|
+    +enabled?: boolean,
+    +prefixes: $ReadOnlyArray<string>,
+    +config?: LinkingConfig,
+    +getStateFromPath?: GetStateFromPath,
+    +getPathFromState?: GetPathFromState,
+  |};
+
+  /**
+   * NavigationContainer
+   */
+
+  declare export type Theme = {|
+    +dark: boolean,
+    +colors: {|
+      +primary: string,
+      +background: string,
+      +card: string,
+      +text: string,
+      +border: string,
+    |},
+  |};
+
+  declare export type NavigationContainerType = React$AbstractComponent<
+    {|
+      ...BaseNavigationContainerProps,
+      +theme?: Theme,
+      +linking?: LinkingOptions,
+      +fallback?: React$Node,
+      +onReady?: () => mixed,
+    |},
+    BaseNavigationContainerInterface,
+  >;
+
+  //---------------------------------------------------------------------------
+  // SECTION 2: EXPORTED MODULE
+  // This section defines the module exports and contains exported types that
+  // are not present in any other React Navigation libdef.
+  //---------------------------------------------------------------------------
+
+  /**
+   * createMaterialTopTabNavigator
+   */
+
+  declare export var createMaterialTopTabNavigator: CreateNavigator<
+    TabNavigationState,
+    MaterialTopTabOptions,
+    MaterialTopTabNavigationEventMap,
+    ExtraMaterialTopTabNavigatorProps,
+  >;
+
+  /**
+   * MaterialTopTabView
+   */
+
+  declare export type MaterialTopTabViewProps = {|
+    ...MaterialTopTabNavigationConfig,
+    ...MaterialTopTabNavigationBuilderResult,
+  |};
+  declare export var MaterialTopTabView: React$ComponentType<
+    MaterialTopTabViewProps,
+  >;
+
+  /**
+   * MaterialTopTabBar
+   */
+
+  declare export var MaterialTopTabBar: React$ComponentType<
+    MaterialTopTabBarProps,
+  >;
+
+}

--- a/flow-typed/npm/@react-navigation/native_v5.x.x.js
+++ b/flow-typed/npm/@react-navigation/native_v5.x.x.js
@@ -1,0 +1,2215 @@
+// flow-typed signature: b2255225d40384acddcae0e4503bf084
+// flow-typed version: 510a06cce0/@react-navigation/native_v5.x.x/flow_>=v0.104.x
+
+declare module '@react-navigation/native' {
+
+  //---------------------------------------------------------------------------
+  // SECTION 1: IDENTICAL TYPE DEFINITIONS
+  // This section is identical across all React Navigation libdefs and contains
+  // shared definitions. We wish we could make it DRY and import from a shared
+  // definition, but that isn't yet possible.
+  //---------------------------------------------------------------------------
+
+  /**
+   * We start with some definitions that we have copy-pasted from React Native
+   * source files.
+   */
+
+  // This is a bastardization of the true StyleObj type located in
+  // react-native/Libraries/StyleSheet/StyleSheetTypes. We unfortunately can't
+  // import that here, and it's too lengthy (and consequently too brittle) to
+  // copy-paste here either.
+  declare type StyleObj =
+    | null
+    | void
+    | number
+    | false
+    | ''
+    | $ReadOnlyArray<StyleObj>
+    | { [name: string]: any, ... };
+  declare type ViewStyleProp = StyleObj;
+  declare type TextStyleProp = StyleObj;
+  declare type AnimatedViewStyleProp = StyleObj;
+  declare type AnimatedTextStyleProp = StyleObj;
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/animations/Animation.js
+  declare type EndResult = { finished: boolean, ... };
+  declare type EndCallback = (result: EndResult) => void;
+  declare interface Animation {
+    start(
+      fromValue: number,
+      onUpdate: (value: number) => void,
+      onEnd: ?EndCallback,
+      previousAnimation: ?Animation,
+      animatedValue: AnimatedValue,
+    ): void;
+    stop(): void;
+  }
+  declare type AnimationConfig = {
+    isInteraction?: boolean,
+    useNativeDriver: boolean,
+    onComplete?: ?EndCallback,
+    iterations?: number,
+    ...
+  };
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedTracking.js
+  declare interface AnimatedTracking {
+    constructor(
+      value: AnimatedValue,
+      parent: any,
+      animationClass: any,
+      animationConfig: Object,
+      callback?: ?EndCallback,
+    ): void;
+    update(): void;
+  }
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedValue.js
+  declare type ValueListenerCallback = (state: { value: number, ... }) => void;
+  declare interface AnimatedValue {
+    constructor(value: number): void;
+    setValue(value: number): void;
+    setOffset(offset: number): void;
+    flattenOffset(): void;
+    extractOffset(): void;
+    addListener(callback: ValueListenerCallback): string;
+    removeListener(id: string): void;
+    removeAllListeners(): void;
+    stopAnimation(callback?: ?(value: number) => void): void;
+    resetAnimation(callback?: ?(value: number) => void): void;
+    interpolate(config: InterpolationConfigType): AnimatedInterpolation;
+    animate(animation: Animation, callback: ?EndCallback): void;
+    stopTracking(): void;
+    track(tracking: AnimatedTracking): void;
+  }
+
+  // Copied from
+  // react-native/Libraries/Animated/src/animations/TimingAnimation.js
+  declare type TimingAnimationConfigSingle = AnimationConfig & {
+    toValue: number | AnimatedValue,
+    easing?: (value: number) => number,
+    duration?: number,
+    delay?: number,
+    ...
+  };
+
+  // Copied from
+  // react-native/Libraries/Animated/src/animations/SpringAnimation.js
+  declare type SpringAnimationConfigSingle = AnimationConfig & {
+    toValue: number | AnimatedValue,
+    overshootClamping?: boolean,
+    restDisplacementThreshold?: number,
+    restSpeedThreshold?: number,
+    velocity?: number,
+    bounciness?: number,
+    speed?: number,
+    tension?: number,
+    friction?: number,
+    stiffness?: number,
+    damping?: number,
+    mass?: number,
+    delay?: number,
+    ...
+  };
+
+  // Copied from react-native/Libraries/Types/CoreEventTypes.js
+  declare type SyntheticEvent<T> = $ReadOnly<{|
+    bubbles: ?boolean,
+    cancelable: ?boolean,
+    currentTarget: number,
+    defaultPrevented: ?boolean,
+    dispatchConfig: $ReadOnly<{|
+      registrationName: string,
+    |}>,
+    eventPhase: ?number,
+    preventDefault: () => void,
+    isDefaultPrevented: () => boolean,
+    stopPropagation: () => void,
+    isPropagationStopped: () => boolean,
+    isTrusted: ?boolean,
+    nativeEvent: T,
+    persist: () => void,
+    target: ?number,
+    timeStamp: number,
+    type: ?string,
+  |}>;
+  declare type Layout = $ReadOnly<{|
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+  |}>;
+  declare type LayoutEvent = SyntheticEvent<
+    $ReadOnly<{|
+      layout: Layout,
+    |}>,
+  >;
+  declare type BlurEvent = SyntheticEvent<
+    $ReadOnly<{|
+      target: number,
+    |}>,
+  >;
+  declare type FocusEvent = SyntheticEvent<
+    $ReadOnly<{|
+      target: number,
+    |}>,
+  >;
+  declare type ResponderSyntheticEvent<T> = $ReadOnly<{|
+    ...SyntheticEvent<T>,
+    touchHistory: $ReadOnly<{|
+      indexOfSingleActiveTouch: number,
+      mostRecentTimeStamp: number,
+      numberActiveTouches: number,
+      touchBank: $ReadOnlyArray<
+        $ReadOnly<{|
+          touchActive: boolean,
+          startPageX: number,
+          startPageY: number,
+          startTimeStamp: number,
+          currentPageX: number,
+          currentPageY: number,
+          currentTimeStamp: number,
+          previousPageX: number,
+          previousPageY: number,
+          previousTimeStamp: number,
+        |}>,
+      >,
+    |}>,
+  |}>;
+  declare type PressEvent = ResponderSyntheticEvent<
+    $ReadOnly<{|
+      changedTouches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
+      force: number,
+      identifier: number,
+      locationX: number,
+      locationY: number,
+      pageX: number,
+      pageY: number,
+      target: ?number,
+      timestamp: number,
+      touches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
+    |}>,
+  >;
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedInterpolation.js
+  declare type ExtrapolateType = 'extend' | 'identity' | 'clamp';
+  declare type InterpolationConfigType = {
+    inputRange: Array<number>,
+    outputRange: Array<number> | Array<string>,
+    easing?: (input: number) => number,
+    extrapolate?: ExtrapolateType,
+    extrapolateLeft?: ExtrapolateType,
+    extrapolateRight?: ExtrapolateType,
+    ...
+  };
+  declare interface AnimatedInterpolation {
+    interpolate(config: InterpolationConfigType): AnimatedInterpolation;
+  }
+
+  // Copied from react-native/Libraries/Components/View/ViewAccessibility.js
+  declare type AccessibilityRole =
+    | 'none'
+    | 'button'
+    | 'link'
+    | 'search'
+    | 'image'
+    | 'keyboardkey'
+    | 'text'
+    | 'adjustable'
+    | 'imagebutton'
+    | 'header'
+    | 'summary'
+    | 'alert'
+    | 'checkbox'
+    | 'combobox'
+    | 'menu'
+    | 'menubar'
+    | 'menuitem'
+    | 'progressbar'
+    | 'radio'
+    | 'radiogroup'
+    | 'scrollbar'
+    | 'spinbutton'
+    | 'switch'
+    | 'tab'
+    | 'tablist'
+    | 'timer'
+    | 'toolbar';
+  declare type AccessibilityActionInfo = $ReadOnly<{
+    name: string,
+    label?: string,
+    ...
+  }>;
+  declare type AccessibilityActionEvent = SyntheticEvent<
+    $ReadOnly<{actionName: string, ...}>,
+  >;
+  declare type AccessibilityState = {
+    disabled?: boolean,
+    selected?: boolean,
+    checked?: ?boolean | 'mixed',
+    busy?: boolean,
+    expanded?: boolean,
+    ...
+  };
+  declare type AccessibilityValue = $ReadOnly<{|
+    min?: number,
+    max?: number,
+    now?: number,
+    text?: string,
+  |}>;
+
+  // Copied from
+  // react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+  declare type Stringish = string;
+  declare type EdgeInsetsProp = $ReadOnly<$Partial<EdgeInsets>>;
+  declare type TouchableWithoutFeedbackProps = $ReadOnly<{|
+    accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
+    accessibilityElementsHidden?: ?boolean,
+    accessibilityHint?: ?Stringish,
+    accessibilityIgnoresInvertColors?: ?boolean,
+    accessibilityLabel?: ?Stringish,
+    accessibilityLiveRegion?: ?('none' | 'polite' | 'assertive'),
+    accessibilityRole?: ?AccessibilityRole,
+    accessibilityState?: ?AccessibilityState,
+    accessibilityValue?: ?AccessibilityValue,
+    accessibilityViewIsModal?: ?boolean,
+    accessible?: ?boolean,
+    children?: ?React$Node,
+    delayLongPress?: ?number,
+    delayPressIn?: ?number,
+    delayPressOut?: ?number,
+    disabled?: ?boolean,
+    focusable?: ?boolean,
+    hitSlop?: ?EdgeInsetsProp,
+    importantForAccessibility?: ?('auto' | 'yes' | 'no' | 'no-hide-descendants'),
+    nativeID?: ?string,
+    onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
+    onBlur?: ?(event: BlurEvent) => mixed,
+    onFocus?: ?(event: FocusEvent) => mixed,
+    onLayout?: ?(event: LayoutEvent) => mixed,
+    onLongPress?: ?(event: PressEvent) => mixed,
+    onPress?: ?(event: PressEvent) => mixed,
+    onPressIn?: ?(event: PressEvent) => mixed,
+    onPressOut?: ?(event: PressEvent) => mixed,
+    pressRetentionOffset?: ?EdgeInsetsProp,
+    rejectResponderTermination?: ?boolean,
+    testID?: ?string,
+    touchSoundDisabled?: ?boolean,
+  |}>;
+
+  // Copied from react-native/Libraries/Image/ImageSource.js
+  declare type ImageURISource = $ReadOnly<{
+    uri?: ?string,
+    bundle?: ?string,
+    method?: ?string,
+    headers?: ?Object,
+    body?: ?string,
+    cache?: ?('default' | 'reload' | 'force-cache' | 'only-if-cached'),
+    width?: ?number,
+    height?: ?number,
+    scale?: ?number,
+    ...
+  }>;
+
+  /**
+   * The following is copied from react-native-gesture-handler's libdef
+   */
+
+  declare type $EventHandlers<ExtraProps: {...}> = {|
+    onGestureEvent?: ($Event<ExtraProps>) => mixed,
+    onHandlerStateChange?: ($Event<ExtraProps>) => mixed,
+    onBegan?: ($Event<ExtraProps>) => mixed,
+    onFailed?: ($Event<ExtraProps>) => mixed,
+    onCancelled?: ($Event<ExtraProps>) => mixed,
+    onActivated?: ($Event<ExtraProps>) => mixed,
+    onEnded?: ($Event<ExtraProps>) => mixed,
+  |};
+
+  declare type HitSlop =
+    | number
+    | {|
+        left?: number,
+        top?: number,
+        right?: number,
+        bottom?: number,
+        vertical?: number,
+        horizontal?: number,
+        width?: number,
+        height?: number,
+      |}
+    | {|
+        width: number,
+        left: number,
+      |}
+    | {|
+        width: number,
+        right: number,
+      |}
+    | {|
+        height: number,
+        top: number,
+      |}
+    | {|
+        height: number,
+        bottom: number,
+      |};
+
+  declare type $GestureHandlerProps<
+    AdditionalProps: {...},
+    ExtraEventsProps: {...}
+  > = $ReadOnly<{|
+    ...$Exact<AdditionalProps>,
+    ...$EventHandlers<ExtraEventsProps>,
+    id?: string,
+    enabled?: boolean,
+    waitFor?: React$Ref<any> | Array<React$Ref<any>>,
+    simultaneousHandlers?: React$Ref<any> | Array<React$Ref<any>>,
+    shouldCancelWhenOutside?: boolean,
+    minPointers?: number,
+    hitSlop?: HitSlop,
+    children?: React$Node,
+  |}>;
+
+  declare type PanGestureHandlerProps = $GestureHandlerProps<
+    {
+      activeOffsetY?: number | [number, number],
+      activeOffsetX?: number | [number, number],
+      failOffsetY?: number | [number, number],
+      failOffsetX?: number | [number, number],
+      minDist?: number,
+      minVelocity?: number,
+      minVelocityX?: number,
+      minVelocityY?: number,
+      minPointers?: number,
+      maxPointers?: number,
+      avgTouches?: boolean,
+      ...
+    },
+    {
+      x: number,
+      y: number,
+      absoluteX: number,
+      absoluteY: number,
+      translationX: number,
+      translationY: number,
+      velocityX: number,
+      velocityY: number,
+      ...
+    }
+  >;
+
+  /**
+   * MAGIC
+   */
+
+  declare type $If<Test: boolean, Then, Else = empty> = $Call<
+    ((true, Then, Else) => Then) & ((false, Then, Else) => Else),
+    Test,
+    Then,
+    Else,
+  >;
+  declare type $IsA<X, Y> = $Call<
+    (Y => true) & (mixed => false),
+    X,
+  >;
+  declare type $IsUndefined<X> = $IsA<X, void>;
+
+  declare type $Partial<T> = $ReadOnly<$Rest<T, {...}>>;
+
+  /**
+   * Actions, state, etc.
+   */
+
+  declare export type ScreenParams = { +[key: string]: mixed, ... };
+
+  declare export type BackAction = {|
+    +type: 'GO_BACK',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type NavigateAction = {|
+    +type: 'NAVIGATE',
+    +payload:
+      | {| +key: string, +params?: ScreenParams |}
+      | {| +name: string, +key?: string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type ResetAction = {|
+    +type: 'RESET',
+    +payload: StaleNavigationState,
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type SetParamsAction = {|
+    +type: 'SET_PARAMS',
+    +payload: {| +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type CommonAction =
+    | BackAction
+    | NavigateAction
+    | ResetAction
+    | SetParamsAction;
+
+  declare type NavigateActionCreator = {|
+    (routeName: string, params?: ScreenParams): NavigateAction,
+    (
+      | {| +key: string, +params?: ScreenParams |}
+      | {| +name: string, +key?: string, +params?: ScreenParams |},
+    ): NavigateAction,
+  |};
+  declare export type CommonActionsType = {|
+    +navigate: NavigateActionCreator,
+    +goBack: () => BackAction,
+    +reset: (state: PossiblyStaleNavigationState) => ResetAction,
+    +setParams: (params: ScreenParams) => SetParamsAction,
+  |};
+
+  declare export type GenericNavigationAction = {|
+    +type: string,
+    +payload?: { +[key: string]: mixed, ... },
+    +source?: string,
+    +target?: string,
+  |};
+
+  declare export type LeafRoute<RouteName: string = string> = {|
+    +key: string,
+    +name: RouteName,
+    +params?: ScreenParams,
+  |};
+  declare export type StateRoute<RouteName: string = string> = {|
+    ...LeafRoute<RouteName>,
+    +state: NavigationState | StaleNavigationState,
+  |};
+  declare export type Route<RouteName: string = string> =
+    | LeafRoute<RouteName>
+    | StateRoute<RouteName>;
+
+  declare export type NavigationState = {|
+    +key: string,
+    +index: number,
+    +routeNames: $ReadOnlyArray<string>,
+    +history?: $ReadOnlyArray<mixed>,
+    +routes: $ReadOnlyArray<Route<>>,
+    +type: string,
+    +stale: false,
+  |};
+
+  declare export type StaleLeafRoute<RouteName: string = string> = {|
+    +key?: string,
+    +name: RouteName,
+    +params?: ScreenParams,
+  |};
+  declare export type StaleStateRoute<RouteName: string = string> = {|
+    ...StaleLeafRoute<RouteName>,
+    +state: StaleNavigationState,
+  |};
+  declare export type StaleRoute<RouteName: string = string> =
+    | StaleLeafRoute<RouteName>
+    | StaleStateRoute<RouteName>;
+  declare export type StaleNavigationState = {|
+    // It's possible to pass React Nav a StaleNavigationState with an undefined
+    // index, but React Nav will always return one with the index set. This is
+    // the same as for the type property below, but in the case of index we tend
+    // to rely on it being set more...
+    +index: number,
+    +history?: $ReadOnlyArray<mixed>,
+    +routes: $ReadOnlyArray<StaleRoute<>>,
+    +type?: string,
+    +stale?: true,
+  |};
+
+  declare export type PossiblyStaleNavigationState =
+    | NavigationState
+    | StaleNavigationState;
+  declare export type PossiblyStaleRoute<RouteName: string = string> =
+    | Route<RouteName>
+    | StaleRoute<RouteName>;
+
+  /**
+   * Routers
+   */
+
+  declare type ActionCreators<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+  > = {
+    +[key: string]: (...args: any) => (Action | State => Action),
+    ...
+  };
+
+  declare export type DefaultRouterOptions = {
+    +initialRouteName?: string,
+    ...
+  };
+
+  declare export type RouterFactory<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+    RouterOptions: DefaultRouterOptions,
+  > = (options: RouterOptions) => Router<State, Action>;
+
+  declare export type ParamListBase = { +[key: string]: ?ScreenParams, ... };
+
+  declare export type RouterConfigOptions = {|
+    +routeNames: $ReadOnlyArray<string>,
+    +routeParamList: ParamListBase,
+  |};
+
+  declare export type Router<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+  > = {|
+    +type: $PropertyType<State, 'type'>,
+    +getInitialState: (options: RouterConfigOptions) => State,
+    +getRehydratedState: (
+      partialState: PossibleStaleNavigationState,
+      options: RouterConfigOptions,
+    ) => State,
+    +getStateForRouteNamesChange: (
+      state: State,
+      options: RouterConfigOptions,
+    ) => State,
+    +getStateForRouteFocus: (state: State, key: string) => State,
+    +getStateForAction: (
+      state: State,
+      action: Action,
+      options: RouterConfigOptions,
+    ) => ?PossiblyStaleNavigationState;
+    +shouldActionChangeFocus: (action: GenericNavigationAction) => boolean,
+    +actionCreators?: ActionCreators<State, Action>,
+  |};
+
+  /**
+   * Stack actions and router
+   */
+
+  declare export type StackNavigationState = {|
+    ...NavigationState,
+    +type: 'stack',
+  |};
+
+  declare export type ReplaceAction = {|
+    +type: 'REPLACE',
+    +payload: {| +name: string, +key?: ?string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PushAction = {|
+    +type: 'PUSH',
+    +payload: {| +name: string, +key?: ?string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PopAction = {|
+    +type: 'POP',
+    +payload: {| +count: number |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PopToTopAction = {|
+    +type: 'POP_TO_TOP',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type StackAction =
+    | CommonAction
+    | ReplaceAction
+    | PushAction
+    | PopAction
+    | PopToTopAction;
+
+  declare export type StackActionsType = {|
+    +replace: (routeName: string, params?: ScreenParams) => ReplaceAction,
+    +push: (routeName: string, params?: ScreenParams) => PushAction,
+    +pop: (count?: number) => PopAction,
+    +popToTop: () => PopToTopAction,
+  |};
+
+  declare export type StackRouterOptions = $Exact<DefaultRouterOptions>;
+
+  /**
+   * Tab actions and router
+   */
+
+  declare export type TabNavigationState = {|
+    ...NavigationState,
+    +type: 'tab',
+    +history: $ReadOnlyArray<{| type: 'route', key: string |}>,
+  |};
+
+  declare export type JumpToAction = {|
+    +type: 'JUMP_TO',
+    +payload: {| +name: string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type TabAction =
+    | CommonAction
+    | JumpToAction;
+
+  declare export type TabActionsType = {|
+    +jumpTo: string => JumpToAction,
+  |};
+
+  declare export type TabRouterOptions = {|
+    ...$Exact<DefaultRouterOptions>,
+    +backBehavior?: 'initialRoute' | 'order' | 'history' | 'none',
+  |};
+
+  /**
+   * Drawer actions and router
+   */
+
+  declare type DrawerHistoryEntry =
+    | {| +type: 'route', +key: string |}
+    | {| +type: 'drawer' |};
+  declare export type DrawerNavigationState = {|
+    ...NavigationState,
+    +type: 'drawer',
+    +history: $ReadOnlyArray<DrawerHistoryEntry>,
+  |};
+
+  declare export type OpenDrawerAction = {|
+    +type: 'OPEN_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type CloseDrawerAction = {|
+    +type: 'CLOSE_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type ToggleDrawerAction = {|
+    +type: 'TOGGLE_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type DrawerAction =
+    | TabAction
+    | OpenDrawerAction
+    | CloseDrawerAction
+    | ToggleDrawerAction;
+
+  declare export type DrawerActionsType = {|
+    ...TabActionsType,
+    +openDrawer: () => OpenDrawerAction,
+    +closeDrawer: () => CloseDrawerAction,
+    +toggleDrawer: () => ToggleDrawerAction,
+  |};
+
+  declare export type DrawerRouterOptions = {|
+    ...TabRouterOptions,
+    +openByDefault?: boolean,
+  |};
+
+  /**
+   * Events
+   */
+
+  declare export type EventMapBase = {
+    +[name: string]: {|
+      +data?: mixed,
+      +canPreventDefault?: boolean,
+    |},
+    ...
+  };
+  declare type EventPreventDefaultProperties<Test: boolean> = $If<
+    Test,
+    {| +defaultPrevented: boolean, +preventDefault: () => void |},
+    {| |},
+  >;
+  declare type EventDataProperties<Data> = $If<
+    $IsUndefined<Data>,
+    {| |},
+    {| +data: Data |},
+  >;
+  declare type EventArg<
+    EventName: string,
+    CanPreventDefault: ?boolean = false,
+    Data = void,
+  > = {|
+    ...EventPreventDefaultProperties<CanPreventDefault>,
+    ...EventDataProperties<Data>,
+    +type: EventName,
+    +target?: string,
+  |};
+  declare type GlobalEventMap<State: PossiblyStaleNavigationState> = {|
+    +state: {| +data: {| +state: State |}, +canPreventDefault: false |},
+  |};
+  declare type EventMapCore<State: PossiblyStaleNavigationState> = {|
+    ...GlobalEventMap<State>,
+    +focus: {| +data: void, +canPreventDefault: false |},
+    +blur: {| +data: void, +canPreventDefault: false |},
+    +beforeRemove: {|
+      +data: {| +action: GenericNavigationAction |},
+      +canPreventDefault: true,
+    |},
+  |};
+  declare type EventListenerCallback<
+    EventName: string,
+    State: PossiblyStaleNavigationState = NavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = (e: EventArg<
+    EventName,
+    $PropertyType<
+      $ElementType<
+        {| ...EventMap, ...EventMapCore<State> |},
+        EventName,
+      >,
+      'canPreventDefault',
+    >,
+    $PropertyType<
+      $ElementType<
+        {| ...EventMap, ...EventMapCore<State> |},
+        EventName,
+      >,
+      'data',
+    >,
+  >) => mixed;
+
+  /**
+   * Navigation prop
+   */
+
+  declare export type SimpleNavigate<ParamList> =
+    <DestinationRouteName: $Keys<ParamList>>(
+      routeName: DestinationRouteName,
+      params: $ElementType<ParamList, DestinationRouteName>,
+    ) => void;
+
+  declare export type Navigate<ParamList> =
+    & SimpleNavigate<ParamList>
+    & <DestinationRouteName: $Keys<ParamList>>(
+        route:
+          | {|
+              key: string,
+              params?: $ElementType<ParamList, DestinationRouteName>,
+            |}
+          | {|
+              name: DestinationRouteName,
+              key?: string,
+              params?: $ElementType<ParamList, DestinationRouteName>,
+            |},
+      ) => void;
+
+  declare type NavigationHelpers<
+    ParamList: ParamListBase,
+    State: PossiblyStaleNavigationState = PossiblyStaleNavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {
+    +navigate: Navigate<ParamList>,
+    +dispatch: (
+      action:
+        | GenericNavigationAction
+        | (State => GenericNavigationAction),
+    ) => void,
+    +reset: PossiblyStaleNavigationState => void,
+    +goBack: () => void,
+    +isFocused: () => boolean,
+    +canGoBack: () => boolean,
+    +dangerouslyGetParent: <Parent: NavigationProp<ParamListBase>>() => ?Parent,
+    +dangerouslyGetState: () => NavigationState,
+    +addListener: <EventName: $Keys<
+      {| ...EventMap, ...EventMapCore<State> |},
+    >>(
+      name: EventName,
+      callback: EventListenerCallback<EventName, State, EventMap>,
+    ) => () => void,
+    +removeListener: <EventName: $Keys<
+      {| ...EventMap, ...EventMapCore<State> |},
+    >>(
+      name: EventName,
+      callback: EventListenerCallback<EventName, State, EventMap>,
+    ) => void,
+    ...
+  };
+
+  declare export type NavigationProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: PossiblyStaleNavigationState = PossiblyStaleNavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {
+    ...$Exact<NavigationHelpers<
+      ParamList,
+      State,
+      EventMap,
+    >>,
+    +setOptions: (options: $Partial<ScreenOptions>) => void,
+    +setParams: (
+      params: $If<
+        $IsUndefined<$ElementType<ParamList, RouteName>>,
+        empty,
+        $Partial<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
+      >,
+    ) => void,
+    ...
+  };
+
+  /**
+   * CreateNavigator
+   */
+
+  declare export type RouteProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList>,
+  > = {|
+    ...LeafRoute<RouteName>,
+    +params: $ElementType<ParamList, RouteName>,
+  |};
+
+  declare export type ScreenListeners<
+    EventMap: EventMapBase = EventMapCore<State>,
+    State: NavigationState = NavigationState,
+  > = $ObjMapi<
+    {| [name: $Keys<EventMap>]: empty |},
+    <K: $Keys<EventMap>>(K, empty) => EventListenerCallback<K, State, EventMap>,
+  >;
+
+  declare type BaseScreenProps<
+    ParamList: ParamListBase,
+    NavProp,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {|
+    +name: RouteName,
+    +options?:
+      | ScreenOptions
+      | ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => ScreenOptions,
+    +listeners?:
+      | ScreenListeners<EventMap, State>
+      | ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => ScreenListeners<EventMap, State>,
+    +initialParams?: $Partial<$ElementType<ParamList, RouteName>>,
+  |};
+
+  declare export type ScreenProps<
+    ParamList: ParamListBase,
+    NavProp,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > =
+    | {|
+        ...BaseScreenProps<
+          ParamList,
+          NavProp,
+          RouteName,
+          State,
+          ScreenOptions,
+          EventMap,
+        >,
+        +component: React$ComponentType<{|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}>,
+      |}
+    | {|
+        ...BaseScreenProps<
+          ParamList,
+          NavProp,
+          RouteName,
+          State,
+          ScreenOptions,
+          EventMap,
+        >,
+        +children: ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => React$Node,
+      |};
+
+  declare export type ScreenComponent<
+    GlobalParamList: ParamListBase,
+    ParamList: ParamListBase,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = <
+    RouteName: $Keys<ParamList>,
+    NavProp: NavigationProp<
+      GlobalParamList,
+      RouteName,
+      State,
+      ScreenOptions,
+      EventMap,
+    >,
+  >(props: ScreenProps<
+    ParamList,
+    NavProp,
+    RouteName,
+    State,
+    ScreenOptions,
+    EventMap,
+  >) => React$Node;
+
+  declare type ScreenOptionsProp<ScreenOptions: {...}, NavProp> = {|
+    +screenOptions?:
+      | ScreenOptions
+      | ({| route: LeafRoute<>, navigation: NavProp |}) => ScreenOptions,
+  |};
+  declare export type ExtraNavigatorPropsBase = {
+    ...$Exact<DefaultRouterOptions>,
+    +children?: React$Node,
+    ...
+  };
+  declare export type NavigatorPropsBase<ScreenOptions: {...}, NavProp> = {
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    ...
+  };
+
+  declare export type CreateNavigator<
+    State: NavigationState,
+    ScreenOptions: {...},
+    EventMap: EventMapBase,
+    ExtraNavigatorProps: ExtraNavigatorPropsBase,
+  > = <
+    GlobalParamList: ParamListBase,
+    ParamList: ParamListBase,
+    NavProp: NavigationHelpers<
+      GlobalParamList,
+      State,
+      EventMap,
+    >,
+  >() => {|
+    +Screen: ScreenComponent<
+      GlobalParamList,
+      ParamList,
+      State,
+      ScreenOptions,
+      EventMap,
+    >,
+    +Navigator: React$ComponentType<{|
+      ...$Exact<ExtraNavigatorProps>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    |}>,
+  |};
+
+  declare export type CreateNavigatorFactory = <
+    State: NavigationState,
+    ScreenOptions: {...},
+    EventMap: EventMapBase,
+    NavProp: NavigationHelpers<
+      ParamListBase,
+      State,
+      EventMap,
+    >,
+    ExtraNavigatorProps: ExtraNavigatorPropsBase,
+  >(
+    navigator: React$ComponentType<{|
+      ...$Exact<ExtraNavigatorPropsBase>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    |}>,
+  ) => CreateNavigator<State, ScreenOptions, EventMap, ExtraNavigatorProps>;
+
+  /**
+   * useNavigationBuilder
+   */
+
+  declare export type Descriptor<
+    NavProp,
+    ScreenOptions: {...} = {...},
+  > = {|
+    +render: () => React$Node,
+    +options: $ReadOnly<ScreenOptions>,
+    +navigation: NavProp,
+  |};
+
+  declare export type UseNavigationBuilder = <
+    State: NavigationState,
+    Action: GenericNavigationAction,
+    ScreenOptions: {...},
+    RouterOptions: DefaultRouterOptions,
+    NavProp,
+  >(
+    routerFactory: RouterFactory<State, Action, RouterOptions>,
+    options: {|
+      ...$Exact<RouterOptions>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+      +children?: React$Node,
+    |},
+  ) => {|
+    +state: State,
+    +descriptors: {| +[key: string]: Descriptor<NavProp, ScreenOptions> |},
+    +navigation: NavProp,
+  |};
+
+  /**
+   * EdgeInsets
+   */
+
+  declare type EdgeInsets = {|
+    +top: number,
+    +right: number,
+    +bottom: number,
+    +left: number,
+  |};
+
+  /**
+   * TransitionPreset
+   */
+
+  declare export type TransitionSpec =
+    | {|
+        animation: 'spring',
+        config: $Diff<
+          SpringAnimationConfigSingle,
+          { toValue: number | AnimatedValue, ... },
+        >,
+      |}
+    | {|
+        animation: 'timing',
+        config: $Diff<
+          TimingAnimationConfigSingle,
+          { toValue: number | AnimatedValue, ... },
+        >,
+      |};
+
+  declare export type StackCardInterpolationProps = {|
+    +current: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +next?: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +index: number,
+    +closing: AnimatedInterpolation,
+    +swiping: AnimatedInterpolation,
+    +inverted: AnimatedInterpolation,
+    +layouts: {|
+      +screen: {| +width: number, +height: number |},
+    |},
+    +insets: EdgeInsets,
+  |};
+  declare export type StackCardInterpolatedStyle = {|
+    containerStyle?: AnimatedViewStyleProp,
+    cardStyle?: AnimatedViewStyleProp,
+    overlayStyle?: AnimatedViewStyleProp,
+    shadowStyle?: AnimatedViewStyleProp,
+  |};
+  declare export type StackCardStyleInterpolator = (
+    props: StackCardInterpolationProps,
+  ) => StackCardInterpolatedStyle;
+
+  declare export type StackHeaderInterpolationProps = {|
+    +current: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +next?: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +layouts: {|
+      +header: {| +width: number, +height: number |},
+      +screen: {| +width: number, +height: number |},
+      +title?: {| +width: number, +height: number |},
+      +leftLabel?: {| +width: number, +height: number |},
+    |},
+  |};
+  declare export type StackHeaderInterpolatedStyle = {|
+    leftLabelStyle?: AnimatedViewStyleProp,
+    leftButtonStyle?: AnimatedViewStyleProp,
+    rightButtonStyle?: AnimatedViewStyleProp,
+    titleStyle?: AnimatedViewStyleProp,
+    backgroundStyle?: AnimatedViewStyleProp,
+  |};
+  declare export type StackHeaderStyleInterpolator = (
+    props: StackHeaderInterpolationProps,
+  ) => StackHeaderInterpolatedStyle;
+
+  declare type GestureDirection =
+    | 'horizontal'
+    | 'horizontal-inverted'
+    | 'vertical'
+    | 'vertical-inverted';
+
+  declare export type TransitionPreset = {|
+    +gestureDirection: GestureDirection,
+    +transitionSpec: {|
+      +open: TransitionSpec,
+      +close: TransitionSpec,
+    |},
+    +cardStyleInterpolator: StackCardStyleInterpolator,
+    +headerStyleInterpolator: StackHeaderStyleInterpolator,
+  |};
+
+  /**
+   * Stack options
+   */
+
+  declare export type StackDescriptor = Descriptor<
+    StackNavigationProp<>,
+    StackOptions,
+  >;
+
+  declare type Scene<T> = {|
+    +route: T,
+    +descriptor: StackDescriptor,
+    +progress: {|
+      +current: AnimatedInterpolation,
+      +next?: AnimatedInterpolation,
+      +previous?: AnimatedInterpolation,
+    |},
+  |};
+
+  declare export type StackHeaderProps = {|
+    +mode: 'float' | 'screen',
+    +layout: {| +width: number, +height: number |},
+    +insets: EdgeInsets,
+    +scene: Scene<Route<>>,
+    +previous?: Scene<Route<>>,
+    +navigation: StackNavigationProp<ParamListBase>,
+    +styleInterpolator: StackHeaderStyleInterpolator,
+  |};
+
+  declare export type StackHeaderLeftButtonProps = $Partial<{|
+    +onPress: (() => void),
+    +pressColorAndroid: string;
+    +backImage: (props: {| tintColor: string |}) => React$Node,
+    +tintColor: string,
+    +label: string,
+    +truncatedLabel: string,
+    +labelVisible: boolean,
+    +labelStyle: AnimatedTextStyleProp,
+    +allowFontScaling: boolean,
+    +onLabelLayout: LayoutEvent => void,
+    +screenLayout: {| +width: number, +height: number |},
+    +titleLayout: {| +width: number, +height: number |},
+    +canGoBack: boolean,
+  |}>;
+
+  declare type StackHeaderTitleInputBase = {
+    +onLayout: LayoutEvent => void,
+    +children: string,
+    +allowFontScaling: ?boolean,
+    +tintColor: ?string,
+    +style: ?AnimatedTextStyleProp,
+    ...
+  };
+
+  declare export type StackHeaderTitleInputProps =
+    $Exact<StackHeaderTitleInputBase>;
+
+  declare export type StackOptions = $Partial<{|
+    +title: string,
+    +header: StackHeaderProps => React$Node,
+    +headerShown: boolean,
+    +cardShadowEnabled: boolean,
+    +cardOverlayEnabled: boolean,
+    +cardOverlay: {| style: ViewStyleProp |} => React$Node,
+    +cardStyle: ViewStyleProp,
+    +animationEnabled: boolean,
+    +animationTypeForReplace: 'push' | 'pop',
+    +gestureEnabled: boolean,
+    +gestureResponseDistance: {| vertical?: number, horizontal?: number |},
+    +gestureVelocityImpact: number,
+    +safeAreaInsets: $Partial<EdgeInsets>,
+    // Transition
+    ...TransitionPreset,
+    // Header
+    +headerTitle: string | (StackHeaderTitleInputProps => React$Node),
+    +headerTitleAlign: 'left' | 'center',
+    +headerTitleStyle: AnimatedTextStyleProp,
+    +headerTitleContainerStyle: ViewStyleProp,
+    +headerTintColor: string,
+    +headerTitleAllowFontScaling: boolean,
+    +headerBackAllowFontScaling: boolean,
+    +headerBackTitle: string | null,
+    +headerBackTitleStyle: TextStyleProp,
+    +headerBackTitleVisible: boolean,
+    +headerTruncatedBackTitle: string,
+    +headerLeft: StackHeaderLeftButtonProps => React$Node,
+    +headerLeftContainerStyle: ViewStyleProp,
+    +headerRight: {| tintColor?: string |} => React$Node,
+    +headerRightContainerStyle: ViewStyleProp,
+    +headerBackImage: $PropertyType<StackHeaderLeftButtonProps, 'backImage'>,
+    +headerPressColorAndroid: string,
+    +headerBackground: ({| style: ViewStyleProp |}) => React$Node,
+    +headerStyle: ViewStyleProp,
+    +headerTransparent: boolean,
+    +headerStatusBarHeight: number,
+  |}>;
+
+  /**
+   * Stack navigation prop
+   */
+
+  declare export type StackNavigationEventMap = {|
+    ...EventMapCore<StackNavigationState>,
+    +transitionStart: {|
+      +data: {| +closing: boolean |},
+      +canPreventDefault: false,
+    |},
+    +transitionEnd: {|
+      +data: {| +closing: boolean |},
+      +canPreventDefault: false,
+    |},
+    +gestureStart: {| +data: void, +canPreventDefault: false |},
+    +gestureEnd: {| +data: void, +canPreventDefault: false |},
+    +gestureCancel: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare type InexactStackNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = StackOptions,
+    EventMap: EventMapBase = StackNavigationEventMap,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      StackNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +replace: SimpleNavigate<ParamList>,
+    +push: SimpleNavigate<ParamList>,
+    +pop: (count?: number) => void,
+    +popToTop: () => void,
+    ...
+  };
+
+  declare export type StackNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = StackOptions,
+    EventMap: EventMapBase = StackNavigationEventMap,
+  > = $Exact<InexactStackNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous stack exports
+   */
+
+  declare type StackNavigationConfig = {|
+    +mode?: 'card' | 'modal',
+    +headerMode?: 'float' | 'screen' | 'none',
+    +keyboardHandlingEnabled?: boolean,
+    +detachInactiveScreens?: boolean,
+  |};
+
+  declare export type ExtraStackNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...StackRouterOptions,
+    ...StackNavigationConfig,
+  |};
+
+  declare export type StackNavigatorProps<
+    NavProp: InexactStackNavigationProp<> = StackNavigationProp<>,
+  > = {|
+    ...ExtraStackNavigatorProps,
+    ...ScreenOptionsProp<StackOptions, NavProp>,
+  |};
+
+  /**
+   * Bottom tab options
+   */
+
+  declare export type BottomTabBarButtonProps = {|
+    ...$Diff<
+      TouchableWithoutFeedbackProps,
+      {| onPress?: ?(event: PressEvent) => mixed |},
+    >,
+    +to?: string,
+    +children: React$Node,
+    +onPress?: (MouseEvent | PressEvent) => void,
+  |};
+
+  declare export type TabBarVisibilityAnimationConfig =
+    | {|
+        +animation: 'spring',
+        +config?: $Diff<
+          SpringAnimationConfigSingle,
+          { toValue: number | AnimatedValue, useNativeDriver: boolean, ... },
+        >,
+      |}
+    | {|
+        +animation: 'timing',
+        +config?: $Diff<
+          TimingAnimationConfigSingle,
+          { toValue: number | AnimatedValue, useNativeDriver: boolean, ... },
+        >,
+      |};
+
+  declare export type BottomTabOptions = $Partial<{|
+    +title: string,
+    +tabBarLabel:
+      | string
+      | ({| focused: boolean, color: string |}) => React$Node,
+    +tabBarIcon: ({|
+      focused: boolean,
+      color: string,
+      size: number,
+    |}) => React$Node,
+    +tabBarBadge: number | string,
+    +tabBarBadgeStyle: TextStyleProp,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+    +tabBarVisible: boolean,
+    +tabBarVisibilityAnimationConfig: $Partial<{|
+      +show: TabBarVisibilityAnimationConfig,
+      +hide: TabBarVisibilityAnimationConfig,
+    |}>,
+    +tabBarButton: BottomTabBarButtonProps => React$Node,
+    +unmountOnBlur: boolean,
+  |}>;
+
+  /**
+   * Bottom tab navigation prop
+   */
+
+  declare export type BottomTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+    +tabLongPress: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare type InexactTabNavigationProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList>,
+    Options: {...},
+    EventMap: EventMapBase,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      TabNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +jumpTo: SimpleNavigate<ParamList>,
+    ...
+  };
+
+  declare export type InexactBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = BottomTabOptions,
+    EventMap: EventMapBase = BottomTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type BottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = BottomTabOptions,
+    EventMap: EventMapBase = BottomTabNavigationEventMap,
+  > = $Exact<InexactBottomTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous bottom tab exports
+   */
+
+  declare export type BottomTabDescriptor = Descriptor<
+    BottomTabNavigationProp<>,
+    BottomTabOptions,
+  >;
+
+  declare export type BottomTabBarOptions = $Partial<{|
+    +keyboardHidesTabBar: boolean,
+    +activeTintColor: string,
+    +inactiveTintColor: string,
+    +activeBackgroundColor: string,
+    +inactiveBackgroundColor: string,
+    +allowFontScaling: boolean,
+    +showLabel: boolean,
+    +showIcon: boolean,
+    +labelStyle: TextStyleProp,
+    +iconStyle: TextStyleProp,
+    +tabStyle: ViewStyleProp,
+    +labelPosition: 'beside-icon' | 'below-icon',
+    +adaptive: boolean,
+    +safeAreaInsets: $Partial<EdgeInsets>,
+    +style: ViewStyleProp,
+  |}>;
+
+  declare type BottomTabNavigationBuilderResult = {|
+    +state: TabNavigationState,
+    +navigation: BottomTabNavigationProp<>,
+    +descriptors: {| +[key: string]: BottomTabDescriptor |},
+  |};
+
+  declare export type BottomTabBarProps = {|
+    ...BottomTabBarOptions,
+    ...BottomTabNavigationBuilderResult,
+  |}
+
+  declare type BottomTabNavigationConfig = {|
+    +lazy?: boolean,
+    +tabBar?: BottomTabBarProps => React$Node,
+    +tabBarOptions?: BottomTabBarOptions,
+    +detachInactiveScreens?: boolean,
+  |};
+
+  declare export type ExtraBottomTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...BottomTabNavigationConfig,
+  |};
+
+  declare export type BottomTabNavigatorProps<
+    NavProp: InexactBottomTabNavigationProp<> = BottomTabNavigationProp<>,
+  > = {|
+    ...ExtraBottomTabNavigatorProps,
+    ...ScreenOptionsProp<BottomTabOptions, NavProp>,
+  |};
+
+  /**
+   * Material bottom tab options
+   */
+
+  declare export type MaterialBottomTabOptions = $Partial<{|
+    +title: string,
+    +tabBarColor: string,
+    +tabBarLabel: string,
+    +tabBarIcon:
+      | string
+      | ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarBadge: boolean | number | string,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+  |}>;
+
+  /**
+   * Material bottom tab navigation prop
+   */
+
+  declare export type MaterialBottomTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+  |};
+
+  declare export type InexactMaterialBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialBottomTabOptions,
+    EventMap: EventMapBase = MaterialBottomTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type MaterialBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialBottomTabOptions,
+    EventMap: EventMapBase = MaterialBottomTabNavigationEventMap,
+  > = $Exact<InexactMaterialBottomTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous material bottom tab exports
+   */
+
+  declare export type PaperFont = {|
+    +fontFamily: string,
+    +fontWeight?:
+      | 'normal'
+      | 'bold'
+      | '100'
+      | '200'
+      | '300'
+      | '400'
+      | '500'
+      | '600'
+      | '700'
+      | '800'
+      | '900',
+  |};
+
+  declare export type PaperFonts = {|
+    +regular: Font,
+    +medium: Font,
+    +light: Font,
+    +thin: Font,
+  |};
+
+  declare export type PaperTheme = {|
+    +dark: boolean,
+    +mode?: 'adaptive' | 'exact',
+    +roundness: number,
+    +colors: {|
+      +primary: string,
+      +background: string,
+      +surface: string,
+      +accent: string,
+      +error: string,
+      +text: string,
+      +onSurface: string,
+      +onBackground: string,
+      +disabled: string,
+      +placeholder: string,
+      +backdrop: string,
+      +notification: string,
+    |},
+    +fonts: PaperFonts,
+    +animation: {|
+      +scale: number,
+    |},
+  |};
+
+  declare export type PaperRoute = {|
+    +key: string,
+    +title?: string,
+    +icon?: any,
+    +badge?: string | number | boolean,
+    +color?: string,
+    +accessibilityLabel?: string,
+    +testID?: string,
+  |};
+
+  declare export type PaperTouchableProps = {|
+    ...TouchableWithoutFeedbackProps,
+    +key: string,
+    +route: PaperRoute,
+    +children: React$Node,
+    +borderless?: boolean,
+    +centered?: boolean,
+    +rippleColor?: string,
+  |};
+
+  declare export type MaterialBottomTabNavigationConfig = {|
+    +shifting?: boolean,
+    +labeled?: boolean,
+    +renderTouchable?: PaperTouchableProps => React$Node,
+    +activeColor?: string,
+    +inactiveColor?: string,
+    +sceneAnimationEnabled?: boolean,
+    +keyboardHidesNavigationBar?: boolean,
+    +barStyle?: ViewStyleProp,
+    +style?: ViewStyleProp,
+    +theme?: PaperTheme,
+  |};
+
+  declare export type ExtraMaterialBottomTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...MaterialBottomTabNavigationConfig,
+  |};
+
+  declare export type MaterialBottomTabNavigatorProps<
+    NavProp: InexactMaterialBottomTabNavigationProp<> =
+      MaterialBottomTabNavigationProp<>,
+  > = {|
+    ...ExtraMaterialBottomTabNavigatorProps,
+    ...ScreenOptionsProp<MaterialBottomTabOptions, NavProp>,
+  |};
+
+  /**
+   * Material top tab options
+   */
+
+  declare export type MaterialTopTabOptions = $Partial<{|
+    +title: string,
+    +tabBarLabel:
+      | string
+      | ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarIcon: ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+  |}>;
+
+  /**
+   * Material top tab navigation prop
+   */
+
+  declare export type MaterialTopTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+    +tabLongPress: {| +data: void, +canPreventDefault: false |},
+    +swipeStart: {| +data: void, +canPreventDefault: false |},
+    +swipeEnd: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare export type InexactMaterialTopTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialTopTabOptions,
+    EventMap: EventMapBase = MaterialTopTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type MaterialTopTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialTopTabOptions,
+    EventMap: EventMapBase = MaterialTopTabNavigationEventMap,
+  > = $Exact<InexactMaterialTopTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous material top tab exports
+   */
+
+  declare type MaterialTopTabPagerCommonProps = {|
+    +keyboardDismissMode: 'none' | 'on-drag' | 'auto',
+    +swipeEnabled: boolean,
+    +swipeVelocityImpact?: number,
+    +springVelocityScale?: number,
+    +springConfig: $Partial<{|
+      +damping: number,
+      +mass: number,
+      +stiffness: number,
+      +restSpeedThreshold: number,
+      +restDisplacementThreshold: number,
+    |}>,
+    +timingConfig: $Partial<{|
+      +duration: number,
+    |}>,
+  |};
+
+  declare export type MaterialTopTabPagerProps = {|
+    ...MaterialTopTabPagerCommonProps,
+    +onSwipeStart?: () => void,
+    +onSwipeEnd?: () => void,
+    +onIndexChange: (index: number) => void,
+    +navigationState: TabNavigationState,
+    +layout: {| +width: number, +height: number |},
+    +removeClippedSubviews: boolean,
+    +children: ({|
+      +addListener: (type: 'enter', listener: number => void) => void,
+      +removeListener: (type: 'enter', listener: number => void) => void,
+      +position: any, // Reanimated.Node<number>
+      +render: React$Node => React$Node,
+      +jumpTo: string => void,
+    |}) => React$Node,
+    +gestureHandlerProps: PanGestureHandlerProps,
+  |};
+
+  declare export type MaterialTopTabBarIndicatorProps = {|
+    +navigationState: TabNavigationState,
+    +width: string,
+    +style?: ViewStyleProp,
+    +getTabWidth: number => number,
+  |};
+
+  declare export type MaterialTopTabBarOptions = $Partial<{|
+    +scrollEnabled: boolean,
+    +bounces: boolean,
+    +pressColor: string,
+    +pressOpacity: number,
+    +getAccessible: ({| +route: Route<> |}) => boolean,
+    +renderBadge: ({| +route: Route<> |}) => React$Node,
+    +renderIndicator: MaterialTopTabBarIndicatorProps => React$Node,
+    +tabStyle: ViewStyleProp,
+    +indicatorStyle: ViewStyleProp,
+    +indicatorContainerStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+    +contentContainerStyle: ViewStyleProp,
+    +style: ViewStyleProp,
+    +activeTintColor: string,
+    +inactiveTintColor: string,
+    +iconStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+    +showLabel: boolean,
+    +showIcon: boolean,
+    +allowFontScaling: boolean,
+  |}>;
+
+  declare export type MaterialTopTabDescriptor = Descriptor<
+    MaterialBottomTabNavigationProp<>,
+    MaterialBottomTabOptions,
+  >;
+
+  declare type MaterialTopTabNavigationBuilderResult = {|
+    +state: TabNavigationState,
+    +navigation: MaterialTopTabNavigationProp<>,
+    +descriptors: {| +[key: string]: MaterialTopTabDescriptor |},
+  |};
+
+  declare export type MaterialTopTabBarProps = {|
+    ...MaterialTopTabBarOptions,
+    ...MaterialTopTabNavigationBuilderResult,
+    +layout: {| +width: number, +height: number |},
+    +position: any, // Reanimated.Node<number>
+    +jumpTo: string => void,
+  |};
+
+  declare export type MaterialTopTabNavigationConfig = {|
+    ...$Partial<MaterialTopTabPagerCommonProps>,
+    +position?: any, // Reanimated.Value<number>
+    +tabBarPosition?: 'top' | 'bottom',
+    +initialLayout?: $Partial<{| +width: number, +height: number |}>,
+    +lazy?: boolean,
+    +lazyPreloadDistance?: number,
+    +removeClippedSubviews?: boolean,
+    +sceneContainerStyle?: ViewStyleProp,
+    +style?: ViewStyleProp,
+    +gestureHandlerProps?: PanGestureHandlerProps,
+    +pager?: MaterialTopTabPagerProps => React$Node,
+    +lazyPlaceholder?: ({| +route: Route<> |}) => React$Node,
+    +tabBar?: MaterialTopTabBarProps => React$Node,
+    +tabBarOptions?: MaterialTopTabBarOptions,
+  |};
+
+  declare export type ExtraMaterialTopTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...MaterialTopTabNavigationConfig,
+  |};
+
+  declare export type MaterialTopTabNavigatorProps<
+    NavProp: InexactMaterialTopTabNavigationProp<> =
+      MaterialTopTabNavigationProp<>,
+  > = {|
+    ...ExtraMaterialTopTabNavigatorProps,
+    ...ScreenOptionsProp<MaterialTopTabOptions, NavProp>,
+  |};
+
+  /**
+   * Drawer options
+   */
+
+  declare export type DrawerOptions = $Partial<{|
+    title: string,
+    drawerLabel:
+      | string
+      | ({| +color: string, +focused: boolean |}) => React$Node,
+    drawerIcon: ({|
+      +color: string,
+      +size: number,
+      +focused: boolean,
+    |}) => React$Node,
+    gestureEnabled: boolean,
+    swipeEnabled: boolean,
+    unmountOnBlur: boolean,
+  |}>;
+
+  /**
+   * Drawer navigation prop
+   */
+
+  declare export type DrawerNavigationEventMap = {|
+    ...EventMapCore<DrawerNavigationState>,
+    +drawerOpen: {| +data: void, +canPreventDefault: false |},
+    +drawerClose: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare export type InexactDrawerNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = DrawerOptions,
+    EventMap: EventMapBase = DrawerNavigationEventMap,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      DrawerNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +jumpTo: SimpleNavigate<ParamList>,
+    +openDrawer: () => void,
+    +closeDrawer: () => void,
+    +toggleDrawer: () => void,
+    ...
+  };
+
+  declare export type DrawerNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = DrawerOptions,
+    EventMap: EventMapBase = DrawerNavigationEventMap,
+  > = $Exact<InexactDrawerNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous drawer exports
+   */
+
+  declare export type DrawerDescriptor = Descriptor<
+    DrawerNavigationProp<>,
+    DrawerOptions,
+  >;
+
+  declare export type DrawerItemListBaseOptions = $Partial<{|
+    +activeTintColor: string,
+    +activeBackgroundColor: string,
+    +inactiveTintColor: string,
+    +inactiveBackgroundColor: string,
+    +itemStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+  |}>;
+
+  declare export type DrawerContentOptions = $Partial<{|
+    ...DrawerItemListBaseOptions,
+    +contentContainerStyle: ViewStyleProp,
+    +style: ViewStyleProp,
+  |}>;
+
+  declare type DrawerNavigationBuilderResult = {|
+    +state: DrawerNavigationState,
+    +navigation: DrawerNavigationProp<>,
+    +descriptors: {| +[key: string]: DrawerDescriptor |},
+  |};
+
+  declare export type DrawerContentProps = {|
+    ...DrawerContentOptions,
+    ...DrawerNavigationBuilderResult,
+    +progress: any, // Reanimated.Node<number>
+  |};
+
+  declare export type DrawerNavigationConfig = {|
+    +drawerPosition?: 'left' | 'right',
+    +drawerType?: 'front' | 'back' | 'slide' | 'permanent',
+    +edgeWidth?: number,
+    +hideStatusBar?: boolean,
+    +keyboardDismissMode?: 'on-drag' | 'none',
+    +minSwipeDistance?: number,
+    +overlayColor?: string,
+    +statusBarAnimation?: 'slide' | 'none' | 'fade',
+    +gestureHandlerProps?: PanGestureHandlerProps,
+    +lazy?: boolean,
+    +drawerContent?: DrawerContentProps => React$Node,
+    +drawerContentOptions?: DrawerContentOptions,
+    +sceneContainerStyle?: ViewStyleProp,
+    +drawerStyle?: ViewStyleProp,
+    +detachInactiveScreens?: boolean,
+  |};
+
+  declare export type ExtraDrawerNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...DrawerRouterOptions,
+    ...DrawerNavigationConfig,
+  |};
+
+  declare export type DrawerNavigatorProps<
+    NavProp: InexactDrawerNavigationProp<> = DrawerNavigationProp<>,
+  > = {|
+    ...ExtraDrawerNavigatorProps,
+    ...ScreenOptionsProp<DrawerOptions, NavProp>,
+  |};
+
+  /**
+   * BaseNavigationContainer
+   */
+
+  declare export type BaseNavigationContainerProps = {|
+    +children: React$Node,
+    +initialState?: PossiblyStaleNavigationState,
+    +onStateChange?: (state: ?PossiblyStaleNavigationState) => void,
+    +independent?: boolean,
+  |};
+
+  declare export type ContainerEventMap = {|
+    ...GlobalEventMap<PossiblyStaleNavigationState>,
+    +options: {|
+      +data: {| +options: { +[key: string]: mixed, ... } |},
+      +canPreventDefault: false,
+    |},
+    +__unsafe_action__: {|
+      +data: {|
+        +action: GenericNavigationAction,
+        +noop: boolean,
+      |},
+      +canPreventDefault: false,
+    |},
+  |};
+
+  declare export type BaseNavigationContainerInterface = {|
+    ...$Exact<NavigationHelpers<
+      ParamListBase,
+      PossiblyStaleNavigationState,
+      ContainerEventMap,
+    >>,
+    +setParams: (params: ScreenParams) => void,
+    +resetRoot: (state?: ?PossiblyStaleNavigationState) => void,
+    +getRootState: () => PossiblyStaleNavigationState,
+  |};
+
+  /**
+   * State utils
+   */
+
+  declare export type GetStateFromPath = (
+    path: string,
+    options?: LinkingConfig,
+  ) => PossiblyStaleNavigationState;
+
+  declare export type GetPathFromState = (
+    state?: ?PossiblyStaleNavigationState,
+    options?: LinkingConfig,
+  ) => string;
+
+  declare export type GetFocusedRouteNameFromRoute =
+    PossiblyStaleRoute<string> => ?string;
+
+  /**
+   * Linking
+   */
+
+  declare export type ScreenLinkingConfig = {|
+    +path?: string,
+    +exact?: boolean,
+    +parse?: {| +[param: string]: string => mixed |},
+    +stringify?: {| +[param: string]: mixed => string |},
+    +screens?: ScreenLinkingConfigMap,
+    +initialRouteName?: string,
+  |};
+
+  declare export type ScreenLinkingConfigMap = {|
+    +[routeName: string]: string | ScreenLinkingConfig,
+  |};
+
+  declare export type LinkingConfig = {|
+    +initialRouteName?: string,
+    +screens: ScreenLinkingConfigMap,
+  |};
+
+  declare export type LinkingOptions = {|
+    +enabled?: boolean,
+    +prefixes: $ReadOnlyArray<string>,
+    +config?: LinkingConfig,
+    +getStateFromPath?: GetStateFromPath,
+    +getPathFromState?: GetPathFromState,
+  |};
+
+  /**
+   * NavigationContainer
+   */
+
+  declare export type Theme = {|
+    +dark: boolean,
+    +colors: {|
+      +primary: string,
+      +background: string,
+      +card: string,
+      +text: string,
+      +border: string,
+    |},
+  |};
+
+  declare export type NavigationContainerType = React$AbstractComponent<
+    {|
+      ...BaseNavigationContainerProps,
+      +theme?: Theme,
+      +linking?: LinkingOptions,
+      +fallback?: React$Node,
+      +onReady?: () => mixed,
+    |},
+    BaseNavigationContainerInterface,
+  >;
+
+  //---------------------------------------------------------------------------
+  // SECTION 2: EXPORTED MODULE
+  // This section defines the module exports and contains exported types that
+  // are not present in any other React Navigation libdef.
+  //---------------------------------------------------------------------------
+
+  /**
+   * Actions and routers
+   */
+
+  declare export var CommonActions: CommonActionsType;
+  declare export var StackActions: StackActionsType;
+  declare export var TabActions: TabActionsType;
+  declare export var DrawerActions: DrawerActionsType;
+
+  declare export var BaseRouter: RouterFactory<
+    NavigationState,
+    CommonAction,
+    DefaultRouterOptions,
+  >;
+  declare export var StackRouter: RouterFactory<
+    StackNavigationState,
+    StackAction,
+    StackRouterOptions,
+  >;
+  declare export var TabRouter: RouterFactory<
+    TabNavigationState,
+    TabAction,
+    TabRouterOptions,
+  >;
+  declare export var DrawerRouter: RouterFactory<
+    DrawerNavigationState,
+    DrawerAction,
+    DrawerRouterOptions,
+  >;
+
+  /**
+   * Navigator utils
+   */
+
+  declare export var BaseNavigationContainer: React$AbstractComponent<
+    BaseNavigationContainerProps,
+    BaseNavigationContainerInterface,
+  >;
+
+  declare export var createNavigatorFactory: CreateNavigatorFactory;
+
+  declare export var useNavigationBuilder: UseNavigationBuilder;
+
+  declare export var NavigationHelpersContext: React$Context<
+    ?NavigationHelpers<ParamListBase>,
+  >;
+
+  /**
+   * Navigation prop / route accessors
+   */
+
+  declare export var NavigationContext: React$Context<
+    ?NavigationProp<ParamListBase>,
+  >;
+  declare export function useNavigation(): NavigationProp<ParamListBase>;
+
+  declare export var NavigationRouteContext: React$Context<?LeafRoute<>>;
+  declare export function useRoute(): LeafRoute<>;
+
+  declare export function useNavigationState<T>(
+    selector: NavigationState => T,
+  ): T;
+
+  /**
+   * Focus utils
+   */
+
+  declare export function useFocusEffect(
+    effect: () => ?(() => mixed),
+  ): void;
+  declare export function useIsFocused(): boolean;
+
+  /**
+   * State utils
+   */
+
+  declare export var getStateFromPath: GetStateFromPath;
+
+  declare export var getPathFromState: GetPathFromState;
+
+  declare export function getActionFromState(
+    state: PossiblyStaleNavigationState,
+  ): ?NavigateAction;
+
+  declare export var getFocusedRouteNameFromRoute: GetFocusedRouteNameFromRoute;
+
+  /**
+   * useScrollToTop
+   */
+
+  declare type ScrollToOptions = { y?: number, animated?: boolean, ... };
+  declare type ScrollToOffsetOptions = {
+    offset: number,
+    animated?: boolean,
+    ...
+  };
+  declare type ScrollableView =
+    | { scrollToTop(): void, ... }
+    | { scrollTo(options: ScrollToOptions): void, ... }
+    | { scrollToOffset(options: ScrollToOffsetOptions): void, ... }
+    | { scrollResponderScrollTo(options: ScrollToOptions): void, ... };
+  declare type ScrollableWrapper =
+    | { getScrollResponder(): React$Node, ... }
+    | { getNode(): ScrollableView, ... }
+    | ScrollableView;
+  declare export function useScrollToTop(
+    ref: { +current: ?ScrollableWrapper, ... },
+  ): void;
+
+  /**
+   * Themes
+   */
+
+  declare export var DefaultTheme: Theme & { +dark: false, ... };
+  declare export var DarkTheme: Theme & { +dark: true, ... };
+  declare export function useTheme(): Theme;
+  declare export var ThemeProvider: React$ComponentType<{|
+    +value: Theme,
+    +children: React$Node,
+  |}>;
+
+  /**
+   * Linking
+   */
+
+  declare export var Link: React$ComponentType<{
+    +to: string,
+    +action?: GenericNavigationAction,
+    +target?: string,
+    +children: React$Node,
+    ...
+  }>;
+
+  declare export function useLinking(
+    container: { +current: ?React$ElementRef<NavigationContainerType>, ... },
+    options: LinkingOptions,
+  ): {| +getInitialState: () => Promise<?PossiblyStaleNavigationState> |};
+
+  declare export function useLinkTo(): (path: string) => void;
+
+  declare export function useLinkProps<To: string>(props: {|
+    +to: Top,
+    +action?: GenericNavigationAction,
+  |}): {|
+    +href: To,
+    +accessibilityRole: 'link',
+    +onPress: (MouseEvent | PressEvent) => void,
+  |};
+
+  declare export function useLinkBuilder(): (
+    name: string,
+    params?: ScreenParams,
+  ) => ?string;
+
+  /**
+   * NavigationContainer
+   */
+
+  declare export var NavigationContainer: NavigationContainerType;
+
+  /**
+   * useBackButton
+   */
+
+  declare export function useBackButton(
+    container: { +current: ?React$ElementRef<NavigationContainerType>, ... },
+  ): void;
+
+}

--- a/flow-typed/npm/@react-navigation/stack_v5.x.x.js
+++ b/flow-typed/npm/@react-navigation/stack_v5.x.x.js
@@ -1,0 +1,2169 @@
+// flow-typed signature: 9e831659b1a7a87cc7ecd433e0cc765e
+// flow-typed version: 510a06cce0/@react-navigation/stack_v5.x.x/flow_>=v0.104.x
+
+declare module '@react-navigation/stack' {
+
+  //---------------------------------------------------------------------------
+  // SECTION 1: IDENTICAL TYPE DEFINITIONS
+  // This section is identical across all React Navigation libdefs and contains
+  // shared definitions. We wish we could make it DRY and import from a shared
+  // definition, but that isn't yet possible.
+  //---------------------------------------------------------------------------
+
+  /**
+   * We start with some definitions that we have copy-pasted from React Native
+   * source files.
+   */
+
+  // This is a bastardization of the true StyleObj type located in
+  // react-native/Libraries/StyleSheet/StyleSheetTypes. We unfortunately can't
+  // import that here, and it's too lengthy (and consequently too brittle) to
+  // copy-paste here either.
+  declare type StyleObj =
+    | null
+    | void
+    | number
+    | false
+    | ''
+    | $ReadOnlyArray<StyleObj>
+    | { [name: string]: any, ... };
+  declare type ViewStyleProp = StyleObj;
+  declare type TextStyleProp = StyleObj;
+  declare type AnimatedViewStyleProp = StyleObj;
+  declare type AnimatedTextStyleProp = StyleObj;
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/animations/Animation.js
+  declare type EndResult = { finished: boolean, ... };
+  declare type EndCallback = (result: EndResult) => void;
+  declare interface Animation {
+    start(
+      fromValue: number,
+      onUpdate: (value: number) => void,
+      onEnd: ?EndCallback,
+      previousAnimation: ?Animation,
+      animatedValue: AnimatedValue,
+    ): void;
+    stop(): void;
+  }
+  declare type AnimationConfig = {
+    isInteraction?: boolean,
+    useNativeDriver: boolean,
+    onComplete?: ?EndCallback,
+    iterations?: number,
+    ...
+  };
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedTracking.js
+  declare interface AnimatedTracking {
+    constructor(
+      value: AnimatedValue,
+      parent: any,
+      animationClass: any,
+      animationConfig: Object,
+      callback?: ?EndCallback,
+    ): void;
+    update(): void;
+  }
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedValue.js
+  declare type ValueListenerCallback = (state: { value: number, ... }) => void;
+  declare interface AnimatedValue {
+    constructor(value: number): void;
+    setValue(value: number): void;
+    setOffset(offset: number): void;
+    flattenOffset(): void;
+    extractOffset(): void;
+    addListener(callback: ValueListenerCallback): string;
+    removeListener(id: string): void;
+    removeAllListeners(): void;
+    stopAnimation(callback?: ?(value: number) => void): void;
+    resetAnimation(callback?: ?(value: number) => void): void;
+    interpolate(config: InterpolationConfigType): AnimatedInterpolation;
+    animate(animation: Animation, callback: ?EndCallback): void;
+    stopTracking(): void;
+    track(tracking: AnimatedTracking): void;
+  }
+
+  // Copied from
+  // react-native/Libraries/Animated/src/animations/TimingAnimation.js
+  declare type TimingAnimationConfigSingle = AnimationConfig & {
+    toValue: number | AnimatedValue,
+    easing?: (value: number) => number,
+    duration?: number,
+    delay?: number,
+    ...
+  };
+
+  // Copied from
+  // react-native/Libraries/Animated/src/animations/SpringAnimation.js
+  declare type SpringAnimationConfigSingle = AnimationConfig & {
+    toValue: number | AnimatedValue,
+    overshootClamping?: boolean,
+    restDisplacementThreshold?: number,
+    restSpeedThreshold?: number,
+    velocity?: number,
+    bounciness?: number,
+    speed?: number,
+    tension?: number,
+    friction?: number,
+    stiffness?: number,
+    damping?: number,
+    mass?: number,
+    delay?: number,
+    ...
+  };
+
+  // Copied from react-native/Libraries/Types/CoreEventTypes.js
+  declare type SyntheticEvent<T> = $ReadOnly<{|
+    bubbles: ?boolean,
+    cancelable: ?boolean,
+    currentTarget: number,
+    defaultPrevented: ?boolean,
+    dispatchConfig: $ReadOnly<{|
+      registrationName: string,
+    |}>,
+    eventPhase: ?number,
+    preventDefault: () => void,
+    isDefaultPrevented: () => boolean,
+    stopPropagation: () => void,
+    isPropagationStopped: () => boolean,
+    isTrusted: ?boolean,
+    nativeEvent: T,
+    persist: () => void,
+    target: ?number,
+    timeStamp: number,
+    type: ?string,
+  |}>;
+  declare type Layout = $ReadOnly<{|
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+  |}>;
+  declare type LayoutEvent = SyntheticEvent<
+    $ReadOnly<{|
+      layout: Layout,
+    |}>,
+  >;
+  declare type BlurEvent = SyntheticEvent<
+    $ReadOnly<{|
+      target: number,
+    |}>,
+  >;
+  declare type FocusEvent = SyntheticEvent<
+    $ReadOnly<{|
+      target: number,
+    |}>,
+  >;
+  declare type ResponderSyntheticEvent<T> = $ReadOnly<{|
+    ...SyntheticEvent<T>,
+    touchHistory: $ReadOnly<{|
+      indexOfSingleActiveTouch: number,
+      mostRecentTimeStamp: number,
+      numberActiveTouches: number,
+      touchBank: $ReadOnlyArray<
+        $ReadOnly<{|
+          touchActive: boolean,
+          startPageX: number,
+          startPageY: number,
+          startTimeStamp: number,
+          currentPageX: number,
+          currentPageY: number,
+          currentTimeStamp: number,
+          previousPageX: number,
+          previousPageY: number,
+          previousTimeStamp: number,
+        |}>,
+      >,
+    |}>,
+  |}>;
+  declare type PressEvent = ResponderSyntheticEvent<
+    $ReadOnly<{|
+      changedTouches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
+      force: number,
+      identifier: number,
+      locationX: number,
+      locationY: number,
+      pageX: number,
+      pageY: number,
+      target: ?number,
+      timestamp: number,
+      touches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
+    |}>,
+  >;
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedInterpolation.js
+  declare type ExtrapolateType = 'extend' | 'identity' | 'clamp';
+  declare type InterpolationConfigType = {
+    inputRange: Array<number>,
+    outputRange: Array<number> | Array<string>,
+    easing?: (input: number) => number,
+    extrapolate?: ExtrapolateType,
+    extrapolateLeft?: ExtrapolateType,
+    extrapolateRight?: ExtrapolateType,
+    ...
+  };
+  declare interface AnimatedInterpolation {
+    interpolate(config: InterpolationConfigType): AnimatedInterpolation;
+  }
+
+  // Copied from react-native/Libraries/Components/View/ViewAccessibility.js
+  declare type AccessibilityRole =
+    | 'none'
+    | 'button'
+    | 'link'
+    | 'search'
+    | 'image'
+    | 'keyboardkey'
+    | 'text'
+    | 'adjustable'
+    | 'imagebutton'
+    | 'header'
+    | 'summary'
+    | 'alert'
+    | 'checkbox'
+    | 'combobox'
+    | 'menu'
+    | 'menubar'
+    | 'menuitem'
+    | 'progressbar'
+    | 'radio'
+    | 'radiogroup'
+    | 'scrollbar'
+    | 'spinbutton'
+    | 'switch'
+    | 'tab'
+    | 'tablist'
+    | 'timer'
+    | 'toolbar';
+  declare type AccessibilityActionInfo = $ReadOnly<{
+    name: string,
+    label?: string,
+    ...
+  }>;
+  declare type AccessibilityActionEvent = SyntheticEvent<
+    $ReadOnly<{actionName: string, ...}>,
+  >;
+  declare type AccessibilityState = {
+    disabled?: boolean,
+    selected?: boolean,
+    checked?: ?boolean | 'mixed',
+    busy?: boolean,
+    expanded?: boolean,
+    ...
+  };
+  declare type AccessibilityValue = $ReadOnly<{|
+    min?: number,
+    max?: number,
+    now?: number,
+    text?: string,
+  |}>;
+
+  // Copied from
+  // react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+  declare type Stringish = string;
+  declare type EdgeInsetsProp = $ReadOnly<$Partial<EdgeInsets>>;
+  declare type TouchableWithoutFeedbackProps = $ReadOnly<{|
+    accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
+    accessibilityElementsHidden?: ?boolean,
+    accessibilityHint?: ?Stringish,
+    accessibilityIgnoresInvertColors?: ?boolean,
+    accessibilityLabel?: ?Stringish,
+    accessibilityLiveRegion?: ?('none' | 'polite' | 'assertive'),
+    accessibilityRole?: ?AccessibilityRole,
+    accessibilityState?: ?AccessibilityState,
+    accessibilityValue?: ?AccessibilityValue,
+    accessibilityViewIsModal?: ?boolean,
+    accessible?: ?boolean,
+    children?: ?React$Node,
+    delayLongPress?: ?number,
+    delayPressIn?: ?number,
+    delayPressOut?: ?number,
+    disabled?: ?boolean,
+    focusable?: ?boolean,
+    hitSlop?: ?EdgeInsetsProp,
+    importantForAccessibility?: ?('auto' | 'yes' | 'no' | 'no-hide-descendants'),
+    nativeID?: ?string,
+    onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
+    onBlur?: ?(event: BlurEvent) => mixed,
+    onFocus?: ?(event: FocusEvent) => mixed,
+    onLayout?: ?(event: LayoutEvent) => mixed,
+    onLongPress?: ?(event: PressEvent) => mixed,
+    onPress?: ?(event: PressEvent) => mixed,
+    onPressIn?: ?(event: PressEvent) => mixed,
+    onPressOut?: ?(event: PressEvent) => mixed,
+    pressRetentionOffset?: ?EdgeInsetsProp,
+    rejectResponderTermination?: ?boolean,
+    testID?: ?string,
+    touchSoundDisabled?: ?boolean,
+  |}>;
+
+  // Copied from react-native/Libraries/Image/ImageSource.js
+  declare type ImageURISource = $ReadOnly<{
+    uri?: ?string,
+    bundle?: ?string,
+    method?: ?string,
+    headers?: ?Object,
+    body?: ?string,
+    cache?: ?('default' | 'reload' | 'force-cache' | 'only-if-cached'),
+    width?: ?number,
+    height?: ?number,
+    scale?: ?number,
+    ...
+  }>;
+
+  /**
+   * The following is copied from react-native-gesture-handler's libdef
+   */
+
+  declare type $EventHandlers<ExtraProps: {...}> = {|
+    onGestureEvent?: ($Event<ExtraProps>) => mixed,
+    onHandlerStateChange?: ($Event<ExtraProps>) => mixed,
+    onBegan?: ($Event<ExtraProps>) => mixed,
+    onFailed?: ($Event<ExtraProps>) => mixed,
+    onCancelled?: ($Event<ExtraProps>) => mixed,
+    onActivated?: ($Event<ExtraProps>) => mixed,
+    onEnded?: ($Event<ExtraProps>) => mixed,
+  |};
+
+  declare type HitSlop =
+    | number
+    | {|
+        left?: number,
+        top?: number,
+        right?: number,
+        bottom?: number,
+        vertical?: number,
+        horizontal?: number,
+        width?: number,
+        height?: number,
+      |}
+    | {|
+        width: number,
+        left: number,
+      |}
+    | {|
+        width: number,
+        right: number,
+      |}
+    | {|
+        height: number,
+        top: number,
+      |}
+    | {|
+        height: number,
+        bottom: number,
+      |};
+
+  declare type $GestureHandlerProps<
+    AdditionalProps: {...},
+    ExtraEventsProps: {...}
+  > = $ReadOnly<{|
+    ...$Exact<AdditionalProps>,
+    ...$EventHandlers<ExtraEventsProps>,
+    id?: string,
+    enabled?: boolean,
+    waitFor?: React$Ref<any> | Array<React$Ref<any>>,
+    simultaneousHandlers?: React$Ref<any> | Array<React$Ref<any>>,
+    shouldCancelWhenOutside?: boolean,
+    minPointers?: number,
+    hitSlop?: HitSlop,
+    children?: React$Node,
+  |}>;
+
+  declare type PanGestureHandlerProps = $GestureHandlerProps<
+    {
+      activeOffsetY?: number | [number, number],
+      activeOffsetX?: number | [number, number],
+      failOffsetY?: number | [number, number],
+      failOffsetX?: number | [number, number],
+      minDist?: number,
+      minVelocity?: number,
+      minVelocityX?: number,
+      minVelocityY?: number,
+      minPointers?: number,
+      maxPointers?: number,
+      avgTouches?: boolean,
+      ...
+    },
+    {
+      x: number,
+      y: number,
+      absoluteX: number,
+      absoluteY: number,
+      translationX: number,
+      translationY: number,
+      velocityX: number,
+      velocityY: number,
+      ...
+    }
+  >;
+
+  /**
+   * MAGIC
+   */
+
+  declare type $If<Test: boolean, Then, Else = empty> = $Call<
+    ((true, Then, Else) => Then) & ((false, Then, Else) => Else),
+    Test,
+    Then,
+    Else,
+  >;
+  declare type $IsA<X, Y> = $Call<
+    (Y => true) & (mixed => false),
+    X,
+  >;
+  declare type $IsUndefined<X> = $IsA<X, void>;
+
+  declare type $Partial<T> = $ReadOnly<$Rest<T, {...}>>;
+
+  /**
+   * Actions, state, etc.
+   */
+
+  declare export type ScreenParams = { +[key: string]: mixed, ... };
+
+  declare export type BackAction = {|
+    +type: 'GO_BACK',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type NavigateAction = {|
+    +type: 'NAVIGATE',
+    +payload:
+      | {| +key: string, +params?: ScreenParams |}
+      | {| +name: string, +key?: string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type ResetAction = {|
+    +type: 'RESET',
+    +payload: StaleNavigationState,
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type SetParamsAction = {|
+    +type: 'SET_PARAMS',
+    +payload: {| +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type CommonAction =
+    | BackAction
+    | NavigateAction
+    | ResetAction
+    | SetParamsAction;
+
+  declare type NavigateActionCreator = {|
+    (routeName: string, params?: ScreenParams): NavigateAction,
+    (
+      | {| +key: string, +params?: ScreenParams |}
+      | {| +name: string, +key?: string, +params?: ScreenParams |},
+    ): NavigateAction,
+  |};
+  declare export type CommonActionsType = {|
+    +navigate: NavigateActionCreator,
+    +goBack: () => BackAction,
+    +reset: (state: PossiblyStaleNavigationState) => ResetAction,
+    +setParams: (params: ScreenParams) => SetParamsAction,
+  |};
+
+  declare export type GenericNavigationAction = {|
+    +type: string,
+    +payload?: { +[key: string]: mixed, ... },
+    +source?: string,
+    +target?: string,
+  |};
+
+  declare export type LeafRoute<RouteName: string = string> = {|
+    +key: string,
+    +name: RouteName,
+    +params?: ScreenParams,
+  |};
+  declare export type StateRoute<RouteName: string = string> = {|
+    ...LeafRoute<RouteName>,
+    +state: NavigationState | StaleNavigationState,
+  |};
+  declare export type Route<RouteName: string = string> =
+    | LeafRoute<RouteName>
+    | StateRoute<RouteName>;
+
+  declare export type NavigationState = {|
+    +key: string,
+    +index: number,
+    +routeNames: $ReadOnlyArray<string>,
+    +history?: $ReadOnlyArray<mixed>,
+    +routes: $ReadOnlyArray<Route<>>,
+    +type: string,
+    +stale: false,
+  |};
+
+  declare export type StaleLeafRoute<RouteName: string = string> = {|
+    +key?: string,
+    +name: RouteName,
+    +params?: ScreenParams,
+  |};
+  declare export type StaleStateRoute<RouteName: string = string> = {|
+    ...StaleLeafRoute<RouteName>,
+    +state: StaleNavigationState,
+  |};
+  declare export type StaleRoute<RouteName: string = string> =
+    | StaleLeafRoute<RouteName>
+    | StaleStateRoute<RouteName>;
+  declare export type StaleNavigationState = {|
+    // It's possible to pass React Nav a StaleNavigationState with an undefined
+    // index, but React Nav will always return one with the index set. This is
+    // the same as for the type property below, but in the case of index we tend
+    // to rely on it being set more...
+    +index: number,
+    +history?: $ReadOnlyArray<mixed>,
+    +routes: $ReadOnlyArray<StaleRoute<>>,
+    +type?: string,
+    +stale?: true,
+  |};
+
+  declare export type PossiblyStaleNavigationState =
+    | NavigationState
+    | StaleNavigationState;
+  declare export type PossiblyStaleRoute<RouteName: string = string> =
+    | Route<RouteName>
+    | StaleRoute<RouteName>;
+
+  /**
+   * Routers
+   */
+
+  declare type ActionCreators<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+  > = {
+    +[key: string]: (...args: any) => (Action | State => Action),
+    ...
+  };
+
+  declare export type DefaultRouterOptions = {
+    +initialRouteName?: string,
+    ...
+  };
+
+  declare export type RouterFactory<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+    RouterOptions: DefaultRouterOptions,
+  > = (options: RouterOptions) => Router<State, Action>;
+
+  declare export type ParamListBase = { +[key: string]: ?ScreenParams, ... };
+
+  declare export type RouterConfigOptions = {|
+    +routeNames: $ReadOnlyArray<string>,
+    +routeParamList: ParamListBase,
+  |};
+
+  declare export type Router<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+  > = {|
+    +type: $PropertyType<State, 'type'>,
+    +getInitialState: (options: RouterConfigOptions) => State,
+    +getRehydratedState: (
+      partialState: PossibleStaleNavigationState,
+      options: RouterConfigOptions,
+    ) => State,
+    +getStateForRouteNamesChange: (
+      state: State,
+      options: RouterConfigOptions,
+    ) => State,
+    +getStateForRouteFocus: (state: State, key: string) => State,
+    +getStateForAction: (
+      state: State,
+      action: Action,
+      options: RouterConfigOptions,
+    ) => ?PossiblyStaleNavigationState;
+    +shouldActionChangeFocus: (action: GenericNavigationAction) => boolean,
+    +actionCreators?: ActionCreators<State, Action>,
+  |};
+
+  /**
+   * Stack actions and router
+   */
+
+  declare export type StackNavigationState = {|
+    ...NavigationState,
+    +type: 'stack',
+  |};
+
+  declare export type ReplaceAction = {|
+    +type: 'REPLACE',
+    +payload: {| +name: string, +key?: ?string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PushAction = {|
+    +type: 'PUSH',
+    +payload: {| +name: string, +key?: ?string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PopAction = {|
+    +type: 'POP',
+    +payload: {| +count: number |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PopToTopAction = {|
+    +type: 'POP_TO_TOP',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type StackAction =
+    | CommonAction
+    | ReplaceAction
+    | PushAction
+    | PopAction
+    | PopToTopAction;
+
+  declare export type StackActionsType = {|
+    +replace: (routeName: string, params?: ScreenParams) => ReplaceAction,
+    +push: (routeName: string, params?: ScreenParams) => PushAction,
+    +pop: (count?: number) => PopAction,
+    +popToTop: () => PopToTopAction,
+  |};
+
+  declare export type StackRouterOptions = $Exact<DefaultRouterOptions>;
+
+  /**
+   * Tab actions and router
+   */
+
+  declare export type TabNavigationState = {|
+    ...NavigationState,
+    +type: 'tab',
+    +history: $ReadOnlyArray<{| type: 'route', key: string |}>,
+  |};
+
+  declare export type JumpToAction = {|
+    +type: 'JUMP_TO',
+    +payload: {| +name: string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type TabAction =
+    | CommonAction
+    | JumpToAction;
+
+  declare export type TabActionsType = {|
+    +jumpTo: string => JumpToAction,
+  |};
+
+  declare export type TabRouterOptions = {|
+    ...$Exact<DefaultRouterOptions>,
+    +backBehavior?: 'initialRoute' | 'order' | 'history' | 'none',
+  |};
+
+  /**
+   * Drawer actions and router
+   */
+
+  declare type DrawerHistoryEntry =
+    | {| +type: 'route', +key: string |}
+    | {| +type: 'drawer' |};
+  declare export type DrawerNavigationState = {|
+    ...NavigationState,
+    +type: 'drawer',
+    +history: $ReadOnlyArray<DrawerHistoryEntry>,
+  |};
+
+  declare export type OpenDrawerAction = {|
+    +type: 'OPEN_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type CloseDrawerAction = {|
+    +type: 'CLOSE_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type ToggleDrawerAction = {|
+    +type: 'TOGGLE_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type DrawerAction =
+    | TabAction
+    | OpenDrawerAction
+    | CloseDrawerAction
+    | ToggleDrawerAction;
+
+  declare export type DrawerActionsType = {|
+    ...TabActionsType,
+    +openDrawer: () => OpenDrawerAction,
+    +closeDrawer: () => CloseDrawerAction,
+    +toggleDrawer: () => ToggleDrawerAction,
+  |};
+
+  declare export type DrawerRouterOptions = {|
+    ...TabRouterOptions,
+    +openByDefault?: boolean,
+  |};
+
+  /**
+   * Events
+   */
+
+  declare export type EventMapBase = {
+    +[name: string]: {|
+      +data?: mixed,
+      +canPreventDefault?: boolean,
+    |},
+    ...
+  };
+  declare type EventPreventDefaultProperties<Test: boolean> = $If<
+    Test,
+    {| +defaultPrevented: boolean, +preventDefault: () => void |},
+    {| |},
+  >;
+  declare type EventDataProperties<Data> = $If<
+    $IsUndefined<Data>,
+    {| |},
+    {| +data: Data |},
+  >;
+  declare type EventArg<
+    EventName: string,
+    CanPreventDefault: ?boolean = false,
+    Data = void,
+  > = {|
+    ...EventPreventDefaultProperties<CanPreventDefault>,
+    ...EventDataProperties<Data>,
+    +type: EventName,
+    +target?: string,
+  |};
+  declare type GlobalEventMap<State: PossiblyStaleNavigationState> = {|
+    +state: {| +data: {| +state: State |}, +canPreventDefault: false |},
+  |};
+  declare type EventMapCore<State: PossiblyStaleNavigationState> = {|
+    ...GlobalEventMap<State>,
+    +focus: {| +data: void, +canPreventDefault: false |},
+    +blur: {| +data: void, +canPreventDefault: false |},
+    +beforeRemove: {|
+      +data: {| +action: GenericNavigationAction |},
+      +canPreventDefault: true,
+    |},
+  |};
+  declare type EventListenerCallback<
+    EventName: string,
+    State: PossiblyStaleNavigationState = NavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = (e: EventArg<
+    EventName,
+    $PropertyType<
+      $ElementType<
+        {| ...EventMap, ...EventMapCore<State> |},
+        EventName,
+      >,
+      'canPreventDefault',
+    >,
+    $PropertyType<
+      $ElementType<
+        {| ...EventMap, ...EventMapCore<State> |},
+        EventName,
+      >,
+      'data',
+    >,
+  >) => mixed;
+
+  /**
+   * Navigation prop
+   */
+
+  declare export type SimpleNavigate<ParamList> =
+    <DestinationRouteName: $Keys<ParamList>>(
+      routeName: DestinationRouteName,
+      params: $ElementType<ParamList, DestinationRouteName>,
+    ) => void;
+
+  declare export type Navigate<ParamList> =
+    & SimpleNavigate<ParamList>
+    & <DestinationRouteName: $Keys<ParamList>>(
+        route:
+          | {|
+              key: string,
+              params?: $ElementType<ParamList, DestinationRouteName>,
+            |}
+          | {|
+              name: DestinationRouteName,
+              key?: string,
+              params?: $ElementType<ParamList, DestinationRouteName>,
+            |},
+      ) => void;
+
+  declare type NavigationHelpers<
+    ParamList: ParamListBase,
+    State: PossiblyStaleNavigationState = PossiblyStaleNavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {
+    +navigate: Navigate<ParamList>,
+    +dispatch: (
+      action:
+        | GenericNavigationAction
+        | (State => GenericNavigationAction),
+    ) => void,
+    +reset: PossiblyStaleNavigationState => void,
+    +goBack: () => void,
+    +isFocused: () => boolean,
+    +canGoBack: () => boolean,
+    +dangerouslyGetParent: <Parent: NavigationProp<ParamListBase>>() => ?Parent,
+    +dangerouslyGetState: () => NavigationState,
+    +addListener: <EventName: $Keys<
+      {| ...EventMap, ...EventMapCore<State> |},
+    >>(
+      name: EventName,
+      callback: EventListenerCallback<EventName, State, EventMap>,
+    ) => () => void,
+    +removeListener: <EventName: $Keys<
+      {| ...EventMap, ...EventMapCore<State> |},
+    >>(
+      name: EventName,
+      callback: EventListenerCallback<EventName, State, EventMap>,
+    ) => void,
+    ...
+  };
+
+  declare export type NavigationProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: PossiblyStaleNavigationState = PossiblyStaleNavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {
+    ...$Exact<NavigationHelpers<
+      ParamList,
+      State,
+      EventMap,
+    >>,
+    +setOptions: (options: $Partial<ScreenOptions>) => void,
+    +setParams: (
+      params: $If<
+        $IsUndefined<$ElementType<ParamList, RouteName>>,
+        empty,
+        $Partial<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
+      >,
+    ) => void,
+    ...
+  };
+
+  /**
+   * CreateNavigator
+   */
+
+  declare export type RouteProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList>,
+  > = {|
+    ...LeafRoute<RouteName>,
+    +params: $ElementType<ParamList, RouteName>,
+  |};
+
+  declare export type ScreenListeners<
+    EventMap: EventMapBase = EventMapCore<State>,
+    State: NavigationState = NavigationState,
+  > = $ObjMapi<
+    {| [name: $Keys<EventMap>]: empty |},
+    <K: $Keys<EventMap>>(K, empty) => EventListenerCallback<K, State, EventMap>,
+  >;
+
+  declare type BaseScreenProps<
+    ParamList: ParamListBase,
+    NavProp,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {|
+    +name: RouteName,
+    +options?:
+      | ScreenOptions
+      | ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => ScreenOptions,
+    +listeners?:
+      | ScreenListeners<EventMap, State>
+      | ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => ScreenListeners<EventMap, State>,
+    +initialParams?: $Partial<$ElementType<ParamList, RouteName>>,
+  |};
+
+  declare export type ScreenProps<
+    ParamList: ParamListBase,
+    NavProp,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > =
+    | {|
+        ...BaseScreenProps<
+          ParamList,
+          NavProp,
+          RouteName,
+          State,
+          ScreenOptions,
+          EventMap,
+        >,
+        +component: React$ComponentType<{|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}>,
+      |}
+    | {|
+        ...BaseScreenProps<
+          ParamList,
+          NavProp,
+          RouteName,
+          State,
+          ScreenOptions,
+          EventMap,
+        >,
+        +children: ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => React$Node,
+      |};
+
+  declare export type ScreenComponent<
+    GlobalParamList: ParamListBase,
+    ParamList: ParamListBase,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = <
+    RouteName: $Keys<ParamList>,
+    NavProp: NavigationProp<
+      GlobalParamList,
+      RouteName,
+      State,
+      ScreenOptions,
+      EventMap,
+    >,
+  >(props: ScreenProps<
+    ParamList,
+    NavProp,
+    RouteName,
+    State,
+    ScreenOptions,
+    EventMap,
+  >) => React$Node;
+
+  declare type ScreenOptionsProp<ScreenOptions: {...}, NavProp> = {|
+    +screenOptions?:
+      | ScreenOptions
+      | ({| route: LeafRoute<>, navigation: NavProp |}) => ScreenOptions,
+  |};
+  declare export type ExtraNavigatorPropsBase = {
+    ...$Exact<DefaultRouterOptions>,
+    +children?: React$Node,
+    ...
+  };
+  declare export type NavigatorPropsBase<ScreenOptions: {...}, NavProp> = {
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    ...
+  };
+
+  declare export type CreateNavigator<
+    State: NavigationState,
+    ScreenOptions: {...},
+    EventMap: EventMapBase,
+    ExtraNavigatorProps: ExtraNavigatorPropsBase,
+  > = <
+    GlobalParamList: ParamListBase,
+    ParamList: ParamListBase,
+    NavProp: NavigationHelpers<
+      GlobalParamList,
+      State,
+      EventMap,
+    >,
+  >() => {|
+    +Screen: ScreenComponent<
+      GlobalParamList,
+      ParamList,
+      State,
+      ScreenOptions,
+      EventMap,
+    >,
+    +Navigator: React$ComponentType<{|
+      ...$Exact<ExtraNavigatorProps>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    |}>,
+  |};
+
+  declare export type CreateNavigatorFactory = <
+    State: NavigationState,
+    ScreenOptions: {...},
+    EventMap: EventMapBase,
+    NavProp: NavigationHelpers<
+      ParamListBase,
+      State,
+      EventMap,
+    >,
+    ExtraNavigatorProps: ExtraNavigatorPropsBase,
+  >(
+    navigator: React$ComponentType<{|
+      ...$Exact<ExtraNavigatorPropsBase>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    |}>,
+  ) => CreateNavigator<State, ScreenOptions, EventMap, ExtraNavigatorProps>;
+
+  /**
+   * useNavigationBuilder
+   */
+
+  declare export type Descriptor<
+    NavProp,
+    ScreenOptions: {...} = {...},
+  > = {|
+    +render: () => React$Node,
+    +options: $ReadOnly<ScreenOptions>,
+    +navigation: NavProp,
+  |};
+
+  declare export type UseNavigationBuilder = <
+    State: NavigationState,
+    Action: GenericNavigationAction,
+    ScreenOptions: {...},
+    RouterOptions: DefaultRouterOptions,
+    NavProp,
+  >(
+    routerFactory: RouterFactory<State, Action, RouterOptions>,
+    options: {|
+      ...$Exact<RouterOptions>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+      +children?: React$Node,
+    |},
+  ) => {|
+    +state: State,
+    +descriptors: {| +[key: string]: Descriptor<NavProp, ScreenOptions> |},
+    +navigation: NavProp,
+  |};
+
+  /**
+   * EdgeInsets
+   */
+
+  declare type EdgeInsets = {|
+    +top: number,
+    +right: number,
+    +bottom: number,
+    +left: number,
+  |};
+
+  /**
+   * TransitionPreset
+   */
+
+  declare export type TransitionSpec =
+    | {|
+        animation: 'spring',
+        config: $Diff<
+          SpringAnimationConfigSingle,
+          { toValue: number | AnimatedValue, ... },
+        >,
+      |}
+    | {|
+        animation: 'timing',
+        config: $Diff<
+          TimingAnimationConfigSingle,
+          { toValue: number | AnimatedValue, ... },
+        >,
+      |};
+
+  declare export type StackCardInterpolationProps = {|
+    +current: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +next?: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +index: number,
+    +closing: AnimatedInterpolation,
+    +swiping: AnimatedInterpolation,
+    +inverted: AnimatedInterpolation,
+    +layouts: {|
+      +screen: {| +width: number, +height: number |},
+    |},
+    +insets: EdgeInsets,
+  |};
+  declare export type StackCardInterpolatedStyle = {|
+    containerStyle?: AnimatedViewStyleProp,
+    cardStyle?: AnimatedViewStyleProp,
+    overlayStyle?: AnimatedViewStyleProp,
+    shadowStyle?: AnimatedViewStyleProp,
+  |};
+  declare export type StackCardStyleInterpolator = (
+    props: StackCardInterpolationProps,
+  ) => StackCardInterpolatedStyle;
+
+  declare export type StackHeaderInterpolationProps = {|
+    +current: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +next?: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +layouts: {|
+      +header: {| +width: number, +height: number |},
+      +screen: {| +width: number, +height: number |},
+      +title?: {| +width: number, +height: number |},
+      +leftLabel?: {| +width: number, +height: number |},
+    |},
+  |};
+  declare export type StackHeaderInterpolatedStyle = {|
+    leftLabelStyle?: AnimatedViewStyleProp,
+    leftButtonStyle?: AnimatedViewStyleProp,
+    rightButtonStyle?: AnimatedViewStyleProp,
+    titleStyle?: AnimatedViewStyleProp,
+    backgroundStyle?: AnimatedViewStyleProp,
+  |};
+  declare export type StackHeaderStyleInterpolator = (
+    props: StackHeaderInterpolationProps,
+  ) => StackHeaderInterpolatedStyle;
+
+  declare type GestureDirection =
+    | 'horizontal'
+    | 'horizontal-inverted'
+    | 'vertical'
+    | 'vertical-inverted';
+
+  declare export type TransitionPreset = {|
+    +gestureDirection: GestureDirection,
+    +transitionSpec: {|
+      +open: TransitionSpec,
+      +close: TransitionSpec,
+    |},
+    +cardStyleInterpolator: StackCardStyleInterpolator,
+    +headerStyleInterpolator: StackHeaderStyleInterpolator,
+  |};
+
+  /**
+   * Stack options
+   */
+
+  declare export type StackDescriptor = Descriptor<
+    StackNavigationProp<>,
+    StackOptions,
+  >;
+
+  declare type Scene<T> = {|
+    +route: T,
+    +descriptor: StackDescriptor,
+    +progress: {|
+      +current: AnimatedInterpolation,
+      +next?: AnimatedInterpolation,
+      +previous?: AnimatedInterpolation,
+    |},
+  |};
+
+  declare export type StackHeaderProps = {|
+    +mode: 'float' | 'screen',
+    +layout: {| +width: number, +height: number |},
+    +insets: EdgeInsets,
+    +scene: Scene<Route<>>,
+    +previous?: Scene<Route<>>,
+    +navigation: StackNavigationProp<ParamListBase>,
+    +styleInterpolator: StackHeaderStyleInterpolator,
+  |};
+
+  declare export type StackHeaderLeftButtonProps = $Partial<{|
+    +onPress: (() => void),
+    +pressColorAndroid: string;
+    +backImage: (props: {| tintColor: string |}) => React$Node,
+    +tintColor: string,
+    +label: string,
+    +truncatedLabel: string,
+    +labelVisible: boolean,
+    +labelStyle: AnimatedTextStyleProp,
+    +allowFontScaling: boolean,
+    +onLabelLayout: LayoutEvent => void,
+    +screenLayout: {| +width: number, +height: number |},
+    +titleLayout: {| +width: number, +height: number |},
+    +canGoBack: boolean,
+  |}>;
+
+  declare type StackHeaderTitleInputBase = {
+    +onLayout: LayoutEvent => void,
+    +children: string,
+    +allowFontScaling: ?boolean,
+    +tintColor: ?string,
+    +style: ?AnimatedTextStyleProp,
+    ...
+  };
+
+  declare export type StackHeaderTitleInputProps =
+    $Exact<StackHeaderTitleInputBase>;
+
+  declare export type StackOptions = $Partial<{|
+    +title: string,
+    +header: StackHeaderProps => React$Node,
+    +headerShown: boolean,
+    +cardShadowEnabled: boolean,
+    +cardOverlayEnabled: boolean,
+    +cardOverlay: {| style: ViewStyleProp |} => React$Node,
+    +cardStyle: ViewStyleProp,
+    +animationEnabled: boolean,
+    +animationTypeForReplace: 'push' | 'pop',
+    +gestureEnabled: boolean,
+    +gestureResponseDistance: {| vertical?: number, horizontal?: number |},
+    +gestureVelocityImpact: number,
+    +safeAreaInsets: $Partial<EdgeInsets>,
+    // Transition
+    ...TransitionPreset,
+    // Header
+    +headerTitle: string | (StackHeaderTitleInputProps => React$Node),
+    +headerTitleAlign: 'left' | 'center',
+    +headerTitleStyle: AnimatedTextStyleProp,
+    +headerTitleContainerStyle: ViewStyleProp,
+    +headerTintColor: string,
+    +headerTitleAllowFontScaling: boolean,
+    +headerBackAllowFontScaling: boolean,
+    +headerBackTitle: string | null,
+    +headerBackTitleStyle: TextStyleProp,
+    +headerBackTitleVisible: boolean,
+    +headerTruncatedBackTitle: string,
+    +headerLeft: StackHeaderLeftButtonProps => React$Node,
+    +headerLeftContainerStyle: ViewStyleProp,
+    +headerRight: {| tintColor?: string |} => React$Node,
+    +headerRightContainerStyle: ViewStyleProp,
+    +headerBackImage: $PropertyType<StackHeaderLeftButtonProps, 'backImage'>,
+    +headerPressColorAndroid: string,
+    +headerBackground: ({| style: ViewStyleProp |}) => React$Node,
+    +headerStyle: ViewStyleProp,
+    +headerTransparent: boolean,
+    +headerStatusBarHeight: number,
+  |}>;
+
+  /**
+   * Stack navigation prop
+   */
+
+  declare export type StackNavigationEventMap = {|
+    ...EventMapCore<StackNavigationState>,
+    +transitionStart: {|
+      +data: {| +closing: boolean |},
+      +canPreventDefault: false,
+    |},
+    +transitionEnd: {|
+      +data: {| +closing: boolean |},
+      +canPreventDefault: false,
+    |},
+    +gestureStart: {| +data: void, +canPreventDefault: false |},
+    +gestureEnd: {| +data: void, +canPreventDefault: false |},
+    +gestureCancel: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare type InexactStackNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = StackOptions,
+    EventMap: EventMapBase = StackNavigationEventMap,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      StackNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +replace: SimpleNavigate<ParamList>,
+    +push: SimpleNavigate<ParamList>,
+    +pop: (count?: number) => void,
+    +popToTop: () => void,
+    ...
+  };
+
+  declare export type StackNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = StackOptions,
+    EventMap: EventMapBase = StackNavigationEventMap,
+  > = $Exact<InexactStackNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous stack exports
+   */
+
+  declare type StackNavigationConfig = {|
+    +mode?: 'card' | 'modal',
+    +headerMode?: 'float' | 'screen' | 'none',
+    +keyboardHandlingEnabled?: boolean,
+    +detachInactiveScreens?: boolean,
+  |};
+
+  declare export type ExtraStackNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...StackRouterOptions,
+    ...StackNavigationConfig,
+  |};
+
+  declare export type StackNavigatorProps<
+    NavProp: InexactStackNavigationProp<> = StackNavigationProp<>,
+  > = {|
+    ...ExtraStackNavigatorProps,
+    ...ScreenOptionsProp<StackOptions, NavProp>,
+  |};
+
+  /**
+   * Bottom tab options
+   */
+
+  declare export type BottomTabBarButtonProps = {|
+    ...$Diff<
+      TouchableWithoutFeedbackProps,
+      {| onPress?: ?(event: PressEvent) => mixed |},
+    >,
+    +to?: string,
+    +children: React$Node,
+    +onPress?: (MouseEvent | PressEvent) => void,
+  |};
+
+  declare export type TabBarVisibilityAnimationConfig =
+    | {|
+        +animation: 'spring',
+        +config?: $Diff<
+          SpringAnimationConfigSingle,
+          { toValue: number | AnimatedValue, useNativeDriver: boolean, ... },
+        >,
+      |}
+    | {|
+        +animation: 'timing',
+        +config?: $Diff<
+          TimingAnimationConfigSingle,
+          { toValue: number | AnimatedValue, useNativeDriver: boolean, ... },
+        >,
+      |};
+
+  declare export type BottomTabOptions = $Partial<{|
+    +title: string,
+    +tabBarLabel:
+      | string
+      | ({| focused: boolean, color: string |}) => React$Node,
+    +tabBarIcon: ({|
+      focused: boolean,
+      color: string,
+      size: number,
+    |}) => React$Node,
+    +tabBarBadge: number | string,
+    +tabBarBadgeStyle: TextStyleProp,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+    +tabBarVisible: boolean,
+    +tabBarVisibilityAnimationConfig: $Partial<{|
+      +show: TabBarVisibilityAnimationConfig,
+      +hide: TabBarVisibilityAnimationConfig,
+    |}>,
+    +tabBarButton: BottomTabBarButtonProps => React$Node,
+    +unmountOnBlur: boolean,
+  |}>;
+
+  /**
+   * Bottom tab navigation prop
+   */
+
+  declare export type BottomTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+    +tabLongPress: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare type InexactTabNavigationProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList>,
+    Options: {...},
+    EventMap: EventMapBase,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      TabNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +jumpTo: SimpleNavigate<ParamList>,
+    ...
+  };
+
+  declare export type InexactBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = BottomTabOptions,
+    EventMap: EventMapBase = BottomTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type BottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = BottomTabOptions,
+    EventMap: EventMapBase = BottomTabNavigationEventMap,
+  > = $Exact<InexactBottomTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous bottom tab exports
+   */
+
+  declare export type BottomTabDescriptor = Descriptor<
+    BottomTabNavigationProp<>,
+    BottomTabOptions,
+  >;
+
+  declare export type BottomTabBarOptions = $Partial<{|
+    +keyboardHidesTabBar: boolean,
+    +activeTintColor: string,
+    +inactiveTintColor: string,
+    +activeBackgroundColor: string,
+    +inactiveBackgroundColor: string,
+    +allowFontScaling: boolean,
+    +showLabel: boolean,
+    +showIcon: boolean,
+    +labelStyle: TextStyleProp,
+    +iconStyle: TextStyleProp,
+    +tabStyle: ViewStyleProp,
+    +labelPosition: 'beside-icon' | 'below-icon',
+    +adaptive: boolean,
+    +safeAreaInsets: $Partial<EdgeInsets>,
+    +style: ViewStyleProp,
+  |}>;
+
+  declare type BottomTabNavigationBuilderResult = {|
+    +state: TabNavigationState,
+    +navigation: BottomTabNavigationProp<>,
+    +descriptors: {| +[key: string]: BottomTabDescriptor |},
+  |};
+
+  declare export type BottomTabBarProps = {|
+    ...BottomTabBarOptions,
+    ...BottomTabNavigationBuilderResult,
+  |}
+
+  declare type BottomTabNavigationConfig = {|
+    +lazy?: boolean,
+    +tabBar?: BottomTabBarProps => React$Node,
+    +tabBarOptions?: BottomTabBarOptions,
+    +detachInactiveScreens?: boolean,
+  |};
+
+  declare export type ExtraBottomTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...BottomTabNavigationConfig,
+  |};
+
+  declare export type BottomTabNavigatorProps<
+    NavProp: InexactBottomTabNavigationProp<> = BottomTabNavigationProp<>,
+  > = {|
+    ...ExtraBottomTabNavigatorProps,
+    ...ScreenOptionsProp<BottomTabOptions, NavProp>,
+  |};
+
+  /**
+   * Material bottom tab options
+   */
+
+  declare export type MaterialBottomTabOptions = $Partial<{|
+    +title: string,
+    +tabBarColor: string,
+    +tabBarLabel: string,
+    +tabBarIcon:
+      | string
+      | ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarBadge: boolean | number | string,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+  |}>;
+
+  /**
+   * Material bottom tab navigation prop
+   */
+
+  declare export type MaterialBottomTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+  |};
+
+  declare export type InexactMaterialBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialBottomTabOptions,
+    EventMap: EventMapBase = MaterialBottomTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type MaterialBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialBottomTabOptions,
+    EventMap: EventMapBase = MaterialBottomTabNavigationEventMap,
+  > = $Exact<InexactMaterialBottomTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous material bottom tab exports
+   */
+
+  declare export type PaperFont = {|
+    +fontFamily: string,
+    +fontWeight?:
+      | 'normal'
+      | 'bold'
+      | '100'
+      | '200'
+      | '300'
+      | '400'
+      | '500'
+      | '600'
+      | '700'
+      | '800'
+      | '900',
+  |};
+
+  declare export type PaperFonts = {|
+    +regular: Font,
+    +medium: Font,
+    +light: Font,
+    +thin: Font,
+  |};
+
+  declare export type PaperTheme = {|
+    +dark: boolean,
+    +mode?: 'adaptive' | 'exact',
+    +roundness: number,
+    +colors: {|
+      +primary: string,
+      +background: string,
+      +surface: string,
+      +accent: string,
+      +error: string,
+      +text: string,
+      +onSurface: string,
+      +onBackground: string,
+      +disabled: string,
+      +placeholder: string,
+      +backdrop: string,
+      +notification: string,
+    |},
+    +fonts: PaperFonts,
+    +animation: {|
+      +scale: number,
+    |},
+  |};
+
+  declare export type PaperRoute = {|
+    +key: string,
+    +title?: string,
+    +icon?: any,
+    +badge?: string | number | boolean,
+    +color?: string,
+    +accessibilityLabel?: string,
+    +testID?: string,
+  |};
+
+  declare export type PaperTouchableProps = {|
+    ...TouchableWithoutFeedbackProps,
+    +key: string,
+    +route: PaperRoute,
+    +children: React$Node,
+    +borderless?: boolean,
+    +centered?: boolean,
+    +rippleColor?: string,
+  |};
+
+  declare export type MaterialBottomTabNavigationConfig = {|
+    +shifting?: boolean,
+    +labeled?: boolean,
+    +renderTouchable?: PaperTouchableProps => React$Node,
+    +activeColor?: string,
+    +inactiveColor?: string,
+    +sceneAnimationEnabled?: boolean,
+    +keyboardHidesNavigationBar?: boolean,
+    +barStyle?: ViewStyleProp,
+    +style?: ViewStyleProp,
+    +theme?: PaperTheme,
+  |};
+
+  declare export type ExtraMaterialBottomTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...MaterialBottomTabNavigationConfig,
+  |};
+
+  declare export type MaterialBottomTabNavigatorProps<
+    NavProp: InexactMaterialBottomTabNavigationProp<> =
+      MaterialBottomTabNavigationProp<>,
+  > = {|
+    ...ExtraMaterialBottomTabNavigatorProps,
+    ...ScreenOptionsProp<MaterialBottomTabOptions, NavProp>,
+  |};
+
+  /**
+   * Material top tab options
+   */
+
+  declare export type MaterialTopTabOptions = $Partial<{|
+    +title: string,
+    +tabBarLabel:
+      | string
+      | ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarIcon: ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+  |}>;
+
+  /**
+   * Material top tab navigation prop
+   */
+
+  declare export type MaterialTopTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+    +tabLongPress: {| +data: void, +canPreventDefault: false |},
+    +swipeStart: {| +data: void, +canPreventDefault: false |},
+    +swipeEnd: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare export type InexactMaterialTopTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialTopTabOptions,
+    EventMap: EventMapBase = MaterialTopTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type MaterialTopTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialTopTabOptions,
+    EventMap: EventMapBase = MaterialTopTabNavigationEventMap,
+  > = $Exact<InexactMaterialTopTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous material top tab exports
+   */
+
+  declare type MaterialTopTabPagerCommonProps = {|
+    +keyboardDismissMode: 'none' | 'on-drag' | 'auto',
+    +swipeEnabled: boolean,
+    +swipeVelocityImpact?: number,
+    +springVelocityScale?: number,
+    +springConfig: $Partial<{|
+      +damping: number,
+      +mass: number,
+      +stiffness: number,
+      +restSpeedThreshold: number,
+      +restDisplacementThreshold: number,
+    |}>,
+    +timingConfig: $Partial<{|
+      +duration: number,
+    |}>,
+  |};
+
+  declare export type MaterialTopTabPagerProps = {|
+    ...MaterialTopTabPagerCommonProps,
+    +onSwipeStart?: () => void,
+    +onSwipeEnd?: () => void,
+    +onIndexChange: (index: number) => void,
+    +navigationState: TabNavigationState,
+    +layout: {| +width: number, +height: number |},
+    +removeClippedSubviews: boolean,
+    +children: ({|
+      +addListener: (type: 'enter', listener: number => void) => void,
+      +removeListener: (type: 'enter', listener: number => void) => void,
+      +position: any, // Reanimated.Node<number>
+      +render: React$Node => React$Node,
+      +jumpTo: string => void,
+    |}) => React$Node,
+    +gestureHandlerProps: PanGestureHandlerProps,
+  |};
+
+  declare export type MaterialTopTabBarIndicatorProps = {|
+    +navigationState: TabNavigationState,
+    +width: string,
+    +style?: ViewStyleProp,
+    +getTabWidth: number => number,
+  |};
+
+  declare export type MaterialTopTabBarOptions = $Partial<{|
+    +scrollEnabled: boolean,
+    +bounces: boolean,
+    +pressColor: string,
+    +pressOpacity: number,
+    +getAccessible: ({| +route: Route<> |}) => boolean,
+    +renderBadge: ({| +route: Route<> |}) => React$Node,
+    +renderIndicator: MaterialTopTabBarIndicatorProps => React$Node,
+    +tabStyle: ViewStyleProp,
+    +indicatorStyle: ViewStyleProp,
+    +indicatorContainerStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+    +contentContainerStyle: ViewStyleProp,
+    +style: ViewStyleProp,
+    +activeTintColor: string,
+    +inactiveTintColor: string,
+    +iconStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+    +showLabel: boolean,
+    +showIcon: boolean,
+    +allowFontScaling: boolean,
+  |}>;
+
+  declare export type MaterialTopTabDescriptor = Descriptor<
+    MaterialBottomTabNavigationProp<>,
+    MaterialBottomTabOptions,
+  >;
+
+  declare type MaterialTopTabNavigationBuilderResult = {|
+    +state: TabNavigationState,
+    +navigation: MaterialTopTabNavigationProp<>,
+    +descriptors: {| +[key: string]: MaterialTopTabDescriptor |},
+  |};
+
+  declare export type MaterialTopTabBarProps = {|
+    ...MaterialTopTabBarOptions,
+    ...MaterialTopTabNavigationBuilderResult,
+    +layout: {| +width: number, +height: number |},
+    +position: any, // Reanimated.Node<number>
+    +jumpTo: string => void,
+  |};
+
+  declare export type MaterialTopTabNavigationConfig = {|
+    ...$Partial<MaterialTopTabPagerCommonProps>,
+    +position?: any, // Reanimated.Value<number>
+    +tabBarPosition?: 'top' | 'bottom',
+    +initialLayout?: $Partial<{| +width: number, +height: number |}>,
+    +lazy?: boolean,
+    +lazyPreloadDistance?: number,
+    +removeClippedSubviews?: boolean,
+    +sceneContainerStyle?: ViewStyleProp,
+    +style?: ViewStyleProp,
+    +gestureHandlerProps?: PanGestureHandlerProps,
+    +pager?: MaterialTopTabPagerProps => React$Node,
+    +lazyPlaceholder?: ({| +route: Route<> |}) => React$Node,
+    +tabBar?: MaterialTopTabBarProps => React$Node,
+    +tabBarOptions?: MaterialTopTabBarOptions,
+  |};
+
+  declare export type ExtraMaterialTopTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...MaterialTopTabNavigationConfig,
+  |};
+
+  declare export type MaterialTopTabNavigatorProps<
+    NavProp: InexactMaterialTopTabNavigationProp<> =
+      MaterialTopTabNavigationProp<>,
+  > = {|
+    ...ExtraMaterialTopTabNavigatorProps,
+    ...ScreenOptionsProp<MaterialTopTabOptions, NavProp>,
+  |};
+
+  /**
+   * Drawer options
+   */
+
+  declare export type DrawerOptions = $Partial<{|
+    title: string,
+    drawerLabel:
+      | string
+      | ({| +color: string, +focused: boolean |}) => React$Node,
+    drawerIcon: ({|
+      +color: string,
+      +size: number,
+      +focused: boolean,
+    |}) => React$Node,
+    gestureEnabled: boolean,
+    swipeEnabled: boolean,
+    unmountOnBlur: boolean,
+  |}>;
+
+  /**
+   * Drawer navigation prop
+   */
+
+  declare export type DrawerNavigationEventMap = {|
+    ...EventMapCore<DrawerNavigationState>,
+    +drawerOpen: {| +data: void, +canPreventDefault: false |},
+    +drawerClose: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare export type InexactDrawerNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = DrawerOptions,
+    EventMap: EventMapBase = DrawerNavigationEventMap,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      DrawerNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +jumpTo: SimpleNavigate<ParamList>,
+    +openDrawer: () => void,
+    +closeDrawer: () => void,
+    +toggleDrawer: () => void,
+    ...
+  };
+
+  declare export type DrawerNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = DrawerOptions,
+    EventMap: EventMapBase = DrawerNavigationEventMap,
+  > = $Exact<InexactDrawerNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous drawer exports
+   */
+
+  declare export type DrawerDescriptor = Descriptor<
+    DrawerNavigationProp<>,
+    DrawerOptions,
+  >;
+
+  declare export type DrawerItemListBaseOptions = $Partial<{|
+    +activeTintColor: string,
+    +activeBackgroundColor: string,
+    +inactiveTintColor: string,
+    +inactiveBackgroundColor: string,
+    +itemStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+  |}>;
+
+  declare export type DrawerContentOptions = $Partial<{|
+    ...DrawerItemListBaseOptions,
+    +contentContainerStyle: ViewStyleProp,
+    +style: ViewStyleProp,
+  |}>;
+
+  declare type DrawerNavigationBuilderResult = {|
+    +state: DrawerNavigationState,
+    +navigation: DrawerNavigationProp<>,
+    +descriptors: {| +[key: string]: DrawerDescriptor |},
+  |};
+
+  declare export type DrawerContentProps = {|
+    ...DrawerContentOptions,
+    ...DrawerNavigationBuilderResult,
+    +progress: any, // Reanimated.Node<number>
+  |};
+
+  declare export type DrawerNavigationConfig = {|
+    +drawerPosition?: 'left' | 'right',
+    +drawerType?: 'front' | 'back' | 'slide' | 'permanent',
+    +edgeWidth?: number,
+    +hideStatusBar?: boolean,
+    +keyboardDismissMode?: 'on-drag' | 'none',
+    +minSwipeDistance?: number,
+    +overlayColor?: string,
+    +statusBarAnimation?: 'slide' | 'none' | 'fade',
+    +gestureHandlerProps?: PanGestureHandlerProps,
+    +lazy?: boolean,
+    +drawerContent?: DrawerContentProps => React$Node,
+    +drawerContentOptions?: DrawerContentOptions,
+    +sceneContainerStyle?: ViewStyleProp,
+    +drawerStyle?: ViewStyleProp,
+    +detachInactiveScreens?: boolean,
+  |};
+
+  declare export type ExtraDrawerNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...DrawerRouterOptions,
+    ...DrawerNavigationConfig,
+  |};
+
+  declare export type DrawerNavigatorProps<
+    NavProp: InexactDrawerNavigationProp<> = DrawerNavigationProp<>,
+  > = {|
+    ...ExtraDrawerNavigatorProps,
+    ...ScreenOptionsProp<DrawerOptions, NavProp>,
+  |};
+
+  /**
+   * BaseNavigationContainer
+   */
+
+  declare export type BaseNavigationContainerProps = {|
+    +children: React$Node,
+    +initialState?: PossiblyStaleNavigationState,
+    +onStateChange?: (state: ?PossiblyStaleNavigationState) => void,
+    +independent?: boolean,
+  |};
+
+  declare export type ContainerEventMap = {|
+    ...GlobalEventMap<PossiblyStaleNavigationState>,
+    +options: {|
+      +data: {| +options: { +[key: string]: mixed, ... } |},
+      +canPreventDefault: false,
+    |},
+    +__unsafe_action__: {|
+      +data: {|
+        +action: GenericNavigationAction,
+        +noop: boolean,
+      |},
+      +canPreventDefault: false,
+    |},
+  |};
+
+  declare export type BaseNavigationContainerInterface = {|
+    ...$Exact<NavigationHelpers<
+      ParamListBase,
+      PossiblyStaleNavigationState,
+      ContainerEventMap,
+    >>,
+    +setParams: (params: ScreenParams) => void,
+    +resetRoot: (state?: ?PossiblyStaleNavigationState) => void,
+    +getRootState: () => PossiblyStaleNavigationState,
+  |};
+
+  /**
+   * State utils
+   */
+
+  declare export type GetStateFromPath = (
+    path: string,
+    options?: LinkingConfig,
+  ) => PossiblyStaleNavigationState;
+
+  declare export type GetPathFromState = (
+    state?: ?PossiblyStaleNavigationState,
+    options?: LinkingConfig,
+  ) => string;
+
+  declare export type GetFocusedRouteNameFromRoute =
+    PossiblyStaleRoute<string> => ?string;
+
+  /**
+   * Linking
+   */
+
+  declare export type ScreenLinkingConfig = {|
+    +path?: string,
+    +exact?: boolean,
+    +parse?: {| +[param: string]: string => mixed |},
+    +stringify?: {| +[param: string]: mixed => string |},
+    +screens?: ScreenLinkingConfigMap,
+    +initialRouteName?: string,
+  |};
+
+  declare export type ScreenLinkingConfigMap = {|
+    +[routeName: string]: string | ScreenLinkingConfig,
+  |};
+
+  declare export type LinkingConfig = {|
+    +initialRouteName?: string,
+    +screens: ScreenLinkingConfigMap,
+  |};
+
+  declare export type LinkingOptions = {|
+    +enabled?: boolean,
+    +prefixes: $ReadOnlyArray<string>,
+    +config?: LinkingConfig,
+    +getStateFromPath?: GetStateFromPath,
+    +getPathFromState?: GetPathFromState,
+  |};
+
+  /**
+   * NavigationContainer
+   */
+
+  declare export type Theme = {|
+    +dark: boolean,
+    +colors: {|
+      +primary: string,
+      +background: string,
+      +card: string,
+      +text: string,
+      +border: string,
+    |},
+  |};
+
+  declare export type NavigationContainerType = React$AbstractComponent<
+    {|
+      ...BaseNavigationContainerProps,
+      +theme?: Theme,
+      +linking?: LinkingOptions,
+      +fallback?: React$Node,
+      +onReady?: () => mixed,
+    |},
+    BaseNavigationContainerInterface,
+  >;
+
+  //---------------------------------------------------------------------------
+  // SECTION 2: EXPORTED MODULE
+  // This section defines the module exports and contains exported types that
+  // are not present in any other React Navigation libdef.
+  //---------------------------------------------------------------------------
+
+  /**
+   * StackView
+   */
+
+  declare export var StackView: React$ComponentType<{|
+    ...StackNavigationConfig,
+    +state: StackNavigationState,
+    +navigation: StackNavigationProp<>,
+    +descriptors: {| +[key: string]: StackDescriptor |},
+  |}>;
+
+  /**
+   * createStackNavigator
+   */
+
+  declare export var createStackNavigator: CreateNavigator<
+    StackNavigationState,
+    StackOptions,
+    StackNavigationEventMap,
+    ExtraStackNavigatorProps,
+  >;
+
+  /**
+   * Header components
+   */
+
+  declare export var Header: React$ComponentType<StackHeaderProps>;
+
+  declare export type StackHeaderTitleProps = $Partial<StackHeaderTitleInputBase>;
+  declare export var HeaderTitle: React$ComponentType<StackHeaderTitleProps>;
+
+  declare export type HeaderBackButtonProps = $Partial<{|
+    ...StackHeaderLeftButtonProps,
+    +disabled: boolean,
+    +accessibilityLabel: string,
+  |}>;
+  declare export var HeaderBackButton: React$ComponentType<
+    HeaderBackButtonProps,
+  >;
+
+  declare export type HeaderBackgroundProps = $Partial<{
+    +children: React$Node,
+    +style: AnimatedViewStyleProp,
+    ...
+  }>;
+  declare export var HeaderBackground: React$ComponentType<
+    HeaderBackgroundProps,
+  >;
+
+  /**
+   * Style/animation options
+   */
+
+  declare export var CardStyleInterpolators: {|
+    +forHorizontalIOS: StackCardStyleInterpolator,
+    +forVerticalIOS: StackCardStyleInterpolator,
+    +forModalPresentationIOS: StackCardStyleInterpolator,
+    +forFadeFromBottomAndroid: StackCardStyleInterpolator,
+    +forRevealFromBottomAndroid: StackCardStyleInterpolator,
+    +forScaleFromCenterAndroid: StackCardStyleInterpolator,
+    +forNoAnimation: StackCardStyleInterpolator,
+  |};
+  declare export var HeaderStyleInterpolators: {|
+    +forUIKit: StackHeaderStyleInterpolator,
+    +forFade: StackHeaderStyleInterpolator,
+    +forSlideLeft: StackHeaderStyleInterpolator,
+    +forSlideRight: StackHeaderStyleInterpolator,
+    +forSlideUp: StackHeaderStyleInterpolator,
+    +forNoAnimation: StackHeaderStyleInterpolator,
+  |};
+  declare export var TransitionSpecs: {|
+    +TransitionIOSSpec: TransitionSpec,
+    +FadeInFromBottomAndroidSpec: TransitionSpec,
+    +FadeOutToBottomAndroidSpec: TransitionSpec,
+    +RevealFromBottomAndroidSpec: TransitionSpec,
+    +ScaleFromCenterAndroidSpec: TransitionSpec,
+  |};
+  declare export var TransitionPresets: {|
+    +SlideFromRightIOS: TransitionPreset,
+    +ModalSlideFromBottomIOS: TransitionPreset,
+    +ModalPresentationIOS: TransitionPreset,
+    +FadeFromBottomAndroid: TransitionPreset,
+    +RevealFromBottomAndroid: TransitionPreset,
+    +ScaleFromCenterAndroid: TransitionPreset,
+    +DefaultTransition: TransitionPreset,
+    +ModalTransition: TransitionPreset,
+  |};
+
+  /**
+   * Image assets
+   */
+
+  declare export var Assets: $ReadOnlyArray<ImageURISource>;
+
+  /**
+   * CardAnimation accessors
+   */
+
+  declare export var CardAnimationContext: React$Context<
+    ?StackCardInterpolationProps,
+  >;
+  declare export function useCardAnimation(): StackCardInterpolationProps
+
+  /**
+   * HeaderHeight accessors
+   */
+
+  declare export var HeaderHeightContext: React$Context<?number>;
+  declare export function useHeaderHeight(): number;
+
+  /**
+   * GestureHandler accessors
+   */
+
+  declare type GestureHandlerRef = React$Ref<
+    React$ComponentType<GestureHandlerProps>,
+  >;
+  declare export var GestureHandlerRefContext: React$Context<
+    ?GestureHandlerRef,
+  >;
+  declare export function useGestureHandlerRef(): GestureHandlerRef;
+
+}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@react-native-community/masked-view": "0.1.10",
     "@react-native-community/netinfo": "5.9.9",
     "@react-navigation/bottom-tabs": "5.11.8",
-    "@react-navigation/drawer": "5.12.5",
     "@react-navigation/material-top-tabs": "5.3.10",
     "@react-navigation/native": "5.9.3",
     "@react-navigation/stack": "5.14.5",

--- a/src/AppNavigator.js
+++ b/src/AppNavigator.js
@@ -115,7 +115,10 @@ const NavigatorSwitch = compose(
       return (
         <Stack.Navigator
           screenOptions={({route}) => ({
-            title: route.params?.title ?? undefined,
+            title:
+              typeof route.params?.title === 'string'
+                ? route.params.title
+                : undefined,
             ...defaultNavigationOptions,
             ...defaultStackNavigatorOptions,
           })}

--- a/src/AppNavigator.js
+++ b/src/AppNavigator.js
@@ -51,7 +51,18 @@ type NavigatorSwitchProps = {|
   isAppSetupComplete: boolean,
   signin: () => void,
 |}
-const Stack = createStackNavigator()
+
+type AppNavigatorRoutes = {
+  maintenance: any,
+  'screens-index': any,
+  storybook: any,
+  'new-wallet': any,
+  'app-root': any,
+  'custom-pin-auth': any,
+  'bio-auth': any,
+}
+
+const Stack = createStackNavigator<any, AppNavigatorRoutes, any>()
 
 const NavigatorSwitch = compose(
   connect(

--- a/src/AppNavigator.js
+++ b/src/AppNavigator.js
@@ -115,10 +115,8 @@ const NavigatorSwitch = compose(
       return (
         <Stack.Navigator
           screenOptions={({route}) => ({
-            title:
-              typeof route.params?.title === 'string'
-                ? route.params.title
-                : undefined,
+            // $FlowFixMe mixed is incompatible with string
+            title: route.params?.title ?? undefined,
             ...defaultNavigationOptions,
             ...defaultStackNavigatorOptions,
           })}

--- a/src/components/Catalyst/Catalyst.stories.js
+++ b/src/components/Catalyst/Catalyst.stories.js
@@ -42,16 +42,17 @@ storiesOf('Catalyst', module)
   })
   .add('Step 5', ({route, navigation}) => {
     return (
+      // $FlowFixMe
       <Step5
         navigation={navigation}
         route={route}
-        //  $FlowFixMe
         unSignedTx={mockUnsignedTx}
       />
     )
   })
   .add('Step 6', ({route, navigation}) => {
     return (
+      // $FlowFixMe
       <Step6
         navigation={navigation}
         route={route}

--- a/src/components/Catalyst/CatalystNavigator.js
+++ b/src/components/Catalyst/CatalystNavigator.js
@@ -17,7 +17,18 @@ import CatalystStep5 from './Step5'
 import CatalystStep6 from './Step6'
 import BiometricAuthScreen from '../Send/BiometricAuthScreen'
 
-const Stack = createStackNavigator()
+type CatalystNavigatorRoutes = {
+  'catalyst-router': any,
+  'catalyst-landing': any,
+  'catalyst-generate-pin': any,
+  'catalyst-confirm-pin': any,
+  'catalyst-generate-trx': any,
+  'catalyst-transaction': any,
+  'catalyst-qr-code': any,
+  'catalyst-biometrics-signing': any,
+}
+
+const Stack = createStackNavigator<any, CatalystNavigatorRoutes, any>()
 
 const CatalystNavigator = () => (
   <Stack.Navigator

--- a/src/components/Catalyst/CatalystNavigator.js
+++ b/src/components/Catalyst/CatalystNavigator.js
@@ -28,7 +28,10 @@ const CatalystNavigator = () => (
       name={CATALYST_ROUTES.STEP1}
       component={CatalystStep1}
       options={({route}) => ({
-        title: route.params?.title ?? undefined,
+        title:
+          typeof route.params?.title === 'string'
+            ? route.params.title
+            : undefined,
         ...defaultNavigationOptions,
       })}
     />
@@ -36,7 +39,10 @@ const CatalystNavigator = () => (
       name={CATALYST_ROUTES.STEP2}
       component={CatalystStep2}
       options={({route}) => ({
-        title: route.params?.title ?? undefined,
+        title:
+          typeof route.params?.title === 'string'
+            ? route.params.title
+            : undefined,
         ...defaultNavigationOptions,
       })}
     />
@@ -44,7 +50,10 @@ const CatalystNavigator = () => (
       name={CATALYST_ROUTES.STEP3}
       component={CatalystStep3}
       options={({route}) => ({
-        title: route.params?.title ?? undefined,
+        title:
+          typeof route.params?.title === 'string'
+            ? route.params.title
+            : undefined,
         ...defaultNavigationOptions,
       })}
     />
@@ -52,7 +61,10 @@ const CatalystNavigator = () => (
       name={CATALYST_ROUTES.STEP4}
       component={CatalystStep4}
       options={({route}) => ({
-        title: route.params?.title ?? undefined,
+        title:
+          typeof route.params?.title === 'string'
+            ? route.params.title
+            : undefined,
         ...defaultNavigationOptions,
       })}
     />
@@ -60,7 +72,10 @@ const CatalystNavigator = () => (
       name={CATALYST_ROUTES.STEP5}
       component={CatalystStep5}
       options={({route}) => ({
-        title: route.params?.title ?? undefined,
+        title:
+          typeof route.params?.title === 'string'
+            ? route.params.title
+            : undefined,
         ...defaultNavigationOptions,
       })}
     />
@@ -68,7 +83,10 @@ const CatalystNavigator = () => (
       name={CATALYST_ROUTES.STEP6}
       component={CatalystStep6}
       options={({route}) => ({
-        title: route.params?.title ?? undefined,
+        title:
+          typeof route.params?.title === 'string'
+            ? route.params.title
+            : undefined,
         ...defaultNavigationOptions,
       })}
     />

--- a/src/components/Catalyst/CatalystNavigator.js
+++ b/src/components/Catalyst/CatalystNavigator.js
@@ -28,10 +28,7 @@ const CatalystNavigator = () => (
       name={CATALYST_ROUTES.STEP1}
       component={CatalystStep1}
       options={({route}) => ({
-        title:
-          typeof route.params?.title === 'string'
-            ? route.params.title
-            : undefined,
+        title: route.params?.title ?? undefined,
         ...defaultNavigationOptions,
       })}
     />
@@ -39,10 +36,7 @@ const CatalystNavigator = () => (
       name={CATALYST_ROUTES.STEP2}
       component={CatalystStep2}
       options={({route}) => ({
-        title:
-          typeof route.params?.title === 'string'
-            ? route.params.title
-            : undefined,
+        title: route.params?.title ?? undefined,
         ...defaultNavigationOptions,
       })}
     />
@@ -50,10 +44,7 @@ const CatalystNavigator = () => (
       name={CATALYST_ROUTES.STEP3}
       component={CatalystStep3}
       options={({route}) => ({
-        title:
-          typeof route.params?.title === 'string'
-            ? route.params.title
-            : undefined,
+        title: route.params?.title ?? undefined,
         ...defaultNavigationOptions,
       })}
     />
@@ -61,10 +52,7 @@ const CatalystNavigator = () => (
       name={CATALYST_ROUTES.STEP4}
       component={CatalystStep4}
       options={({route}) => ({
-        title:
-          typeof route.params?.title === 'string'
-            ? route.params.title
-            : undefined,
+        title: route.params?.title ?? undefined,
         ...defaultNavigationOptions,
       })}
     />
@@ -72,10 +60,7 @@ const CatalystNavigator = () => (
       name={CATALYST_ROUTES.STEP5}
       component={CatalystStep5}
       options={({route}) => ({
-        title:
-          typeof route.params?.title === 'string'
-            ? route.params.title
-            : undefined,
+        title: route.params?.title ?? undefined,
         ...defaultNavigationOptions,
       })}
     />
@@ -83,10 +68,7 @@ const CatalystNavigator = () => (
       name={CATALYST_ROUTES.STEP6}
       component={CatalystStep6}
       options={({route}) => ({
-        title:
-          typeof route.params?.title === 'string'
-            ? route.params.title
-            : undefined,
+        title: route.params?.title ?? undefined,
         ...defaultNavigationOptions,
       })}
     />

--- a/src/components/Catalyst/Step5.js
+++ b/src/components/Catalyst/Step5.js
@@ -74,7 +74,6 @@ const messages = defineMessages({
 type Props = {|
   navigation: Navigation,
   route: Object, // TODO(navigation): type
-  unSignedTx: ?ISignRequest<any>,
 |}
 
 type HOCProps = {
@@ -82,6 +81,7 @@ type HOCProps = {
   isEasyConfirmationEnabled: boolean,
   submitTransaction: (ISignRequest<any>, string) => void,
   defaultAsset: DefaultAsset,
+  unSignedTx?: ISignRequest<any>,
 }
 
 const Step5 = ({

--- a/src/components/Catalyst/Step6.js
+++ b/src/components/Catalyst/Step6.js
@@ -61,7 +61,6 @@ const {FlagSecure} = NativeModules
 type Props = {|
   navigation: Navigation,
   route: Object, // TODO(navigation): type
-  encryptedKey?: string,
 |}
 
 type HOCProps = {

--- a/src/components/Delegation/StakingCenterNavigator.js
+++ b/src/components/Delegation/StakingCenterNavigator.js
@@ -20,7 +20,13 @@ import {
 
 import styles from '../TxHistory/styles/SettingsButton.style'
 
-const Stack = createStackNavigator()
+type StakingCenterRoutes = {
+  'staking-center': any,
+  'delegation-confirmation': any,
+  'biometrics-signing': any,
+}
+
+const Stack = createStackNavigator<any, StakingCenterRoutes, any>()
 
 const StakingCenterNavigator = () => (
   <Stack.Navigator

--- a/src/components/Delegation/StakingCenterNavigator.js
+++ b/src/components/Delegation/StakingCenterNavigator.js
@@ -25,10 +25,8 @@ const Stack = createStackNavigator()
 const StakingCenterNavigator = () => (
   <Stack.Navigator
     screenOptions={({route}) => ({
-      title:
-        typeof route.params?.title === 'string'
-          ? route.params.title
-          : undefined,
+      // $FlowFixMe mixed is not compatible with string
+      title: route.params?.title ?? undefined,
       ...defaultNavigationOptions,
       ...defaultStackNavigatorOptions,
     })}

--- a/src/components/Delegation/StakingCenterNavigator.js
+++ b/src/components/Delegation/StakingCenterNavigator.js
@@ -25,7 +25,10 @@ const Stack = createStackNavigator()
 const StakingCenterNavigator = () => (
   <Stack.Navigator
     screenOptions={({route}) => ({
-      title: route.params?.title ?? undefined,
+      title:
+        typeof route.params?.title === 'string'
+          ? route.params.title
+          : undefined,
       ...defaultNavigationOptions,
       ...defaultStackNavigatorOptions,
     })}

--- a/src/components/Delegation/StakingDashboard.js
+++ b/src/components/Delegation/StakingDashboard.js
@@ -717,10 +717,11 @@ class StakingDashboard extends React.Component<Props, State> {
   }
 }
 
-type ExternalProps = {
+type ExternalProps = {|
   navigation: Navigation,
+  route: any,
   intl: IntlShape,
-}
+|}
 
 export default injectIntl(
   (compose(

--- a/src/components/Delegation/StakingDashboard.js
+++ b/src/components/Delegation/StakingDashboard.js
@@ -717,10 +717,10 @@ class StakingDashboard extends React.Component<Props, State> {
   }
 }
 
-type ExternalProps = {|
+type ExternalProps = {
   navigation: Navigation,
   intl: IntlShape,
-|}
+}
 
 export default injectIntl(
   (compose(

--- a/src/components/Delegation/StakingDashboard.stories.js
+++ b/src/components/Delegation/StakingDashboard.stories.js
@@ -39,7 +39,6 @@ const poolInfo = {
 
 storiesOf('StakingDashboard', module)
   .add('Default', ({navigation, route}) => (
-    // $FlowFixMe
     <StakingDashboard
       navigation={navigation}
       route={route}
@@ -55,7 +54,6 @@ storiesOf('StakingDashboard', module)
     />
   ))
   .add('Loading', ({navigation, route}) => (
-    // $FlowFixMe
     <StakingDashboard
       navigation={navigation}
       route={route}
@@ -74,7 +72,6 @@ storiesOf('StakingDashboard', module)
     />
   ))
   .add('Loaded', ({navigation, route}) => (
-    // $FlowFixMe
     <StakingDashboard
       navigation={navigation}
       route={route}

--- a/src/components/Delegation/StakingDashboard.stories.js
+++ b/src/components/Delegation/StakingDashboard.stories.js
@@ -39,6 +39,7 @@ const poolInfo = {
 
 storiesOf('StakingDashboard', module)
   .add('Default', ({navigation, route}) => (
+    // $FlowFixMe accountBalance is missing in ExternalProps
     <StakingDashboard
       navigation={navigation}
       route={route}
@@ -54,6 +55,7 @@ storiesOf('StakingDashboard', module)
     />
   ))
   .add('Loading', ({navigation, route}) => (
+    // $FlowFixMe accountBalance is missing in ExternalProps
     <StakingDashboard
       navigation={navigation}
       route={route}
@@ -72,6 +74,7 @@ storiesOf('StakingDashboard', module)
     />
   ))
   .add('Loaded', ({navigation, route}) => (
+    // $FlowFixMe accountBalance is missing in ExternalProps
     <StakingDashboard
       navigation={navigation}
       route={route}

--- a/src/components/Delegation/StakingDashboardNavigator.js
+++ b/src/components/Delegation/StakingDashboardNavigator.js
@@ -26,14 +26,20 @@ const Stack = createStackNavigator()
 const DelegationNavigatorSummary = () => (
   <Stack.Navigator
     screenOptions={({route}) => {
-      const extraOptions = isJormungandr(route.params?.networkId)
+      if (typeof route.params?.networkId !== 'number') {
+        throw new Error('Invalid networkId')
+      }
+      const extraOptions = isJormungandr(route.params.networkId)
         ? jormunNavigationOptions
         : {}
       return {
         cardStyle: {
           backgroundColor: 'transparent',
         },
-        title: route.params?.title ?? undefined,
+        title:
+          typeof route.params?.title === 'string'
+            ? route.params.title
+            : undefined,
         ...defaultNavigationOptions,
         ...defaultStackNavigatorOptions,
         ...extraOptions,

--- a/src/components/Delegation/StakingDashboardNavigator.js
+++ b/src/components/Delegation/StakingDashboardNavigator.js
@@ -26,20 +26,15 @@ const Stack = createStackNavigator()
 const DelegationNavigatorSummary = () => (
   <Stack.Navigator
     screenOptions={({route}) => {
-      if (typeof route.params?.networkId !== 'number') {
-        throw new Error('Invalid networkId')
-      }
-      const extraOptions = isJormungandr(route.params.networkId)
+      // $FlowFixMe mixed is incompatible with number
+      const extraOptions = isJormungandr(route.params?.networkId)
         ? jormunNavigationOptions
         : {}
       return {
         cardStyle: {
           backgroundColor: 'transparent',
         },
-        title:
-          typeof route.params?.title === 'string'
-            ? route.params.title
-            : undefined,
+        title: route.params?.title ?? undefined,
         ...defaultNavigationOptions,
         ...defaultStackNavigatorOptions,
         ...extraOptions,

--- a/src/components/Delegation/StakingDashboardNavigator.js
+++ b/src/components/Delegation/StakingDashboardNavigator.js
@@ -21,7 +21,13 @@ import {
 
 import styles from '../TxHistory/styles/SettingsButton.style'
 
-const Stack = createStackNavigator()
+type DelegationNavigatorRoutes = {
+  'staking-dashboard': any,
+  'staking-center': any,
+  'biometrics-signing': any,
+}
+
+const Stack = createStackNavigator<any, DelegationNavigatorRoutes, any>()
 
 const DelegationNavigatorSummary = () => (
   <Stack.Navigator

--- a/src/components/FirstRun/FirstRunNavigator.js
+++ b/src/components/FirstRun/FirstRunNavigator.js
@@ -18,7 +18,10 @@ const FirstRunNavigator = () => (
     initialRouteName={FIRST_RUN_ROUTES.LANGUAGE}
     screenOptions={({route}) => {
       return {
-        title: route.params?.title ?? undefined,
+        title:
+          typeof route.params?.title === 'string'
+            ? route.params.title
+            : undefined,
         cardStyle: {
           backgroundColor: 'transparent',
         },

--- a/src/components/FirstRun/FirstRunNavigator.js
+++ b/src/components/FirstRun/FirstRunNavigator.js
@@ -18,10 +18,8 @@ const FirstRunNavigator = () => (
     initialRouteName={FIRST_RUN_ROUTES.LANGUAGE}
     screenOptions={({route}) => {
       return {
-        title:
-          typeof route.params?.title === 'string'
-            ? route.params.title
-            : undefined,
+        // $FlowFixMe mixed is incompatible with string
+        title: route.params?.title ?? undefined,
         cardStyle: {
           backgroundColor: 'transparent',
         },

--- a/src/components/FirstRun/FirstRunNavigator.js
+++ b/src/components/FirstRun/FirstRunNavigator.js
@@ -11,7 +11,13 @@ import {FIRST_RUN_ROUTES} from '../../RoutesList'
 import AcceptTermsOfServiceScreen from './AcceptTermsOfServiceScreen'
 import CustomPinScreen from './CustomPinScreen'
 
-const Stack = createStackNavigator()
+type FirstRunRoute = {
+  'language-pick': any,
+  'accept-terms-of-service': any,
+  'custom-pin': any,
+}
+
+const Stack = createStackNavigator<any, FirstRunRoute, any>()
 
 const FirstRunNavigator = () => (
   <Stack.Navigator

--- a/src/components/FirstRun/LanguagePickerScreen.js
+++ b/src/components/FirstRun/LanguagePickerScreen.js
@@ -17,9 +17,9 @@ import type {ComponentType} from 'react'
 
 import styles from './styles/LanguagePickerScreen.style'
 
-type ExternalProps = {|
+type ExternalProps = {
   navigation: Navigation,
-|}
+}
 
 const LanguagePickerScreen = ({
   navigation,

--- a/src/components/FirstRun/LanguagePickerScreen.js
+++ b/src/components/FirstRun/LanguagePickerScreen.js
@@ -17,9 +17,10 @@ import type {ComponentType} from 'react'
 
 import styles from './styles/LanguagePickerScreen.style'
 
-type ExternalProps = {
+type ExternalProps = {|
   navigation: Navigation,
-}
+  route: any,
+|}
 
 const LanguagePickerScreen = ({
   navigation,

--- a/src/components/FirstRun/LanguagePickerScreen.stories.js
+++ b/src/components/FirstRun/LanguagePickerScreen.stories.js
@@ -6,6 +6,9 @@ import {storiesOf} from '@storybook/react-native'
 
 import LanguagePickerScreen from './LanguagePickerScreen'
 
-storiesOf('LanguagePickerScreen', module).add('Default', ({navigation}) => (
-  <LanguagePickerScreen navigation={navigation} />
-))
+storiesOf('LanguagePickerScreen', module).add(
+  'Default',
+  ({navigation, route}) => (
+    <LanguagePickerScreen navigation={navigation} route={route} />
+  ),
+)

--- a/src/components/Login/CustomPinLogin.js
+++ b/src/components/Login/CustomPinLogin.js
@@ -50,9 +50,10 @@ const CustomPinLogin = injectIntl(({intl, onPinEnter}: Props) => (
   </View>
 ))
 
-type ExternalProps = {
+type ExternalProps = {|
   navigation: Navigation,
-}
+  route: any,
+|}
 
 export default injectIntl(
   (compose(

--- a/src/components/Login/CustomPinLogin.js
+++ b/src/components/Login/CustomPinLogin.js
@@ -50,11 +50,9 @@ const CustomPinLogin = injectIntl(({intl, onPinEnter}: Props) => (
   </View>
 ))
 
-type ExternalProps = {|
+type ExternalProps = {
   navigation: Navigation,
-  customPinHash: ?string,
-  intl: IntlShape,
-|}
+}
 
 export default injectIntl(
   (compose(

--- a/src/components/MaintenanceScreen.js
+++ b/src/components/MaintenanceScreen.js
@@ -123,7 +123,9 @@ export default injectIntl(
         initApp,
       },
     ),
-  )(MaintenanceScreen): ComponentType<{
+  )(MaintenanceScreen): ComponentType<{|
     intl: IntlShape,
-  }>),
+    navigation: any,
+    route: any,
+  |}>),
 )

--- a/src/components/MaintenanceScreen.js
+++ b/src/components/MaintenanceScreen.js
@@ -123,7 +123,7 @@ export default injectIntl(
         initApp,
       },
     ),
-  )(MaintenanceScreen): ComponentType<{|
+  )(MaintenanceScreen): ComponentType<{
     intl: IntlShape,
-  |}>),
+  }>),
 )

--- a/src/components/MaintenanceScreen.stories.js
+++ b/src/components/MaintenanceScreen.stories.js
@@ -5,6 +5,9 @@ import {storiesOf} from '@storybook/react-native'
 
 import MaintenanceScreen from './MaintenanceScreen'
 
-storiesOf('Maintenance Screen', module).add('default', () => (
-  <MaintenanceScreen />
-))
+storiesOf('Maintenance Screen', module).add(
+  'default',
+  ({route, navigation}) => (
+    <MaintenanceScreen route={route} navigation={navigation} />
+  ),
+)

--- a/src/components/Receive/ReceiveScreenNavigator.js
+++ b/src/components/Receive/ReceiveScreenNavigator.js
@@ -14,10 +14,8 @@ const Stack = createStackNavigator()
 const ReceiveScreenNavigator = () => (
   <Stack.Navigator
     screenOptions={({route}) => ({
-      title:
-        typeof route.params?.title === 'string'
-          ? typeof route.params.title
-          : undefined,
+      // $FlowFixMe mixed is incompatible with string
+      title: route.params?.title ?? undefined,
       ...defaultNavigationOptions,
       ...defaultStackNavigatorOptions,
     })}

--- a/src/components/Receive/ReceiveScreenNavigator.js
+++ b/src/components/Receive/ReceiveScreenNavigator.js
@@ -9,7 +9,11 @@ import {
   defaultStackNavigatorOptions,
 } from '../../navigationOptions'
 
-const Stack = createStackNavigator()
+type ReceiveScreenNavigatorRoute = {
+  'receive-ada': {title: string},
+}
+
+const Stack = createStackNavigator<any, ReceiveScreenNavigatorRoute, any>()
 
 const ReceiveScreenNavigator = () => (
   <Stack.Navigator

--- a/src/components/Receive/ReceiveScreenNavigator.js
+++ b/src/components/Receive/ReceiveScreenNavigator.js
@@ -14,7 +14,10 @@ const Stack = createStackNavigator()
 const ReceiveScreenNavigator = () => (
   <Stack.Navigator
     screenOptions={({route}) => ({
-      title: route.params?.title ?? undefined,
+      title:
+        typeof route.params?.title === 'string'
+          ? typeof route.params.title
+          : undefined,
       ...defaultNavigationOptions,
       ...defaultStackNavigatorOptions,
     })}

--- a/src/components/Send/SendScreen.js
+++ b/src/components/Send/SendScreen.js
@@ -937,10 +937,10 @@ class SendScreen extends Component<Props, State> {
   }
 }
 
-type ExternalProps = {|
+type ExternalProps = {
   navigation: Navigation,
   intl: IntlShape,
-|}
+}
 
 export default injectIntl(
   (compose(

--- a/src/components/Send/SendScreen.js
+++ b/src/components/Send/SendScreen.js
@@ -937,10 +937,11 @@ class SendScreen extends Component<Props, State> {
   }
 }
 
-type ExternalProps = {
+type ExternalProps = {|
   navigation: Navigation,
+  route: any,
   intl: IntlShape,
-}
+|}
 
 export default injectIntl(
   (compose(

--- a/src/components/Send/SendScreenNavigator.js
+++ b/src/components/Send/SendScreenNavigator.js
@@ -43,10 +43,8 @@ const SendScreenNavigator = () => (
   <Stack.Navigator
     initialRouteName={SEND_ROUTES.MAIN}
     screenOptions={({route}) => ({
-      title:
-        typeof route.params?.title === 'string'
-          ? route.params.title
-          : undefined,
+      // $FlowFixMe mixed is incompatible with string
+      title: route.params?.title ?? undefined,
       ...defaultNavigationOptions,
       ...defaultStackNavigatorOptions,
     })}
@@ -55,10 +53,7 @@ const SendScreenNavigator = () => (
       name={SEND_ROUTES.MAIN}
       component={SendScreen}
       options={({navigation, route}) => ({
-        title:
-          typeof route.params?.title === 'string'
-            ? route.params.title
-            : undefined,
+        title: route.params?.title ?? undefined,
         headerRight: () => (
           <Button
             style={styles.qrButton}

--- a/src/components/Send/SendScreenNavigator.js
+++ b/src/components/Send/SendScreenNavigator.js
@@ -37,7 +37,14 @@ const setAmount = (amount, route) => {
   handlerAmount && handlerAmount(pastedFormatter(amount))
 }
 
-const Stack = createStackNavigator()
+type SendScreenNavigatorRoutes = {
+  'send-ada': any,
+  'address-reader-qr': any,
+  'send-ada-confirm': any,
+  'biometrics-signing': any,
+}
+
+const Stack = createStackNavigator<any, SendScreenNavigatorRoutes, any>()
 
 const SendScreenNavigator = () => (
   <Stack.Navigator

--- a/src/components/Send/SendScreenNavigator.js
+++ b/src/components/Send/SendScreenNavigator.js
@@ -43,7 +43,10 @@ const SendScreenNavigator = () => (
   <Stack.Navigator
     initialRouteName={SEND_ROUTES.MAIN}
     screenOptions={({route}) => ({
-      title: route.params?.title ?? undefined,
+      title:
+        typeof route.params?.title === 'string'
+          ? route.params.title
+          : undefined,
       ...defaultNavigationOptions,
       ...defaultStackNavigatorOptions,
     })}
@@ -52,7 +55,10 @@ const SendScreenNavigator = () => (
       name={SEND_ROUTES.MAIN}
       component={SendScreen}
       options={({navigation, route}) => ({
-        title: route.params?.title ?? undefined,
+        title:
+          typeof route.params?.title === 'string'
+            ? route.params.title
+            : undefined,
         headerRight: () => (
           <Button
             style={styles.qrButton}

--- a/src/components/Settings/ChangeCustomPinScreen.js
+++ b/src/components/Settings/ChangeCustomPinScreen.js
@@ -146,8 +146,8 @@ export default injectIntl(
       handleVerifyPin,
       handleNewPinEnter,
     }),
-  )(ChangeCustomPinScreen): ComponentType<{|
+  )(ChangeCustomPinScreen): ComponentType<{
     navigation: Navigation,
     intl: IntlShape,
-  |}>),
+  }>),
 )

--- a/src/components/Settings/ChangeCustomPinScreen.js
+++ b/src/components/Settings/ChangeCustomPinScreen.js
@@ -146,8 +146,9 @@ export default injectIntl(
       handleVerifyPin,
       handleNewPinEnter,
     }),
-  )(ChangeCustomPinScreen): ComponentType<{
+  )(ChangeCustomPinScreen): ComponentType<{|
     navigation: Navigation,
+    route: any,
     intl: IntlShape,
-  }>),
+  |}>),
 )

--- a/src/components/Settings/ChangeWalletName.js
+++ b/src/components/Settings/ChangeWalletName.js
@@ -130,8 +130,8 @@ export default injectIntl(
         navigation.goBack()
       },
     }),
-  )(ChangeWalletName): ComponentType<{|
+  )(ChangeWalletName): ComponentType<{
     navigation: Navigation,
     intl: IntlShape,
-  |}>),
+  }>),
 )

--- a/src/components/Settings/ChangeWalletName.js
+++ b/src/components/Settings/ChangeWalletName.js
@@ -130,8 +130,9 @@ export default injectIntl(
         navigation.goBack()
       },
     }),
-  )(ChangeWalletName): ComponentType<{
+  )(ChangeWalletName): ComponentType<{|
     navigation: Navigation,
+    route: any,
     intl: IntlShape,
-  }>),
+  |}>),
 )

--- a/src/components/Settings/SettingsScreenNavigator.js
+++ b/src/components/Settings/SettingsScreenNavigator.js
@@ -37,7 +37,12 @@ const messages = defineMessages({
   },
 })
 
-const Tab = createMaterialTopTabNavigator()
+type SettingsTabRoutes = {
+  'wallet-settings': any,
+  'app-settings': any,
+}
+
+const Tab = createMaterialTopTabNavigator<any, SettingsTabRoutes, any>()
 const SettingsTabNavigator = injectIntl(({intl}: {intl: IntlShape}) => (
   <Tab.Navigator
     screenOptions={({route}) => ({
@@ -76,7 +81,22 @@ const SettingsTabNavigator = injectIntl(({intl}: {intl: IntlShape}) => (
   </Tab.Navigator>
 ))
 
-const Stack = createStackNavigator()
+type SettingsStackNavigatorRoutes = {
+  settings: any,
+  'change-wallet-name': any,
+  'terms-of-use': any,
+  support: any,
+  'fingerprint-link': any,
+  'remove-wallet': any,
+  'change-language': any,
+  'easy-confirmation': any,
+  'change-password': any,
+  'change-custom-pin': any,
+  'bio-authenticate': any,
+  'setup-custom-pin': any,
+}
+
+const Stack = createStackNavigator<any, SettingsStackNavigatorRoutes, any>()
 const SettingsScreenNavigator = () => (
   <Stack.Navigator
     screenOptions={{

--- a/src/components/Settings/WalletSettingsScreen.js
+++ b/src/components/Settings/WalletSettingsScreen.js
@@ -258,8 +258,8 @@ export default injectIntl(
         500,
       ),
     }),
-  )(WalletSettingsScreen): ComponentType<{|
+  )(WalletSettingsScreen): ComponentType<{
     navigation: Navigation,
     intl: IntlShape,
-  |}>),
+  }>),
 )

--- a/src/components/Settings/WalletSettingsScreen.js
+++ b/src/components/Settings/WalletSettingsScreen.js
@@ -258,8 +258,9 @@ export default injectIntl(
         500,
       ),
     }),
-  )(WalletSettingsScreen): ComponentType<{
+  )(WalletSettingsScreen): ComponentType<{|
     navigation: Navigation,
+    route: any,
     intl: IntlShape,
-  }>),
+  |}>),
 )

--- a/src/components/TxHistory/TxDetails.js
+++ b/src/components/TxHistory/TxDetails.js
@@ -440,5 +440,9 @@ export default injectIntl(
         setAddressDetail(null)
       },
     }),
-  )(TxDetails): ComponentType<{navigation: Navigation, intl: IntlShape}>),
+  )(TxDetails): ComponentType<{|
+    navigation: Navigation,
+    route: any,
+    intl: IntlShape,
+  |}>),
 )

--- a/src/components/TxHistory/TxDetails.js
+++ b/src/components/TxHistory/TxDetails.js
@@ -440,5 +440,5 @@ export default injectIntl(
         setAddressDetail(null)
       },
     }),
-  )(TxDetails): ComponentType<{|navigation: Navigation, intl: IntlShape|}>),
+  )(TxDetails): ComponentType<{navigation: Navigation, intl: IntlShape}>),
 )

--- a/src/components/TxHistory/TxHistory.js
+++ b/src/components/TxHistory/TxHistory.js
@@ -311,9 +311,9 @@ const TxHistory = ({
   )
 }
 
-type ExternalProps = {|
+type ExternalProps = {
   navigation: Navigation,
-|}
+}
 
 export default injectIntl(
   (compose(

--- a/src/components/TxHistory/TxHistory.js
+++ b/src/components/TxHistory/TxHistory.js
@@ -311,9 +311,10 @@ const TxHistory = ({
   )
 }
 
-type ExternalProps = {
+type ExternalProps = {|
   navigation: Navigation,
-}
+  route: any,
+|}
 
 export default injectIntl(
   (compose(

--- a/src/components/TxHistory/TxHistoryNavigator.js
+++ b/src/components/TxHistory/TxHistoryNavigator.js
@@ -26,7 +26,10 @@ const TxHistoryNavigator = () => (
       name={TX_HISTORY_ROUTES.MAIN}
       component={TxHistory}
       options={({navigation, route}) => ({
-        title: route.params?.title ?? undefined,
+        title:
+          typeof route.params?.title === 'string'
+            ? route.params.title
+            : undefined,
         headerRight: () => (
           <Button
             style={styles.settingsButton}
@@ -43,7 +46,10 @@ const TxHistoryNavigator = () => (
       name={TX_HISTORY_ROUTES.TX_DETAIL}
       component={TxDetails}
       options={({route}) => ({
-        title: route.params?.title ?? undefined,
+        title:
+          typeof route.params?.title === 'string'
+            ? route.params.title
+            : undefined,
         ...defaultNavigationOptions,
       })}
     />

--- a/src/components/TxHistory/TxHistoryNavigator.js
+++ b/src/components/TxHistory/TxHistoryNavigator.js
@@ -26,10 +26,7 @@ const TxHistoryNavigator = () => (
       name={TX_HISTORY_ROUTES.MAIN}
       component={TxHistory}
       options={({navigation, route}) => ({
-        title:
-          typeof route.params?.title === 'string'
-            ? route.params.title
-            : undefined,
+        title: route.params?.title ?? undefined,
         headerRight: () => (
           <Button
             style={styles.settingsButton}
@@ -46,10 +43,7 @@ const TxHistoryNavigator = () => (
       name={TX_HISTORY_ROUTES.TX_DETAIL}
       component={TxDetails}
       options={({route}) => ({
-        title:
-          typeof route.params?.title === 'string'
-            ? route.params.title
-            : undefined,
+        title: route.params?.title ?? undefined,
         ...defaultNavigationOptions,
       })}
     />

--- a/src/components/TxHistory/TxHistoryNavigator.js
+++ b/src/components/TxHistory/TxHistoryNavigator.js
@@ -15,7 +15,12 @@ import {
 
 import styles from './styles/SettingsButton.style'
 
-const Stack = createStackNavigator()
+type TxHistoryRoutes = {
+  'tx-history-list': any,
+  'tx-details': any,
+}
+
+const Stack = createStackNavigator<any, TxHistoryRoutes, any>()
 
 const TxHistoryNavigator = () => (
   <Stack.Navigator

--- a/src/components/WalletInit/ConnectNanoX/ConnectNanoXScreen.js
+++ b/src/components/WalletInit/ConnectNanoX/ConnectNanoXScreen.js
@@ -113,12 +113,12 @@ const ConnectNanoXScreen = ({
   )
 }
 
-type ExternalProps = {|
+type ExternalProps = {
   intl: IntlShape,
   defaultDevices: ?Array<Device>,
   navigation: Navigation,
   route: Object, // TODO(navigation): type
-|}
+}
 
 export default injectIntl(
   (compose(

--- a/src/components/WalletInit/ConnectNanoX/ConnectNanoXScreen.js
+++ b/src/components/WalletInit/ConnectNanoX/ConnectNanoXScreen.js
@@ -113,12 +113,12 @@ const ConnectNanoXScreen = ({
   )
 }
 
-type ExternalProps = {
+type ExternalProps = {|
   intl: IntlShape,
   defaultDevices: ?Array<Device>,
   navigation: Navigation,
   route: Object, // TODO(navigation): type
-}
+|}
 
 export default injectIntl(
   (compose(

--- a/src/components/WalletInit/CreateWallet/MnemonicCheckScreen.js
+++ b/src/components/WalletInit/CreateWallet/MnemonicCheckScreen.js
@@ -266,8 +266,8 @@ export default injectIntl(
         1000,
       ),
     }),
-  )(MnemonicCheckScreen): ComponentType<{|
+  )(MnemonicCheckScreen): ComponentType<{
     navigation: Navigation,
     intl: IntlShape,
-  |}>),
+  }>),
 )

--- a/src/components/WalletInit/CreateWallet/MnemonicCheckScreen.js
+++ b/src/components/WalletInit/CreateWallet/MnemonicCheckScreen.js
@@ -266,8 +266,9 @@ export default injectIntl(
         1000,
       ),
     }),
-  )(MnemonicCheckScreen): ComponentType<{
+  )(MnemonicCheckScreen): ComponentType<{|
     navigation: Navigation,
+    route: any,
     intl: IntlShape,
-  }>),
+  |}>),
 )

--- a/src/components/WalletInit/CreateWallet/MnemonicCheckScreen.stories.js
+++ b/src/components/WalletInit/CreateWallet/MnemonicCheckScreen.stories.js
@@ -14,7 +14,6 @@ storiesOf('MnemonicCheckScreen', module).add(
       password: CONFIG.DEBUG.PASSWORD,
       networkId: CONFIG.NETWORKS.HASKELL_SHELLEY.NETWORK_ID,
     }
-    // $FlowFixMe
     return <MnemonicCheckScreen route={route} navigation={navigation} />
   },
 )

--- a/src/components/WalletInit/WalletInitNavigator.js
+++ b/src/components/WalletInit/WalletInitNavigator.js
@@ -24,7 +24,23 @@ import WalletCredentialsScreen from './RestoreWallet/WalletCredentialsScreen'
 import {WALLET_INIT_ROUTES} from '../../RoutesList'
 import {isJormungandr} from '../../config/networks'
 
-const Stack = createStackNavigator()
+type WalletInitRoutes = {
+  'choose-create-restore': any,
+  'initial-choose-create-restore': any,
+  'create-wallet-form': any,
+  'restore-wallet-form': any,
+  'import-read-only': any,
+  'save-read-only': any,
+  'check-nano-x': any,
+  'connect-nano-x': any,
+  'save-nano-x': any,
+  'mnemoinc-show': any,
+  'mnemonic-check': any,
+  'wallet-account-checksum': any,
+  'wallet-credentials': any,
+}
+
+const Stack = createStackNavigator<any, WalletInitRoutes, any>()
 
 const WalletInitNavigator = () => (
   <Stack.Navigator

--- a/src/components/WalletInit/WalletInitNavigator.js
+++ b/src/components/WalletInit/WalletInitNavigator.js
@@ -32,20 +32,16 @@ const WalletInitNavigator = () => (
     screenOptions={({route}) => {
       // note: jormun is currently not supported. If you want to add this
       // jormun style, make sure to pass the networkId as a route param
-      if (typeof route.params?.networkId !== 'number') {
-        throw new Error('Invalid networkId')
-      }
-      const extraOptions = isJormungandr(route.params.networkId)
+
+      // $FlowFixMe mixed is incompatible with number
+      const extraOptions = isJormungandr(route.params?.networkId)
         ? jormunNavigationOptions
         : {}
       return {
         cardStyle: {
           backgroundColor: 'transparent',
         },
-        title:
-          typeof route.params?.title === 'string'
-            ? route.params.title
-            : undefined,
+        title: route.params?.title ?? undefined,
         ...defaultNavigationOptions,
         ...defaultStackNavigatorOptions,
         ...extraOptions,

--- a/src/components/WalletInit/WalletInitNavigator.js
+++ b/src/components/WalletInit/WalletInitNavigator.js
@@ -32,14 +32,20 @@ const WalletInitNavigator = () => (
     screenOptions={({route}) => {
       // note: jormun is currently not supported. If you want to add this
       // jormun style, make sure to pass the networkId as a route param
-      const extraOptions = isJormungandr(route.params?.networkId)
+      if (typeof route.params?.networkId !== 'number') {
+        throw new Error('Invalid networkId')
+      }
+      const extraOptions = isJormungandr(route.params.networkId)
         ? jormunNavigationOptions
         : {}
       return {
         cardStyle: {
           backgroundColor: 'transparent',
         },
-        title: route.params?.title ?? undefined,
+        title:
+          typeof route.params?.title === 'string'
+            ? route.params.title
+            : undefined,
         ...defaultNavigationOptions,
         ...defaultStackNavigatorOptions,
         ...extraOptions,
@@ -75,10 +81,9 @@ const WalletInitNavigator = () => (
       name={WALLET_INIT_ROUTES.CHECK_NANO_X}
       component={CheckNanoXScreen}
     />
-    <Stack.Screen
-      name={WALLET_INIT_ROUTES.CONNECT_NANO_X}
-      component={ConnectNanoXScreen}
-    />
+    <Stack.Screen name={WALLET_INIT_ROUTES.CONNECT_NANO_X}>
+      {(props) => <ConnectNanoXScreen {...props} defaultDevices={null} />}
+    </Stack.Screen>
     <Stack.Screen
       name={WALLET_INIT_ROUTES.SAVE_NANO_X}
       component={SaveNanoXScreen}

--- a/src/components/WalletNavigator.js
+++ b/src/components/WalletNavigator.js
@@ -164,7 +164,14 @@ const WalletTabNavigator = injectIntl(
   ),
 )
 
-const Stack = createStackNavigator()
+type WalletStackRoute = {
+  'wallet-selection': any,
+  'main-wallet-routes': any,
+  settings: any,
+  'catalyst-router': any,
+}
+
+const Stack = createStackNavigator<any, WalletStackRoute, any>()
 const WalletNavigator = () => (
   <Stack.Navigator
     initialRouteName={WALLET_ROOT_ROUTES.WALLET_SELECTION}

--- a/src/components/WalletNavigator.js
+++ b/src/components/WalletNavigator.js
@@ -177,10 +177,6 @@ const WalletNavigator = () => (
     <Stack.Screen
       name={WALLET_ROOT_ROUTES.SETTINGS}
       component={SettingsScreenNavigator}
-      screenOptions={{
-        headerShown: false,
-        ...defaultNavigationOptions,
-      }}
     />
     <Stack.Screen
       name={CATALYST_ROUTES.ROOT}

--- a/src/components/WalletNavigator.js
+++ b/src/components/WalletNavigator.js
@@ -106,28 +106,18 @@ const WalletTabNavigator = injectIntl(
     }) => (
       <Tab.Navigator
         initialRouteName={WALLET_ROUTES.TX_HISTORY}
-        screenOptions={({navigation, route}) => {
+        screenOptions={({route}) => {
           const attributes = routeTabAttributes[route.name]
           if (attributes == null) throw new Error('unknown wallet route')
+
           return {
-            tabBarIcon: ({focused, _color, _size}) => {
+            tabBarIcon: ({focused}) => {
               const icon = focused
                 ? attributes.activeIcon
                 : attributes.normalIcon
               return <Image source={icon} />
             },
             tabBarLabel: intl.formatMessage(attributes.label),
-            title: route.params?.title ?? undefined,
-            headerRight: () => (
-              <Button
-                style={styles.settingsButton}
-                onPress={() => navigation.navigate(WALLET_ROOT_ROUTES.SETTINGS)}
-                iconImage={iconGear}
-                title=""
-                withoutBackground
-              />
-            ),
-            ...defaultNavigationOptions,
           }
         }}
         tabBarOptions={{
@@ -139,7 +129,6 @@ const WalletTabNavigator = injectIntl(
         <Tab.Screen
           name={WALLET_ROUTES.TX_HISTORY}
           component={TxHistoryNavigator}
-          options={{headerShown: false}}
         />
         {!isReadOnly && (
           <Tab.Screen

--- a/src/components/WalletNavigator.js
+++ b/src/components/WalletNavigator.js
@@ -84,7 +84,15 @@ const routeTabAttributes = {
   },
 }
 
-const Tab = createBottomTabNavigator()
+type WalletTabRoutes = {
+  history: any,
+  'send-ada': any,
+  'receive-ada': any,
+  'staking-dashboard': any,
+  'staking-center': any,
+}
+
+const Tab = createBottomTabNavigator<any, WalletTabRoutes, any>()
 const WalletTabNavigator = injectIntl(
   compose(
     connect((state) => ({

--- a/src/components/WalletNavigator.js
+++ b/src/components/WalletNavigator.js
@@ -11,7 +11,6 @@ import {injectIntl, defineMessages, type IntlShape} from 'react-intl'
 import {walletMetaSelector, isReadOnlySelector} from '../selectors'
 import {isHaskellShelley} from '../config/config'
 import {WALLET_ROOT_ROUTES, WALLET_ROUTES, CATALYST_ROUTES} from '../RoutesList'
-import {Button} from './UiKit'
 import WalletSelectionScreen from './WalletSelection/WalletSelectionScreen'
 import TxHistoryNavigator from './TxHistory/TxHistoryNavigator'
 import StakingCenterNavigator from './Delegation/StakingCenterNavigator'
@@ -23,7 +22,6 @@ import {defaultNavigationOptions} from '../navigationOptions'
 import CatalystNavigator from './Catalyst/CatalystNavigator'
 
 import {theme} from '../styles/config'
-import styles from './TxHistory/styles/SettingsButton.style'
 import iconHistory from '../assets/img/icon/txhistory.png'
 import iconHistoryActive from '../assets/img/icon/txhistory-active.png'
 import iconSend from '../assets/img/icon/send.png'
@@ -34,7 +32,6 @@ import iconDashboard from '../assets/img/icon/dashboard.png'
 import iconDashboardActive from '../assets/img/icon/dashboard-active.png'
 import iconDelegate from '../assets/img/icon/delegation.png'
 import iconDelegateActive from '../assets/img/icon/delegation-active.png'
-import iconGear from '../assets/img/gear.png'
 
 const messages = defineMessages({
   transactionsButton: {

--- a/src/navigationOptions.js
+++ b/src/navigationOptions.js
@@ -26,6 +26,6 @@ export const defaultStackNavigatorOptions = {
   headerBackTitleVisible: false,
 }
 
-export const jormunNavigationOptions = {
+export const jormunNavigationOptions: Object = {
   headerBackground: () => <GradientHeader />,
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3146,14 +3146,6 @@
     query-string "^6.13.6"
     react-is "^16.13.0"
 
-"@react-navigation/drawer@5.12.5":
-  version "5.12.5"
-  resolved "https://registry.yarnpkg.com/@react-navigation/drawer/-/drawer-5.12.5.tgz#463bd33b29bfcefaa474207b50c2bd3bac6dae79"
-  integrity sha512-WMfz/tKg/K7QBb5rhjXW/pho4zXh3OoHXnHETk5SuVzHlDPM7r84uvAeC5l+ySp5jmipLrJn3zL+kfv9+KKHZQ==
-  dependencies:
-    color "^3.1.3"
-    react-native-iphone-x-helper "^1.3.0"
-
 "@react-navigation/material-top-tabs@5.3.10":
   version "5.3.10"
   resolved "https://registry.yarnpkg.com/@react-navigation/material-top-tabs/-/material-top-tabs-5.3.10.tgz#158b694e87bff2eb9577e8142415de8ac3547412"


### PR DESCRIPTION
add react-navigation types
add navigator routes types

`<Navigator.Screen>` no longer needs route names pulled from `'RoutesList.js'`