### PR TITLE
Using fingerprint in asset-list and asset-selector

### DIFF
--- a/legacy/components/Send/AssetSelectorScreen/AssetSelectorScreen.js
+++ b/legacy/components/Send/AssetSelectorScreen/AssetSelectorScreen.js
@@ -14,7 +14,7 @@ import type {TokenEntry} from '../../../crypto/MultiToken'
 import globalMessages, {txLabels} from '../../../i18n/global-messages'
 import {COLORS} from '../../../styles/config'
 import {type Token} from '../../../types/HistoryTransaction'
-import {decodeHexAscii, formatTokenAmount, getAssetDenominationOrId} from '../../../utils/format'
+import {decodeHexAscii, formatTokenAmount, getAssetDenominationOrId, getTokenFingerprint} from '../../../utils/format'
 import {Button, Spacer, Text, TextInput} from '../../UiKit'
 
 type Props = {
@@ -91,7 +91,7 @@ const AssetSelectorItem = ({assetToken, tokenInfo, onPress}: AssetSelectorItemPr
             {getAssetDenominationOrId(tokenInfo) || intl.formatMessage(messages.unknownAsset)}
           </Text>
           <Text numberOfLines={1} ellipsizeMode={'middle'} style={{color: COLORS.TEXT_INPUT}}>
-            {tokenInfo.metadata.assetName}
+            {tokenInfo.isDefault ? '' : getTokenFingerprint(tokenInfo)}
           </Text>
         </View>
 

--- a/src/TxHistory/AssetList.tsx
+++ b/src/TxHistory/AssetList.tsx
@@ -10,7 +10,7 @@ import {Text} from '../../legacy/components/UiKit'
 import globalMessages, {actionMessages} from '../../legacy/i18n/global-messages'
 import {tokenBalanceSelector, tokenInfoSelector} from '../../legacy/selectors'
 import {COLORS} from '../../legacy/styles/config'
-import {formatTokenAmount, getAssetDenominationOrId} from '../../legacy/utils/format'
+import {formatTokenAmount, getAssetDenominationOrId, getTokenFingerprint} from '../../legacy/utils/format'
 import AdaImage from '../assets/img/icon/asset_ada.png'
 import NoImage from '../assets/img/icon/asset_no_image.png'
 import {Spacer} from '../components/Spacer'
@@ -87,7 +87,7 @@ const AssetItem = ({assetToken, tokenInfo, onPress}: AssetItemProps) => {
             {getAssetDenominationOrId(tokenInfo) || strings.unknown}
           </Text>
           <Text numberOfLines={1} ellipsizeMode={'middle'} style={styles.tokenName}>
-            {tokenInfo.metadata.assetName}
+            {tokenInfo.isDefault ? '' : getTokenFingerprint(tokenInfo)}
           </Text>
         </View>
 


### PR DESCRIPTION
In the asset-list (in transactions page) and in the asset-selector (in send page) replacing undecoded asset name on the second line with the fingerprint which is more useful for users to see.