### PR TITLE
Fixed duplicate words handling in wallet confirmaiton

### DIFF
--- a/src/components/WalletInit/CreateWallet/MnemonicCheckScreen.js
+++ b/src/components/WalletInit/CreateWallet/MnemonicCheckScreen.js
@@ -63,10 +63,8 @@ const MnemonicCheckScreen = () => {
   const sortedWordEntries = mnemonic
     .split(' ')
     .sort()
-    .map((s, i) => [s, i]);
-
-  const [partialPhraseEntries, setPartialPhraseEntries] =
-    React.useState<Array<[string, number]>>([])
+    .map((s, i) => [s, i])
+  const [partialPhraseEntries, setPartialPhraseEntries] = React.useState<Array<[string, number]>>([])
   const selectWord = (addWordEntry: [string, number]) =>
     setPartialPhraseEntries([...partialPhraseEntries, addWordEntry])
   const deselectWord = ([, removeWordIdx]: [string, number]) =>
@@ -113,7 +111,11 @@ const MnemonicCheckScreen = () => {
 
       <Spacer height={24} />
 
-      <MnemonicInput onPress={deselectWord} partialPhraseEntries={partialPhraseEntries} error={!isPhraseValid && isPhraseComplete} />
+      <MnemonicInput
+        onPress={deselectWord}
+        partialPhraseEntries={partialPhraseEntries}
+        error={!isPhraseValid && isPhraseComplete}
+      />
 
       <Spacer height={8} />
 
@@ -193,12 +195,11 @@ const WordBadges = ({
   partialPhraseEntries: Array<[string, number]>,
   onSelect: (wordEntry: [string, number]) => any,
 }) => {
-  const isWordUsed = (wordIdx: number) =>
-    partialPhraseEntries.some(([, idx]) => idx === wordIdx);
+  const isWordUsed = (wordIdx: number) => partialPhraseEntries.some(([, idx]) => idx === wordIdx)
   return (
     <View style={styles.words}>
       {wordEntries.map(([word, wordIdx]) => {
-        const isUsed = isWordUsed(wordIdx);
+        const isUsed = isWordUsed(wordIdx)
         return (
           <View key={word} style={[styles.wordBadgeContainer, isUsed && styles.hidden]}>
             <WordBadge
@@ -208,7 +209,7 @@ const WordBadges = ({
               testID={isUsed ? `wordBadgeTapped-${word}` : `wordBadgeNonTapped-${word}`}
             />
           </View>
-        );
+        )
       })}
     </View>
   )


### PR DESCRIPTION
Mnemonic phrases may contain any number of duplicate words, it's valid. Right now duplicates are not handled correctly - all duplicates are removed in case a single similar word is selected. Fixed that problem and also tried to implement the optimal duplicates handling so that we will correctly hide the exact word the user tapped, no matter its position among the duplicates.

```
/*
   * The mnemonic are handled in "word entries" instead of plain text word
   * Where each entry is [word, wordIndex] with index in sorted array
   * This is done so that each word including any duplicates
   * is uniquely identified by its index in the sorted array
   * to improve the UX of the word selecting.
   *
   * Example: original words might be [air, sand, air, desk], which is valid.
   * Sorted entries will be: [[air, 0], [air, 1], [desk, 2], [sand, 3]]
   *
   * We don't care which of the "air" words the user will want to use first.
   * If user clicks on [air, 1] we will be able to detect that this specific
   * was selected and hide it from the options while keeping the first "air"
   * visible, which should be the most intuitive and expected behaviour for the users.
   *
   * When comparing with the original mnemonic we ignore the indexes.
   */
   ```