### PR TITLE
upgrade flow

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -38,6 +38,7 @@ node_modules/warning/.*
 ; or just get rid of this dependency)
 .*/node_modules/react-native-linear-gradient/common.js
 
+.*/node_modules/react-native/Libraries/ReactNative/PaperUIManager.js
 [include]
 
 [libs]
@@ -99,4 +100,4 @@ untyped-import
 untyped-type-import
 
 [version]
-^0.122.0
+0.126.0

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "eslint-plugin-react": "7.21.5",
     "eslint-plugin-react-native": "3.10.0",
     "extract-react-intl-messages": "^0.14.0",
-    "flow-bin": "0.122.0",
+    "flow-bin": "0.126.0",
     "flow-coverage-report": "0.8.0",
     "flow-typed": "3.1.0",
     "jest": "25.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8689,10 +8689,10 @@ flow-annotation-check@^1.8.1:
     glob "7.1.6"
     load-pkg "^4.0.0"
 
-flow-bin@0.122.0:
-  version "0.122.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.122.0.tgz#c723a2b33b1a70bd10204704ae1dc776d5d89d79"
-  integrity sha512-my8N5jgl/A+UVby9E7NDppHdhLgRbWgKbmFZSx2MSYMRh3d9YGnM2MM+wexpUpl0ftY1IM6ZcUwaAhrypLyvlA==
+flow-bin@0.126.0:
+  version "0.126.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.126.0.tgz#df06d1c6bf2cb770b71c38a76e8e4491cc57d624"
+  integrity sha512-91nCLt3B0drolW9bXmTssNxhshkkGDwokVyuquBA7TeHMCajbMNxm77JI0JydzHEv9xa6nMbBJXYyM6XW8Jzgg==
 
 flow-coverage-report@0.8.0:
   version "0.8.0"


### PR DESCRIPTION
v0.122.0 is over a year old
flow@latest catches >700 errors
there were some significant changes to flow at v0.127.0
upgrading beyond v0.126.0 should be in a different pr