### PR TITLE
fix: Cleaning the pin input when the error dialog is closed

### DIFF
--- a/src/auth/CheckPinInput/CheckPinInput.tsx
+++ b/src/auth/CheckPinInput/CheckPinInput.tsx
@@ -8,7 +8,12 @@ import {CONFIG} from '../../legacy/config'
 import {useStorage} from '../../Storage'
 import {PinInput} from '../PinInput'
 
+type Ref = {
+  clean: () => void
+}
+
 export const CheckPinInput = ({onValid}: {onValid: () => void}) => {
+  const inputRef = React.useRef<null | Ref>(null)
   const intl = useIntl()
   const strings = useStrings()
   const storage = useStorage()
@@ -17,16 +22,19 @@ export const CheckPinInput = ({onValid}: {onValid: () => void}) => {
       if (isValid) {
         onValid()
       } else {
-        showErrorDialog(errorMessages.incorrectPin, intl)
+        showErrorDialog({...errorMessages.incorrectPin, onPressYesButton: () => inputRef.current?.clean()}, intl)
       }
     },
     onError: (error) => {
-      showErrorDialog(errorMessages.generalError, intl, {message: error.message})
+      showErrorDialog({...errorMessages.generalError, onPressYesButton: () => inputRef.current?.clean()}, intl, {
+        message: error.message,
+      })
     },
   })
 
   return (
     <PinInput
+      ref={inputRef}
       title={strings.title}
       subtitles={[strings.subtitle]}
       enabled={!isLoading}

--- a/src/auth/CheckPinInput/CheckPinInput.tsx
+++ b/src/auth/CheckPinInput/CheckPinInput.tsx
@@ -6,14 +6,10 @@ import {errorMessages} from '../../i18n/global-messages'
 import {showErrorDialog} from '../../legacy/actions'
 import {CONFIG} from '../../legacy/config'
 import {useStorage} from '../../Storage'
-import {PinInput} from '../PinInput'
-
-type Ref = {
-  clean: () => void
-}
+import {PinInput, PinInputRef} from '../PinInput'
 
 export const CheckPinInput = ({onValid}: {onValid: () => void}) => {
-  const pinInputRef = React.useRef<null | Ref>(null)
+  const pinInputRef = React.useRef<null | PinInputRef>(null)
   const intl = useIntl()
   const strings = useStrings()
   const storage = useStorage()

--- a/src/auth/CheckPinInput/CheckPinInput.tsx
+++ b/src/auth/CheckPinInput/CheckPinInput.tsx
@@ -12,21 +12,16 @@ export const CheckPinInput = ({onValid}: {onValid: () => void}) => {
   const intl = useIntl()
   const strings = useStrings()
   const storage = useStorage()
-
-  const [currentPin, setCurrentPin] = React.useState('')
-
   const {checkPin, isLoading} = useCheckPin(storage, {
     onSuccess: (isValid) => {
       if (isValid) {
         onValid()
       } else {
-        showErrorDialog({...errorMessages.incorrectPin, onPressYesButton: () => setCurrentPin('')}, intl)
+        showErrorDialog(errorMessages.incorrectPin, intl)
       }
     },
     onError: (error) => {
-      showErrorDialog({...errorMessages.generalError, onPressYesButton: () => setCurrentPin('')}, intl, {
-        message: error.message,
-      })
+      showErrorDialog(errorMessages.generalError, intl, {message: error.message})
     },
   })
 
@@ -37,8 +32,6 @@ export const CheckPinInput = ({onValid}: {onValid: () => void}) => {
       enabled={!isLoading}
       onDone={checkPin}
       pinMaxLength={CONFIG.PIN_LENGTH}
-      pin={currentPin}
-      setPin={setCurrentPin}
     />
   )
 }

--- a/src/auth/CheckPinInput/CheckPinInput.tsx
+++ b/src/auth/CheckPinInput/CheckPinInput.tsx
@@ -13,7 +13,7 @@ type Ref = {
 }
 
 export const CheckPinInput = ({onValid}: {onValid: () => void}) => {
-  const inputRef = React.useRef<null | Ref>(null)
+  const pinInputRef = React.useRef<null | Ref>(null)
   const intl = useIntl()
   const strings = useStrings()
   const storage = useStorage()
@@ -22,11 +22,11 @@ export const CheckPinInput = ({onValid}: {onValid: () => void}) => {
       if (isValid) {
         onValid()
       } else {
-        showErrorDialog({...errorMessages.incorrectPin, onPressYes: () => inputRef.current?.clean()}, intl)
+        showErrorDialog({...errorMessages.incorrectPin, onPressYes: () => pinInputRef.current?.clean()}, intl)
       }
     },
     onError: (error) => {
-      showErrorDialog({...errorMessages.generalError, onPressYes: () => inputRef.current?.clean()}, intl, {
+      showErrorDialog({...errorMessages.generalError, onPressYes: () => pinInputRef.current?.clean()}, intl, {
         message: error.message,
       })
     },
@@ -34,7 +34,7 @@ export const CheckPinInput = ({onValid}: {onValid: () => void}) => {
 
   return (
     <PinInput
-      ref={inputRef}
+      ref={pinInputRef}
       title={strings.title}
       subtitles={[strings.subtitle]}
       enabled={!isLoading}

--- a/src/auth/CheckPinInput/CheckPinInput.tsx
+++ b/src/auth/CheckPinInput/CheckPinInput.tsx
@@ -12,16 +12,21 @@ export const CheckPinInput = ({onValid}: {onValid: () => void}) => {
   const intl = useIntl()
   const strings = useStrings()
   const storage = useStorage()
+
+  const [currentPin, setCurrentPin] = React.useState('')
+
   const {checkPin, isLoading} = useCheckPin(storage, {
     onSuccess: (isValid) => {
       if (isValid) {
         onValid()
       } else {
-        showErrorDialog(errorMessages.incorrectPin, intl)
+        showErrorDialog({...errorMessages.incorrectPin, onPressYesButton: () => setCurrentPin('')}, intl)
       }
     },
     onError: (error) => {
-      showErrorDialog(errorMessages.generalError, intl, {message: error.message})
+      showErrorDialog({...errorMessages.generalError, onPressYesButton: () => setCurrentPin('')}, intl, {
+        message: error.message,
+      })
     },
   })
 
@@ -32,6 +37,8 @@ export const CheckPinInput = ({onValid}: {onValid: () => void}) => {
       enabled={!isLoading}
       onDone={checkPin}
       pinMaxLength={CONFIG.PIN_LENGTH}
+      pin={currentPin}
+      setPin={setCurrentPin}
     />
   )
 }

--- a/src/auth/CheckPinInput/CheckPinInput.tsx
+++ b/src/auth/CheckPinInput/CheckPinInput.tsx
@@ -22,11 +22,11 @@ export const CheckPinInput = ({onValid}: {onValid: () => void}) => {
       if (isValid) {
         onValid()
       } else {
-        showErrorDialog({...errorMessages.incorrectPin, onPressYesButton: () => inputRef.current?.clean()}, intl)
+        showErrorDialog({...errorMessages.incorrectPin, onPressYes: () => inputRef.current?.clean()}, intl)
       }
     },
     onError: (error) => {
-      showErrorDialog({...errorMessages.generalError, onPressYesButton: () => inputRef.current?.clean()}, intl, {
+      showErrorDialog({...errorMessages.generalError, onPressYes: () => inputRef.current?.clean()}, intl, {
         message: error.message,
       })
     },

--- a/src/auth/CheckPinInput/CheckPinInput.tsx
+++ b/src/auth/CheckPinInput/CheckPinInput.tsx
@@ -18,13 +18,13 @@ export const CheckPinInput = ({onValid}: {onValid: () => void}) => {
       if (isValid) {
         onValid()
       } else {
-        showErrorDialog({...errorMessages.incorrectPin, onPressYes: () => pinInputRef.current?.clean()}, intl)
+        showErrorDialog(errorMessages.incorrectPin, intl)
+        pinInputRef.current?.clear()
       }
     },
     onError: (error) => {
-      showErrorDialog({...errorMessages.generalError, onPressYes: () => pinInputRef.current?.clean()}, intl, {
-        message: error.message,
-      })
+      showErrorDialog(errorMessages.generalError, intl, {message: error.message})
+      pinInputRef.current?.clear()
     },
   })
 

--- a/src/auth/CreatePinInput/CreatePinInput.tsx
+++ b/src/auth/CreatePinInput/CreatePinInput.tsx
@@ -18,17 +18,10 @@ export const CreatePinInput: React.FC<{onDone: () => void}> = ({onDone}) => {
 
   const {createPin, isLoading} = useCreatePin(storage, {
     onSuccess: () => onDone(),
-    onError: (error) =>
-      showErrorDialog(
-        {
-          ...errorMessages.generalError,
-          onPressYes: () => (step === 'pin' ? pinInputRef : pinConfirmationInputRef).current?.clean(),
-        },
-        intl,
-        {
-          message: error.message,
-        },
-      ),
+    onError: (error) => {
+      showErrorDialog(errorMessages.generalError, intl, {message: error.message})
+      step === 'pin' ? pinInputRef.current?.clear() : pinConfirmationInputRef.current?.clear()
+    },
   })
   const [pin, setPin] = React.useState('')
   const [step, setStep] = React.useState<'pin' | 'pinConfirmation'>('pin')
@@ -40,13 +33,8 @@ export const CreatePinInput: React.FC<{onDone: () => void}> = ({onDone}) => {
 
   const onPinConfirmation = (pinConfirmation: string) => {
     if (pinConfirmation !== pin) {
-      showErrorDialog(
-        {
-          ...errorMessages.pinMismatch,
-          onPressYes: () => (step === 'pin' ? pinInputRef : pinConfirmationInputRef).current?.clean(),
-        },
-        intl,
-      )
+      showErrorDialog(errorMessages.pinMismatch, intl)
+      step === 'pin' ? pinInputRef.current?.clear() : pinConfirmationInputRef.current?.clear()
       return
     }
 

--- a/src/auth/CreatePinInput/CreatePinInput.tsx
+++ b/src/auth/CreatePinInput/CreatePinInput.tsx
@@ -12,33 +12,25 @@ export const CreatePinInput: React.FC<{onDone: () => void}> = ({onDone}) => {
   const intl = useIntl()
   const strings = useStrings()
   const storage = useStorage()
-
-  const [currentPin, setCurrentPin] = React.useState('')
-  const [previousPin, setPreviousPin] = React.useState('')
-
   const {createPin, isLoading} = useCreatePin(storage, {
     onSuccess: () => onDone(),
-    onError: (error) =>
-      showErrorDialog({...errorMessages.generalError, onPressYesButton: () => setCurrentPin('')}, intl, {
-        message: error.message,
-      }),
+    onError: (error) => showErrorDialog(errorMessages.generalError, intl, {message: error.message}),
   })
-
+  const [pin, setPin] = React.useState('')
   const [step, setStep] = React.useState<'pin' | 'pinConfirmation'>('pin')
 
   const onPinInput = (pin: string) => {
-    setPreviousPin(pin)
-    setCurrentPin('')
+    setPin(pin)
     setStep('pinConfirmation')
   }
 
   const onPinConfirmation = (pinConfirmation: string) => {
-    if (pinConfirmation !== previousPin) {
-      showErrorDialog({...errorMessages.pinMismatch, onPressYesButton: () => setCurrentPin('')}, intl)
+    if (pinConfirmation !== pin) {
+      showErrorDialog(errorMessages.pinMismatch, intl)
       return
     }
 
-    createPin(previousPin)
+    createPin(pin)
   }
 
   return step === 'pin' ? (
@@ -48,8 +40,6 @@ export const CreatePinInput: React.FC<{onDone: () => void}> = ({onDone}) => {
       subtitles={[strings.pinInputSubtitle]}
       pinMaxLength={CONFIG.PIN_LENGTH}
       onDone={onPinInput}
-      pin={currentPin}
-      setPin={setCurrentPin}
     />
   ) : (
     <PinInput
@@ -58,8 +48,6 @@ export const CreatePinInput: React.FC<{onDone: () => void}> = ({onDone}) => {
       title={strings.pinInputConfirmationTitle}
       pinMaxLength={CONFIG.PIN_LENGTH}
       onDone={onPinConfirmation}
-      pin={currentPin}
-      setPin={setCurrentPin}
     />
   )
 }

--- a/src/auth/CreatePinInput/CreatePinInput.tsx
+++ b/src/auth/CreatePinInput/CreatePinInput.tsx
@@ -12,25 +12,33 @@ export const CreatePinInput: React.FC<{onDone: () => void}> = ({onDone}) => {
   const intl = useIntl()
   const strings = useStrings()
   const storage = useStorage()
+
+  const [currentPin, setCurrentPin] = React.useState('')
+  const [previousPin, setPreviousPin] = React.useState('')
+
   const {createPin, isLoading} = useCreatePin(storage, {
     onSuccess: () => onDone(),
-    onError: (error) => showErrorDialog(errorMessages.generalError, intl, {message: error.message}),
+    onError: (error) =>
+      showErrorDialog({...errorMessages.generalError, onPressYesButton: () => setCurrentPin('')}, intl, {
+        message: error.message,
+      }),
   })
-  const [pin, setPin] = React.useState('')
+
   const [step, setStep] = React.useState<'pin' | 'pinConfirmation'>('pin')
 
   const onPinInput = (pin: string) => {
-    setPin(pin)
+    setPreviousPin(pin)
+    setCurrentPin('')
     setStep('pinConfirmation')
   }
 
   const onPinConfirmation = (pinConfirmation: string) => {
-    if (pinConfirmation !== pin) {
-      showErrorDialog(errorMessages.pinMismatch, intl)
+    if (pinConfirmation !== previousPin) {
+      showErrorDialog({...errorMessages.pinMismatch, onPressYesButton: () => setCurrentPin('')}, intl)
       return
     }
 
-    createPin(pin)
+    createPin(previousPin)
   }
 
   return step === 'pin' ? (
@@ -40,6 +48,8 @@ export const CreatePinInput: React.FC<{onDone: () => void}> = ({onDone}) => {
       subtitles={[strings.pinInputSubtitle]}
       pinMaxLength={CONFIG.PIN_LENGTH}
       onDone={onPinInput}
+      pin={currentPin}
+      setPin={setCurrentPin}
     />
   ) : (
     <PinInput
@@ -48,6 +58,8 @@ export const CreatePinInput: React.FC<{onDone: () => void}> = ({onDone}) => {
       title={strings.pinInputConfirmationTitle}
       pinMaxLength={CONFIG.PIN_LENGTH}
       onDone={onPinConfirmation}
+      pin={currentPin}
+      setPin={setCurrentPin}
     />
   )
 }

--- a/src/auth/CreatePinInput/CreatePinInput.tsx
+++ b/src/auth/CreatePinInput/CreatePinInput.tsx
@@ -26,7 +26,7 @@ export const CreatePinInput: React.FC<{onDone: () => void}> = ({onDone}) => {
       showErrorDialog(
         {
           ...errorMessages.generalError,
-          onPressYesButton: () => (step === 'pin' ? inputRefPinInput : inputRefPinConfirmationInput).current?.clean(),
+          onPressYes: () => (step === 'pin' ? inputRefPinInput : inputRefPinConfirmationInput).current?.clean(),
         },
         intl,
         {
@@ -47,7 +47,7 @@ export const CreatePinInput: React.FC<{onDone: () => void}> = ({onDone}) => {
       showErrorDialog(
         {
           ...errorMessages.pinMismatch,
-          onPressYesButton: () => (step === 'pin' ? inputRefPinInput : inputRefPinConfirmationInput).current?.clean(),
+          onPressYes: () => (step === 'pin' ? inputRefPinInput : inputRefPinConfirmationInput).current?.clean(),
         },
         intl,
       )

--- a/src/auth/CreatePinInput/CreatePinInput.tsx
+++ b/src/auth/CreatePinInput/CreatePinInput.tsx
@@ -6,15 +6,11 @@ import {errorMessages} from '../../i18n/global-messages'
 import {showErrorDialog} from '../../legacy/actions'
 import {CONFIG} from '../../legacy/config'
 import {useStorage} from '../../Storage'
-import {PinInput} from '../PinInput'
-
-type Ref = {
-  clean: () => void
-}
+import {PinInput, PinInputRef} from '../PinInput'
 
 export const CreatePinInput: React.FC<{onDone: () => void}> = ({onDone}) => {
-  const pinInputRef = React.useRef<null | Ref>(null)
-  const pinConfirmationInputRef = React.useRef<null | Ref>(null)
+  const pinInputRef = React.useRef<null | PinInputRef>(null)
+  const pinConfirmationInputRef = React.useRef<null | PinInputRef>(null)
 
   const intl = useIntl()
   const strings = useStrings()

--- a/src/auth/CreatePinInput/CreatePinInput.tsx
+++ b/src/auth/CreatePinInput/CreatePinInput.tsx
@@ -13,8 +13,8 @@ type Ref = {
 }
 
 export const CreatePinInput: React.FC<{onDone: () => void}> = ({onDone}) => {
-  const inputRefPinInput = React.useRef<null | Ref>(null)
-  const inputRefPinConfirmationInput = React.useRef<null | Ref>(null)
+  const pinInputRef = React.useRef<null | Ref>(null)
+  const pinConfirmationInputRef = React.useRef<null | Ref>(null)
 
   const intl = useIntl()
   const strings = useStrings()
@@ -26,7 +26,7 @@ export const CreatePinInput: React.FC<{onDone: () => void}> = ({onDone}) => {
       showErrorDialog(
         {
           ...errorMessages.generalError,
-          onPressYes: () => (step === 'pin' ? inputRefPinInput : inputRefPinConfirmationInput).current?.clean(),
+          onPressYes: () => (step === 'pin' ? pinInputRef : pinConfirmationInputRef).current?.clean(),
         },
         intl,
         {
@@ -47,7 +47,7 @@ export const CreatePinInput: React.FC<{onDone: () => void}> = ({onDone}) => {
       showErrorDialog(
         {
           ...errorMessages.pinMismatch,
-          onPressYes: () => (step === 'pin' ? inputRefPinInput : inputRefPinConfirmationInput).current?.clean(),
+          onPressYes: () => (step === 'pin' ? pinInputRef : pinConfirmationInputRef).current?.clean(),
         },
         intl,
       )
@@ -59,7 +59,7 @@ export const CreatePinInput: React.FC<{onDone: () => void}> = ({onDone}) => {
 
   return step === 'pin' ? (
     <PinInput
-      ref={inputRefPinInput}
+      ref={pinInputRef}
       key="pinInput"
       title={strings.pinInputTitle}
       subtitles={[strings.pinInputSubtitle]}
@@ -68,7 +68,7 @@ export const CreatePinInput: React.FC<{onDone: () => void}> = ({onDone}) => {
     />
   ) : (
     <PinInput
-      ref={inputRefPinConfirmationInput}
+      ref={pinConfirmationInputRef}
       key="pinConfirmationInput"
       enabled={!isLoading}
       title={strings.pinInputConfirmationTitle}

--- a/src/auth/PinInput/PinInput.stories.tsx
+++ b/src/auth/PinInput/PinInput.stories.tsx
@@ -1,0 +1,56 @@
+import {storiesOf} from '@storybook/react-native'
+import React from 'react'
+import {defineMessages, useIntl} from 'react-intl'
+import {StyleSheet, View} from 'react-native'
+
+import {Button} from '../../components'
+import {CONFIG} from '../../legacy/config'
+import {PinInput, PinInputRef} from './PinInput'
+
+const PinInputWrapper = ({enabled = true}: {enabled?: boolean}) => {
+  const pinInputRef = React.useRef<null | PinInputRef>(null)
+  const strings = useStrings()
+
+  return (
+    <View style={styles.root}>
+      <View style={styles.button}>
+        <Button title="Clean Pin" onPress={() => pinInputRef.current?.clear()} />
+      </View>
+      <PinInput
+        ref={pinInputRef}
+        enabled={enabled}
+        pinMaxLength={CONFIG.PIN_LENGTH}
+        title={strings.title}
+        onDone={() => undefined}
+      />
+    </View>
+  )
+}
+
+storiesOf('PinInput', module)
+  .add('Default', () => <PinInputWrapper />)
+  .add('Disabled', () => <PinInputWrapper enabled={false} />)
+
+const useStrings = () => {
+  const intl = useIntl()
+
+  return {
+    title: intl.formatMessage(messages.title),
+  }
+}
+
+const messages = defineMessages({
+  title: {
+    id: 'components.login.custompinlogin.title',
+    defaultMessage: '!!!Enter PIN',
+  },
+})
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  button: {
+    padding: 10,
+  },
+})

--- a/src/auth/PinInput/PinInput.tsx
+++ b/src/auth/PinInput/PinInput.tsx
@@ -14,11 +14,11 @@ type Props = {
   onDone: (pin: string) => void
   pinMaxLength: number
   enabled?: boolean
+  pin: string
+  setPin: (pin: string) => void
 }
 
-export const PinInput = ({enabled = true, pinMaxLength, title, subtitles = [], onDone}: Props) => {
-  const [pin, setPin] = React.useState('')
-
+export const PinInput = ({enabled = true, pinMaxLength, title, subtitles = [], onDone, pin, setPin}: Props) => {
   const onKeyDown = (value: string) => {
     if (!enabled) return
     if (value === BACKSPACE) {

--- a/src/auth/PinInput/PinInput.tsx
+++ b/src/auth/PinInput/PinInput.tsx
@@ -14,11 +14,11 @@ type Props = {
   onDone: (pin: string) => void
   pinMaxLength: number
   enabled?: boolean
-  pin: string
-  setPin: (pin: string) => void
 }
 
-export const PinInput = ({enabled = true, pinMaxLength, title, subtitles = [], onDone, pin, setPin}: Props) => {
+export const PinInput = ({enabled = true, pinMaxLength, title, subtitles = [], onDone}: Props) => {
+  const [pin, setPin] = React.useState('')
+
   const onKeyDown = (value: string) => {
     if (!enabled) return
     if (value === BACKSPACE) {

--- a/src/auth/PinInput/PinInput.tsx
+++ b/src/auth/PinInput/PinInput.tsx
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import React from 'react'
+import React, {ForwardedRef} from 'react'
 import {View} from 'react-native'
 import {StyleSheet} from 'react-native'
 
@@ -16,8 +16,24 @@ type Props = {
   enabled?: boolean
 }
 
-export const PinInput = ({enabled = true, pinMaxLength, title, subtitles = [], onDone}: Props) => {
+type Ref = ForwardedRef<{
+  clean: () => void
+}>
+
+export const PinInput = React.forwardRef((props: Props, ref: Ref) => {
+  const {enabled = true, pinMaxLength, title, subtitles = [], onDone} = props
+
   const [pin, setPin] = React.useState('')
+
+  const clean = () => {
+    setPin('')
+  }
+
+  React.useImperativeHandle(ref, () => ({
+    clean: () => {
+      clean()
+    },
+  }))
 
   const onKeyDown = (value: string) => {
     if (!enabled) return
@@ -58,7 +74,7 @@ export const PinInput = ({enabled = true, pinMaxLength, title, subtitles = [], o
       <Keyboard onKeyDown={onKeyDown} />
     </View>
   )
-}
+})
 
 const styles = StyleSheet.create({
   root: {
@@ -104,6 +120,7 @@ const styles = StyleSheet.create({
 type PinPlaceholderProps = {
   isActive: boolean
 }
+
 const PinPlaceholder = ({isActive}: PinPlaceholderProps) => (
   <View style={[styles.pin, !isActive && styles.pinInactive]} />
 )

--- a/src/auth/PinInput/PinInput.tsx
+++ b/src/auth/PinInput/PinInput.tsx
@@ -17,7 +17,7 @@ type Props = {
 }
 
 export type PinInputRef = {
-  clean: () => void
+  clear: () => void
 }
 
 export const PinInput = React.forwardRef<PinInputRef, Props>((props, ref) => {
@@ -26,7 +26,7 @@ export const PinInput = React.forwardRef<PinInputRef, Props>((props, ref) => {
   const [pin, setPin] = React.useState('')
 
   React.useImperativeHandle(ref, () => ({
-    clean: () => {
+    clear: () => {
       setPin('')
     },
   }))

--- a/src/auth/PinInput/PinInput.tsx
+++ b/src/auth/PinInput/PinInput.tsx
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import React, {ForwardedRef} from 'react'
+import React from 'react'
 import {View} from 'react-native'
 import {StyleSheet} from 'react-native'
 
@@ -16,22 +16,18 @@ type Props = {
   enabled?: boolean
 }
 
-type Ref = ForwardedRef<{
+export type PinInputRef = {
   clean: () => void
-}>
+}
 
-export const PinInput = React.forwardRef((props: Props, ref: Ref) => {
+export const PinInput = React.forwardRef<PinInputRef, Props>((props, ref) => {
   const {enabled = true, pinMaxLength, title, subtitles = [], onDone} = props
 
   const [pin, setPin] = React.useState('')
 
-  const clean = () => {
-    setPin('')
-  }
-
   React.useImperativeHandle(ref, () => ({
     clean: () => {
-      clean()
+      setPin('')
     },
   }))
 

--- a/src/auth/PinLoginScreen/PinLoginScreen.tsx
+++ b/src/auth/PinLoginScreen/PinLoginScreen.tsx
@@ -16,14 +16,9 @@ export const PinLoginScreen = () => {
   const strings = useStrings()
   const dispatch = useDispatch()
   const storage = useStorage()
-
-  const [currentPin, setCurrentPin] = React.useState('')
-
   const {checkPin, isLoading} = useCheckPin(storage, {
     onSuccess: (isValid) => {
-      isValid
-        ? dispatch(signin())
-        : showErrorDialog({...errorMessages.incorrectPin, onPressYesButton: () => setCurrentPin('')}, intl)
+      isValid ? dispatch(signin()) : showErrorDialog(errorMessages.incorrectPin, intl)
     },
   })
 
@@ -31,14 +26,7 @@ export const PinLoginScreen = () => {
     <SafeAreaView edges={['left', 'right', 'bottom']} style={{flex: 1}}>
       <StatusBar type="dark" />
 
-      <PinInput
-        enabled={!isLoading}
-        pinMaxLength={CONFIG.PIN_LENGTH}
-        title={strings.title}
-        onDone={checkPin}
-        pin={currentPin}
-        setPin={setCurrentPin}
-      />
+      <PinInput enabled={!isLoading} pinMaxLength={CONFIG.PIN_LENGTH} title={strings.title} onDone={checkPin} />
     </SafeAreaView>
   )
 }

--- a/src/auth/PinLoginScreen/PinLoginScreen.tsx
+++ b/src/auth/PinLoginScreen/PinLoginScreen.tsx
@@ -16,9 +16,14 @@ export const PinLoginScreen = () => {
   const strings = useStrings()
   const dispatch = useDispatch()
   const storage = useStorage()
+
+  const [currentPin, setCurrentPin] = React.useState('')
+
   const {checkPin, isLoading} = useCheckPin(storage, {
     onSuccess: (isValid) => {
-      isValid ? dispatch(signin()) : showErrorDialog(errorMessages.incorrectPin, intl)
+      isValid
+        ? dispatch(signin())
+        : showErrorDialog({...errorMessages.incorrectPin, onPressYesButton: () => setCurrentPin('')}, intl)
     },
   })
 
@@ -26,7 +31,14 @@ export const PinLoginScreen = () => {
     <SafeAreaView edges={['left', 'right', 'bottom']} style={{flex: 1}}>
       <StatusBar type="dark" />
 
-      <PinInput enabled={!isLoading} pinMaxLength={CONFIG.PIN_LENGTH} title={strings.title} onDone={checkPin} />
+      <PinInput
+        enabled={!isLoading}
+        pinMaxLength={CONFIG.PIN_LENGTH}
+        title={strings.title}
+        onDone={checkPin}
+        pin={currentPin}
+        setPin={setCurrentPin}
+      />
     </SafeAreaView>
   )
 }

--- a/src/auth/PinLoginScreen/PinLoginScreen.tsx
+++ b/src/auth/PinLoginScreen/PinLoginScreen.tsx
@@ -9,14 +9,10 @@ import {errorMessages} from '../../i18n/global-messages'
 import {showErrorDialog, signin} from '../../legacy/actions'
 import {CONFIG} from '../../legacy/config'
 import {useStorage} from '../../Storage'
-import {PinInput} from '../PinInput'
-
-type Ref = {
-  clean: () => void
-}
+import {PinInput, PinInputRef} from '../PinInput'
 
 export const PinLoginScreen = () => {
-  const pinInputRef = React.useRef<null | Ref>(null)
+  const pinInputRef = React.useRef<null | PinInputRef>(null)
   const intl = useIntl()
   const strings = useStrings()
   const dispatch = useDispatch()

--- a/src/auth/PinLoginScreen/PinLoginScreen.tsx
+++ b/src/auth/PinLoginScreen/PinLoginScreen.tsx
@@ -11,14 +11,22 @@ import {CONFIG} from '../../legacy/config'
 import {useStorage} from '../../Storage'
 import {PinInput} from '../PinInput'
 
+type Ref = {
+  clean: () => void
+}
+
 export const PinLoginScreen = () => {
+  const inputRef = React.useRef<null | Ref>(null)
   const intl = useIntl()
   const strings = useStrings()
   const dispatch = useDispatch()
   const storage = useStorage()
+
   const {checkPin, isLoading} = useCheckPin(storage, {
     onSuccess: (isValid) => {
-      isValid ? dispatch(signin()) : showErrorDialog(errorMessages.incorrectPin, intl)
+      isValid
+        ? dispatch(signin())
+        : showErrorDialog({...errorMessages.incorrectPin, onPressYesButton: () => inputRef.current?.clean()}, intl)
     },
   })
 
@@ -26,7 +34,13 @@ export const PinLoginScreen = () => {
     <SafeAreaView edges={['left', 'right', 'bottom']} style={{flex: 1}}>
       <StatusBar type="dark" />
 
-      <PinInput enabled={!isLoading} pinMaxLength={CONFIG.PIN_LENGTH} title={strings.title} onDone={checkPin} />
+      <PinInput
+        ref={inputRef}
+        enabled={!isLoading}
+        pinMaxLength={CONFIG.PIN_LENGTH}
+        title={strings.title}
+        onDone={checkPin}
+      />
     </SafeAreaView>
   )
 }

--- a/src/auth/PinLoginScreen/PinLoginScreen.tsx
+++ b/src/auth/PinLoginScreen/PinLoginScreen.tsx
@@ -26,7 +26,7 @@ export const PinLoginScreen = () => {
     onSuccess: (isValid) => {
       isValid
         ? dispatch(signin())
-        : showErrorDialog({...errorMessages.incorrectPin, onPressYesButton: () => inputRef.current?.clean()}, intl)
+        : showErrorDialog({...errorMessages.incorrectPin, onPressYes: () => inputRef.current?.clean()}, intl)
     },
   })
 

--- a/src/auth/PinLoginScreen/PinLoginScreen.tsx
+++ b/src/auth/PinLoginScreen/PinLoginScreen.tsx
@@ -16,7 +16,7 @@ type Ref = {
 }
 
 export const PinLoginScreen = () => {
-  const inputRef = React.useRef<null | Ref>(null)
+  const pinInputRef = React.useRef<null | Ref>(null)
   const intl = useIntl()
   const strings = useStrings()
   const dispatch = useDispatch()
@@ -26,7 +26,7 @@ export const PinLoginScreen = () => {
     onSuccess: (isValid) => {
       isValid
         ? dispatch(signin())
-        : showErrorDialog({...errorMessages.incorrectPin, onPressYes: () => inputRef.current?.clean()}, intl)
+        : showErrorDialog({...errorMessages.incorrectPin, onPressYes: () => pinInputRef.current?.clean()}, intl)
     },
   })
 
@@ -35,7 +35,7 @@ export const PinLoginScreen = () => {
       <StatusBar type="dark" />
 
       <PinInput
-        ref={inputRef}
+        ref={pinInputRef}
         enabled={!isLoading}
         pinMaxLength={CONFIG.PIN_LENGTH}
         title={strings.title}

--- a/src/auth/PinLoginScreen/PinLoginScreen.tsx
+++ b/src/auth/PinLoginScreen/PinLoginScreen.tsx
@@ -20,9 +20,12 @@ export const PinLoginScreen = () => {
 
   const {checkPin, isLoading} = useCheckPin(storage, {
     onSuccess: (isValid) => {
-      isValid
-        ? dispatch(signin())
-        : showErrorDialog({...errorMessages.incorrectPin, onPressYes: () => pinInputRef.current?.clean()}, intl)
+      if (isValid) {
+        dispatch(signin())
+      } else {
+        showErrorDialog(errorMessages.incorrectPin, intl)
+        pinInputRef.current?.clear()
+      }
     },
   })
 

--- a/src/legacy/actions.ts
+++ b/src/legacy/actions.ts
@@ -321,7 +321,7 @@ type DialogOptions = {
   message: string
   yesButton?: string
   noButton?: string
-  onPressYesButton?: () => void
+  onPressYes?: () => void
 }
 export const DIALOG_BUTTONS = {
   YES: 'Yes',
@@ -329,7 +329,7 @@ export const DIALOG_BUTTONS = {
 }
 type DialogButton = typeof DIALOG_BUTTONS[keyof typeof DIALOG_BUTTONS]
 
-const showDialog = ({onPressYesButton, ...translations}: DialogOptions): Promise<DialogButton> =>
+const showDialog = ({onPressYes, ...translations}: DialogOptions): Promise<DialogButton> =>
   new Promise((resolve) => {
     const {title, message, yesButton, noButton} = translations
     const buttons: Array<any> = []
@@ -346,7 +346,7 @@ const showDialog = ({onPressYesButton, ...translations}: DialogOptions): Promise
       text: yesButton,
       onPress: () => {
         resolve(DIALOG_BUTTONS.YES)
-        onPressYesButton?.()
+        onPressYes?.()
       },
     })
     Alert.alert(title, message, buttons, {
@@ -358,7 +358,7 @@ export const showErrorDialog = (
   dialog: {
     title: Record<string, any>
     message: Record<string, any>
-    onPressYesButton?: () => void
+    onPressYes?: () => void
   },
   intl: IntlShape | null | undefined,
   msgOptions?: {
@@ -366,7 +366,7 @@ export const showErrorDialog = (
   },
 ): Promise<DialogButton> => {
   let title, message, yesButton
-  const onPressYesButton = dialog.onPressYesButton || undefined
+  const onPressYes = dialog.onPressYes || undefined
 
   if (intl != null) {
     title = intl.formatMessage(dialog.title)
@@ -391,7 +391,7 @@ export const showErrorDialog = (
     title,
     message,
     yesButton,
-    onPressYesButton,
+    onPressYes,
   })
 }
 export const showConfirmationDialog = (dialog: any | DialogOptions, intl: IntlShape): Promise<DialogButton> =>

--- a/src/legacy/actions.ts
+++ b/src/legacy/actions.ts
@@ -321,6 +321,7 @@ type DialogOptions = {
   message: string
   yesButton?: string
   noButton?: string
+  onPressYesButton?: () => void
 }
 export const DIALOG_BUTTONS = {
   YES: 'Yes',
@@ -328,7 +329,7 @@ export const DIALOG_BUTTONS = {
 }
 type DialogButton = typeof DIALOG_BUTTONS[keyof typeof DIALOG_BUTTONS]
 
-const showDialog = (translations: DialogOptions): Promise<DialogButton> =>
+const showDialog = ({onPressYesButton, ...translations}: DialogOptions): Promise<DialogButton> =>
   new Promise((resolve) => {
     const {title, message, yesButton, noButton} = translations
     const buttons: Array<any> = []
@@ -343,7 +344,10 @@ const showDialog = (translations: DialogOptions): Promise<DialogButton> =>
 
     buttons.push({
       text: yesButton,
-      onPress: () => resolve(DIALOG_BUTTONS.YES),
+      onPress: () => {
+        resolve(DIALOG_BUTTONS.YES)
+        onPressYesButton?.()
+      },
     })
     Alert.alert(title, message, buttons, {
       cancelable: false,
@@ -354,6 +358,7 @@ export const showErrorDialog = (
   dialog: {
     title: Record<string, any>
     message: Record<string, any>
+    onPressYesButton?: () => void
   },
   intl: IntlShape | null | undefined,
   msgOptions?: {
@@ -361,6 +366,7 @@ export const showErrorDialog = (
   },
 ): Promise<DialogButton> => {
   let title, message, yesButton
+  const onPressYesButton = dialog.onPressYesButton || undefined
 
   if (intl != null) {
     title = intl.formatMessage(dialog.title)
@@ -385,6 +391,7 @@ export const showErrorDialog = (
     title,
     message,
     yesButton,
+    onPressYesButton,
   })
 }
 export const showConfirmationDialog = (dialog: any | DialogOptions, intl: IntlShape): Promise<DialogButton> =>

--- a/src/legacy/actions.ts
+++ b/src/legacy/actions.ts
@@ -321,7 +321,6 @@ type DialogOptions = {
   message: string
   yesButton?: string
   noButton?: string
-  onPressYes?: () => void
 }
 export const DIALOG_BUTTONS = {
   YES: 'Yes',
@@ -329,7 +328,7 @@ export const DIALOG_BUTTONS = {
 }
 type DialogButton = typeof DIALOG_BUTTONS[keyof typeof DIALOG_BUTTONS]
 
-const showDialog = ({onPressYes, ...translations}: DialogOptions): Promise<DialogButton> =>
+const showDialog = (translations: DialogOptions): Promise<DialogButton> =>
   new Promise((resolve) => {
     const {title, message, yesButton, noButton} = translations
     const buttons: Array<any> = []
@@ -344,10 +343,7 @@ const showDialog = ({onPressYes, ...translations}: DialogOptions): Promise<Dialo
 
     buttons.push({
       text: yesButton,
-      onPress: () => {
-        resolve(DIALOG_BUTTONS.YES)
-        onPressYes?.()
-      },
+      onPress: () => resolve(DIALOG_BUTTONS.YES),
     })
     Alert.alert(title, message, buttons, {
       cancelable: false,
@@ -358,7 +354,6 @@ export const showErrorDialog = (
   dialog: {
     title: Record<string, any>
     message: Record<string, any>
-    onPressYes?: () => void
   },
   intl: IntlShape | null | undefined,
   msgOptions?: {
@@ -366,7 +361,6 @@ export const showErrorDialog = (
   },
 ): Promise<DialogButton> => {
   let title, message, yesButton
-  const onPressYes = dialog.onPressYes || undefined
 
   if (intl != null) {
     title = intl.formatMessage(dialog.title)
@@ -391,7 +385,6 @@ export const showErrorDialog = (
     title,
     message,
     yesButton,
-    onPressYes,
   })
 }
 export const showConfirmationDialog = (dialog: any | DialogOptions, intl: IntlShape): Promise<DialogButton> =>

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -77,6 +77,7 @@ function loadStories() {
 	require('../src/auth/CheckPinInput/CheckPinInput.stories');
 	require('../src/auth/CreatePinInput/CreatePinInput.stories');
 	require('../src/auth/CreatePinScreen/CreatePinScreen.stories');
+	require('../src/auth/PinInput/PinInput.stories');
 	require('../src/auth/PinLoginScreen/PinLoginScreen.stories');
 	require('../src/components/Boundary/Boundary.stories');
 	require('../src/components/Button/Button.stories');
@@ -174,6 +175,7 @@ const stories = [
 	'../src/auth/CheckPinInput/CheckPinInput.stories',
 	'../src/auth/CreatePinInput/CreatePinInput.stories',
 	'../src/auth/CreatePinScreen/CreatePinScreen.stories',
+	'../src/auth/PinInput/PinInput.stories',
 	'../src/auth/PinLoginScreen/PinLoginScreen.stories',
 	'../src/components/Boundary/Boundary.stories',
 	'../src/components/Button/Button.stories',


### PR DESCRIPTION
No action was taken to clear the input pin when an error happens and the error dialog is displayed.

Now the pin input is cleaned at same time that the error dialog is displayed.