### PR TITLE
fix: Selected currency is not saved

### DIFF
--- a/src/Settings/Currency/CurrencyContext.tsx
+++ b/src/Settings/Currency/CurrencyContext.tsx
@@ -33,7 +33,6 @@ const missingProvider = () => {
 
 const useCurrency = () => {
   const query = useQuery<CurrencySymbol, Error>({
-    initialData: defaultCurrency,
     queryKey: ['currencySymbol'],
     queryFn: async () => {
       const storedCurrencySymbol = await AsyncStorage.getItem('/appSettings/currencySymbol')


### PR DESCRIPTION
Initial value was being set every time the context was loaded, independently of the value stored in the phone.