### PR TITLE
Add support to protocol max_output_size and max_tx_size parameters

### DIFF
--- a/src/config/networks.js
+++ b/src/config/networks.js
@@ -306,3 +306,7 @@ export const DEFAULT_ASSETS: Array<Object> = flatten(
       throw new Error(`Missing default asset for network type ${JSON.stringify(network)}`)
     }),
 )
+
+// Same as serialization-lib
+export const MAX_OUTPUT_SIZE = 4000
+export const MAX_TX_SIZE = 8000

--- a/src/crypto/shelley/transactions.js
+++ b/src/crypto/shelley/transactions.js
@@ -37,11 +37,13 @@ import {BigNumber} from 'bignumber.js'
 import type {RawUtxo} from '../../api/types'
 /* eslint-enable camelcase */
 import {CONFIG} from '../../config/config'
+import {MAX_OUTPUT_SIZE, MAX_TX_SIZE} from '../../config/networks'
 import {AssetOverflowError, InsufficientFunds, NoOutputsError} from '../errors'
 import type {
   Address,
   AddressedUtxo,
   Addressing,
+  ProtocolParameters,
   TxOutput,
   V4UnsignedTxAddressedUtxoResponse,
   V4UnsignedTxUtxoResponse,
@@ -76,13 +78,7 @@ export const sendAllUnsignedTxFromUtxo = async (
   receiver: {|...Address, ...InexactSubset<Addressing>|},
   allUtxos: Array<RawUtxo>,
   absSlotNumber: BigNumber,
-  protocolParams: {|
-    linearFee: LinearFee,
-    minimumUtxoVal: BigNum,
-    poolDeposit: BigNum,
-    keyDeposit: BigNum,
-    networkId: number,
-  |},
+  protocolParams: ProtocolParameters,
   auxiliaryData: AuxiliaryData | void,
 ): Promise<V4UnsignedTxUtxoResponse> => {
   const totalBalance = allUtxos
@@ -97,6 +93,10 @@ export const sendAllUnsignedTxFromUtxo = async (
     protocolParams.minimumUtxoVal,
     protocolParams.poolDeposit,
     protocolParams.keyDeposit,
+    // $FlowFixMe sketchy-null-number
+    protocolParams.maxOutputSize || MAX_OUTPUT_SIZE,
+    // $FlowFixMe sketchy-null-number
+    protocolParams.maxTxSize || MAX_TX_SIZE,
   )
   await txBuilder.set_ttl(absSlotNumber.plus(defaultTtlOffset).toNumber())
   for (const input of allUtxos) {
@@ -308,13 +308,7 @@ export const newAdaUnsignedTxFromUtxo = async (
   changeAdaAddr: void | {|...Address, ...Addressing|},
   utxos: Array<RawUtxo>,
   absSlotNumber: BigNumber,
-  protocolParams: {|
-    linearFee: LinearFee,
-    minimumUtxoVal: BigNum,
-    poolDeposit: BigNum,
-    keyDeposit: BigNum,
-    networkId: number,
-  |},
+  protocolParams: ProtocolParameters,
   certificates: $ReadOnlyArray<Certificate>,
   withdrawals: $ReadOnlyArray<{|
     address: RewardAddress,
@@ -354,6 +348,10 @@ export const newAdaUnsignedTxFromUtxo = async (
     protocolParams.minimumUtxoVal,
     protocolParams.poolDeposit,
     protocolParams.keyDeposit,
+    // $FlowFixMe sketchy-null-number
+    protocolParams.maxOutputSize || MAX_OUTPUT_SIZE,
+    // $FlowFixMe sketchy-null-number
+    protocolParams.maxTxSize || MAX_TX_SIZE,
   )
   if (certificates.length > 0) {
     const certsNative = await Certificates.new()
@@ -603,10 +601,7 @@ async function minRequiredForChange(
   txBuilder: TransactionBuilder,
   changeAdaAddr: {|...Address, ...Addressing|},
   value: Value,
-  protocolParams: {
-    linearFee: LinearFee,
-    minimumUtxoVal: BigNum,
-  },
+  protocolParams: $Shape<ProtocolParameters>,
 ): Promise<BigNum> {
   if (changeAdaAddr == null) throw new NoOutputsError()
   const wasmChange = await normalizeToAddress(changeAdaAddr.address)

--- a/src/crypto/types.js
+++ b/src/crypto/types.js
@@ -5,6 +5,7 @@ import {
   Certificate as V4Certificate,
   TransactionBuilder as V4TransactionBuilder,
 } from '@emurgo/react-native-haskell-shelley'
+import {LinearFee} from '@emurgo/react-native-haskell-shelley'
 import {BigNumber} from 'bignumber.js'
 
 import type {RawUtxo} from '../api/types'
@@ -157,4 +158,14 @@ export type EncryptionMethod = 'BIOMETRICS' | 'SYSTEM_PIN' | 'MASTER_PASSWORD'
 export type PlateResponse = {|
   addresses: Array<string>,
   accountPlate: WalletChecksum,
+|}
+
+export type ProtocolParameters = {|
+  +linearFee: LinearFee,
+  +minimumUtxoVal: BigNumber,
+  +poolDeposit: BigNumber,
+  +keyDeposit: BigNumber,
+  +networkId: number,
+  +maxOutputSize?: number,
+  +maxTxSize?: number,
 |}


### PR DESCRIPTION
- Adds support to the new protocol parameters

To test it, you will need to set the serialization lib to the proper branch of the bindings.