### PR TITLE
Bump @unstoppabledomains/resolution to v6.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@react-navigation/routers": "5.7.2",
     "@react-navigation/stack": "5.14.5",
     "@sentry/react-native": "1.4.5",
-    "@unstoppabledomains/resolution": "5.0.2",
+    "@unstoppabledomains/resolution": "6.0.3",
     "@v-almonacid/react-native-hid": "5.15.4",
     "add": "2.0.6",
     "babel-eslint": "^10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4002,14 +4002,13 @@
     "@typescript-eslint/types" "5.0.0"
     eslint-visitor-keys "^3.0.0"
 
-"@unstoppabledomains/resolution@5.0.2":
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/@unstoppabledomains/resolution/-/resolution-5.0.2.tgz#5390ab5d28b96ae6a3e05a2de17cb4f756ba1d3c"
-  integrity sha512-CHZeUi0fjqAJL1R5qLjOzpfWTTQ74Mha8g+HWbOY84Nb63OxvPA8wwJUbq4LST77exY3RJdEhq2chWjQdFOM7A==
+"@unstoppabledomains/resolution@6.0.3":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@unstoppabledomains/resolution/-/resolution-6.0.3.tgz#a70888840c86a5918cb3134e7ac745e054c92aa5"
+  integrity sha512-J57SOzDqTDbrTfTzMSybM010LNvyNgEqKtdNcC5CAFg1IeNjC9woX5j1o/IbglXd9CPp1NL7n2Q1mVn9py211g==
   dependencies:
     "@ethersproject/abi" "^5.0.1"
     bn.js "^4.4.0"
-    commander "^4.1.1"
     cross-fetch "^3.1.4"
     elliptic "^6.5.4"
     ethereum-ens-network-map "^1.0.2"


### PR DESCRIPTION
Hello Yoroi team,

I wanted to follow up on the issue with v6.0.0 and the bundler.
I tested `v6.0.3` on mainnet with my own domains, and `brad.crypto`.

All seems to work as expected. Please let me know if any changes can be made on my end.