### PR TITLE
Fix bio

### DIFF
--- a/legacy/actions.js
+++ b/legacy/actions.js
@@ -3,7 +3,6 @@
 import {type IntlShape} from 'react-intl'
 import {Alert, AppState, Keyboard, Platform} from 'react-native'
 import RNBootSplash from 'react-native-bootsplash'
-import {QueryClient} from 'react-query'
 import {type Dispatch} from 'redux'
 import uuid from 'uuid'
 
@@ -273,15 +272,14 @@ export const initApp = () => async (dispatch: Dispatch<any>, getState: any) => {
   RNBootSplash.hide({fade: true})
 }
 
-export const checkBiometricStatus = (queryClient: QueryClient) => async (dispatch: Dispatch<any>, getState: any) => {
+export const checkBiometricStatus = () => async (dispatch: Dispatch<any>, getState: any) => {
   const bioShouldBeDisabled =
     Platform.OS === 'android' && CONFIG.ANDROID_BIO_AUTH_EXCLUDED_SDK.includes(Platform.Version)
-
   if (bioShouldBeDisabled) return
 
   const state = getState()
-  const canEnableBioFromCurrentState = canEnableBiometricSelector(state)
 
+  const canEnableBioFromCurrentState = canEnableBiometricSelector(state)
   if (!canEnableBioFromCurrentState) return
 
   const canEnableBioFromDevice = await canBiometricEncryptionBeEnabled()
@@ -290,11 +288,10 @@ export const checkBiometricStatus = (queryClient: QueryClient) => async (dispatc
   if (bioWasTurnedOff) {
     Logger.debug('Biometric was turned off')
     await dispatch(setAppSettingField(APP_SETTINGS_KEYS.CAN_ENABLE_BIOMETRIC_ENCRYPTION, false))
-    queryClient.invalidateQueries(['walletMetas'])
     try {
       await walletManager.disableEasyConfirmation()
     } catch (_e) {
-      Logger.debug('Ignore if no wallet is selected.')
+      Logger.debug('Ignore if no wallet is selected')
     }
     await dispatch(logout())
   }

--- a/legacy/actions.js
+++ b/legacy/actions.js
@@ -3,6 +3,7 @@
 import {type IntlShape} from 'react-intl'
 import {Alert, AppState, Keyboard, Platform} from 'react-native'
 import RNBootSplash from 'react-native-bootsplash'
+import {QueryClient} from 'react-query'
 import {type Dispatch} from 'redux'
 import uuid from 'uuid'
 
@@ -272,19 +273,30 @@ export const initApp = () => async (dispatch: Dispatch<any>, getState: any) => {
   RNBootSplash.hide({fade: true})
 }
 
-export const checkBiometricStatus = () => async (dispatch: Dispatch<any>, getState: any) => {
-  const state = getState()
-  const shouldNotEnableBiometricAuth =
-    !isAppSetupCompleteSelector(state) &&
-    Platform.OS === 'android' &&
-    CONFIG.ANDROID_BIO_AUTH_EXCLUDED_SDK.includes(Platform.Version)
-  const currentCanEnableBiometricEncryption = canEnableBiometricSelector(state)
-  const canEnableBiometricEncryption = (await canBiometricEncryptionBeEnabled()) && !shouldNotEnableBiometricAuth
+export const checkBiometricStatus = (queryClient: QueryClient) => async (dispatch: Dispatch<any>, getState: any) => {
+  const bioShouldBeDisabled =
+    Platform.OS === 'android' && CONFIG.ANDROID_BIO_AUTH_EXCLUDED_SDK.includes(Platform.Version)
 
-  const biometricWasTurnedOff = !canEnableBiometricEncryption && currentCanEnableBiometricEncryption
-  Logger.debug('willResetBiometric:', biometricWasTurnedOff)
-  if (biometricWasTurnedOff) {
-    await dispatch(setAppSettingField(APP_SETTINGS_KEYS.CAN_ENABLE_BIOMETRIC_ENCRYPTION, canEnableBiometricEncryption))
+  if (bioShouldBeDisabled) return
+
+  const state = getState()
+  const canEnableBioFromCurrentState = canEnableBiometricSelector(state)
+
+  if (!canEnableBioFromCurrentState) return
+
+  const canEnableBioFromDevice = await canBiometricEncryptionBeEnabled()
+
+  const bioWasTurnedOff = !canEnableBioFromDevice && canEnableBioFromCurrentState
+  if (bioWasTurnedOff) {
+    Logger.debug('Biometric was turned off')
+    await dispatch(setAppSettingField(APP_SETTINGS_KEYS.CAN_ENABLE_BIOMETRIC_ENCRYPTION, false))
+    queryClient.invalidateQueries(['walletMetas'])
+    try {
+      await walletManager.disableEasyConfirmation()
+    } catch (_e) {
+      Logger.debug('Ignore if no wallet is selected.')
+    }
+    await dispatch(logout())
   }
 }
 

--- a/src/AppNavigator.tsx
+++ b/src/AppNavigator.tsx
@@ -72,7 +72,8 @@ const NavigatorSwitch = () => {
 
   useEffect(() => {
     const appStateSubscription = AppState.addEventListener('change', async () => {
-      await dispatch(checkBiometricStatus(queryClient))
+      await dispatch(checkBiometricStatus())
+      queryClient.invalidateQueries(['walletMetas'])
     })
     return () => appStateSubscription?.remove()
   }, [dispatch, queryClient])

--- a/src/AppNavigator.tsx
+++ b/src/AppNavigator.tsx
@@ -4,10 +4,11 @@ import {isEmpty} from 'lodash'
 import React, {useEffect} from 'react'
 import type {IntlShape} from 'react-intl'
 import {defineMessages, useIntl} from 'react-intl'
-import {Alert} from 'react-native'
+import {Alert, AppState} from 'react-native'
+import {useQueryClient} from 'react-query'
 import {useDispatch, useSelector} from 'react-redux'
 
-import {showErrorDialog, signin} from '../legacy/actions'
+import {checkBiometricStatus, showErrorDialog, signin} from '../legacy/actions'
 import IndexScreen from '../legacy/components/IndexScreen'
 import MaintenanceScreen from '../legacy/components/MaintenanceScreen'
 import BiometricAuthScreen from '../legacy/components/Send/BiometricAuthScreen'
@@ -66,7 +67,15 @@ const NavigatorSwitch = () => {
   const isAppSetupComplete = useSelector(isAppSetupCompleteSelector)
   const canEnableBiometrics = useSelector(canEnableBiometricSelector)
   const installationId = useSelector(installationIdSelector)
+  const queryClient = useQueryClient()
   const dispatch = useDispatch()
+
+  useEffect(() => {
+    const appStateSubscription = AppState.addEventListener('change', async () => {
+      await dispatch(checkBiometricStatus(queryClient))
+    })
+    return () => appStateSubscription?.remove()
+  }, [dispatch, queryClient])
 
   useEffect(() => {
     if (hasAnyWallet && !isAuthenticated && isSystemAuthEnabled && !canEnableBiometrics && !isMaintenance) {

--- a/src/SelectedWallet/WalletSelection/WalletSelectionScreen.tsx
+++ b/src/SelectedWallet/WalletSelection/WalletSelectionScreen.tsx
@@ -7,7 +7,7 @@ import {SafeAreaView} from 'react-native-safe-area-context'
 import {useMutation, UseMutationOptions} from 'react-query'
 import {useDispatch} from 'react-redux'
 
-import {checkBiometricStatus, logout, showErrorDialog} from '../../../legacy/actions'
+import {logout, showErrorDialog} from '../../../legacy/actions'
 import Screen from '../../../legacy/components/Screen'
 import {Button, PleaseWaitModal, ScreenBackground, StatusBar} from '../../../legacy/components/UiKit'
 import {CONFIG, isNightly} from '../../../legacy/config/config'
@@ -54,7 +54,6 @@ export const WalletSelectionScreen = () => {
         resetToWalletSelection()
       } else if (error instanceof KeysAreInvalid) {
         await showErrorDialog(errorMessages.walletKeysInvalidated, intl)
-        await dispatch(checkBiometricStatus())
         await dispatch(logout())
       } else {
         throw error

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ import {AppRegistry, LogBox, Text} from 'react-native'
 import {Provider, useSelector} from 'react-redux'
 
 import {handleGeneralError, setupHooks} from '../legacy/actions'
+import {ApiError, NetworkError} from '../legacy/api/errors'
 import {CONFIG} from '../legacy/config/config'
 import getConfiguredStore from '../legacy/helpers/configureStore'
 import translations from '../legacy/i18n/translations'
@@ -13,7 +14,6 @@ import {setLogLevel} from '../legacy/utils/logging'
 import App from './App'
 import {name as appName} from './app.json'
 import {ErrorBoundary} from './components/ErrorBoundary'
-
 setLogLevel(CONFIG.LOG_LEVEL)
 
 bluebird.config({
@@ -42,7 +42,11 @@ global.Promise = bluebird as any
 
 const cache = createIntlCache()
 const intl = createIntl({locale: 'en-US', messages: translations['en-US']}, cache)
-global.onunhandledrejection = (e) => handleGeneralError(e.message, e, intl)
+global.onunhandledrejection = (error) => {
+  if (error instanceof NetworkError) return
+  if (error instanceof ApiError) return
+  handleGeneralError(error.message, error, intl)
+}
 
 const store = getConfiguredStore()
 store.dispatch(setupHooks())

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,6 @@ import {AppRegistry, LogBox, Text} from 'react-native'
 import {Provider, useSelector} from 'react-redux'
 
 import {handleGeneralError, setupHooks} from '../legacy/actions'
-import {ApiError, NetworkError} from '../legacy/api/errors'
 import {CONFIG} from '../legacy/config/config'
 import getConfiguredStore from '../legacy/helpers/configureStore'
 import translations from '../legacy/i18n/translations'
@@ -14,6 +13,7 @@ import {setLogLevel} from '../legacy/utils/logging'
 import App from './App'
 import {name as appName} from './app.json'
 import {ErrorBoundary} from './components/ErrorBoundary'
+
 setLogLevel(CONFIG.LOG_LEVEL)
 
 bluebird.config({
@@ -42,11 +42,7 @@ global.Promise = bluebird as any
 
 const cache = createIntlCache()
 const intl = createIntl({locale: 'en-US', messages: translations['en-US']}, cache)
-global.onunhandledrejection = (error) => {
-  if (error instanceof NetworkError) return
-  if (error instanceof ApiError) return
-  handleGeneralError(error.message, error, intl)
-}
+global.onunhandledrejection = (e) => handleGeneralError(e.message, e, intl)
 
 const store = getConfiguredStore()
 store.dispatch(setupHooks())


### PR DESCRIPTION
- Right now if the device's settings for bio auth are turned off we only recheck it when switching wallets, therefore using the current wallet will fail to submit a transaction. 
- Since the only way to access device settings and disable them is by sending the app to the background, (except on emulators), we switched to matching bio status (app x device) when app state changes