### PR TITLE
[chore] Circle ci update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,6 @@ jobs:
 
       # Because npm link will write in this path
       - run: sudo chown -R "$(whoami):$(whoami)" /usr/local/lib/node_modules
-      - run: npm link rust-cardano-crypto
       - run: yarn lint
 
   android:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,11 +23,6 @@ jobs:
       - run: rustup install 1.41.0
       - run: rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
       - run: cargo install cargo-lipo
-
-      - run:
-          name: Match bitrise's yarn version
-          command: sudo npm install -g yarn@${BITRISE_YARN_VER}
-
       - run:
           name: Install Dependencies
           command: yarn install --network-concurrency 1
@@ -37,19 +32,16 @@ jobs:
             - node_modules
             - yarn.lock
 
-
       - persist_to_workspace:
           root: .
-          paths: .
+          paths: 
+            - .
 
   flow:
     <<: *rn_defaults
     steps:
       - attach_workspace:
           at: ~/project
-      - run:
-          name: Match bitrise's yarn version
-          command: sudo npm install -g yarn@${BITRISE_YARN_VER}
       - run: yarn flow
 
   test:
@@ -57,9 +49,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/project
-      - run:
-          name: Match bitrise's yarn version
-          command: sudo npm install -g yarn@${BITRISE_YARN_VER}
       - run: yarn test
 
   lint:
@@ -68,9 +57,6 @@ jobs:
       - attach_workspace:
          at: ~/project
 
-      - run:
-          name: Match bitrise's yarn version
-          command: sudo npm install -g yarn@${BITRISE_YARN_VER}
       # Because npm link will write in this path
       - run: sudo chown -R "$(whoami):$(whoami)" /usr/local/lib/node_modules
       - run: npm link rust-cardano-crypto
@@ -122,8 +108,3 @@ workflows:
       - test:
           requires:
             - install-dependencies
-#      - android:
-#          requires:
-#            - install-dependencies
-#            - lint
-#            - flow

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/project
-      - run: yarn test
+      - run: yarn test --runInBand
 
   lint:
     <<: *rn_defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 rn_defaults: &rn_defaults
   working_directory: ~/project
   docker:
-    - image: circleci/node:10.14.2
+    - image: cimg/node:16.5.0
 
 jobs:
   install-dependencies:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-nodejs 10.14.2
+nodejs 16.5.0
 rust 1.41.0
 java adoptopenjdk-8.0.292+10
 python 2.7.18

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "react-native": "0.63.4",
     "react-native-background-timer": "2.4.1",
     "react-native-ble-plx": "2.0.2",
-    "react-native-blockies-svg": "Emurgo/react-native-blockies-svg",
+    "react-native-blockies-svg": "git+https://github.com/Emurgo/react-native-blockies-svg",
     "react-native-bootsplash": "3.2.3",
     "react-native-camera": "3.44.0",
     "react-native-config": "0.12.0",
@@ -167,7 +167,7 @@
     "prettylint": "1.0.0",
     "react-dom": "16.8.3",
     "react-intl-translations-manager": "^5.0.3",
-    "react-native-inhibit-warnings": "https://github.com/Emurgo/react-native-inhibit-warnings.git",
+    "react-native-inhibit-warnings": "git+https://github.com/Emurgo/react-native-inhibit-warnings.git",
     "react-native-schemes-manager": "^1.0.5",
     "react-native-storybook-loader": "^1.8.1",
     "react-test-renderer": "16.13.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14648,9 +14648,9 @@ react-native-ble-plx@2.0.2:
   resolved "https://registry.yarnpkg.com/react-native-ble-plx/-/react-native-ble-plx-2.0.2.tgz#0912c50d4d807ed279a2a1043362c96318518154"
   integrity sha512-NjUl5H7bMgNfMma6i+W+wCsfQjOrUxSnLdmYgb8LSas4UZmmsakhEVK4C9/qHm2oxKB+SLR87zD6upZfD/R3sw==
 
-react-native-blockies-svg@Emurgo/react-native-blockies-svg:
+"react-native-blockies-svg@git+https://github.com/Emurgo/react-native-blockies-svg":
   version "0.0.1"
-  resolved "https://codeload.github.com/Emurgo/react-native-blockies-svg/tar.gz/f3bca0e23b234e3d9373e56cae8ad5bcd07ed378"
+  resolved "git+https://github.com/Emurgo/react-native-blockies-svg#f3bca0e23b234e3d9373e56cae8ad5bcd07ed378"
   dependencies:
     react-native-svg "^7.2.0"
 
@@ -14729,9 +14729,9 @@ react-native-gesture-handler@1.10.3:
     invariant "^2.2.4"
     prop-types "^15.7.2"
 
-"react-native-inhibit-warnings@https://github.com/Emurgo/react-native-inhibit-warnings.git":
+"react-native-inhibit-warnings@git+https://github.com/Emurgo/react-native-inhibit-warnings.git":
   version "1.1.0"
-  resolved "https://github.com/Emurgo/react-native-inhibit-warnings.git#e80b42e3c8f8ae99dcb138e69572a47750ae5ea6"
+  resolved "git+https://github.com/Emurgo/react-native-inhibit-warnings.git#e80b42e3c8f8ae99dcb138e69572a47750ae5ea6"
   dependencies:
     chalk "^1.1.3"
     glob "^7.1.1"


### PR DESCRIPTION
- Move from old legacy circleci repo to cimg 
- Bump node img version to 16.5.0