### PR TITLE
add @react-navigation/routers

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@react-navigation/material-top-tabs": "5.3.10",
     "@react-navigation/native": "5.9.3",
     "@react-navigation/stack": "5.14.5",
+    "@react-navigation/routers": "5.7.2",
     "@sentry/react-native": "1.4.5",
     "@v-almonacid/react-native-hid": "5.15.4",
     "add": "2.0.6",


### PR DESCRIPTION
i forgot to add @react-navigations/routers when resetting the send screen
it still worked because @react-navigation/native  requires @react-navigation/core which requires @react-navigation/routers