### PR TITLE
fix: Display path

### DIFF
--- a/src/Receive/AddressModal.stories.tsx
+++ b/src/Receive/AddressModal.stories.tsx
@@ -15,7 +15,11 @@ storiesOf('AddressModal', module)
       <WithModalProps>
         {({visible, onRequestClose}) => (
           <AddressModal
-            index={1}
+            path={{
+              account: 0,
+              index: 1,
+              role: 0,
+            }}
             onAddressVerify={action('onAddressVerify')}
             address={address}
             visible={visible}
@@ -30,7 +34,25 @@ storiesOf('AddressModal', module)
       <WithModalProps>
         {({visible, onRequestClose}) => (
           <AddressModal
-            index={1}
+            path={{
+              account: 0,
+              index: 1,
+              role: 0,
+            }}
+            onAddressVerify={action('onAddressVerify')}
+            address={address}
+            visible={visible}
+            onRequestClose={onRequestClose}
+          />
+        )}
+      </WithModalProps>
+    </SelectedWalletProvider>
+  ))
+  .add('without Path', () => (
+    <SelectedWalletProvider wallet={{...mockWallet, isHW: true}}>
+      <WithModalProps>
+        {({visible, onRequestClose}) => (
+          <AddressModal
             onAddressVerify={action('onAddressVerify')}
             address={address}
             visible={visible}

--- a/src/Receive/Modals.tsx
+++ b/src/Receive/Modals.tsx
@@ -24,7 +24,7 @@ import {AddressVerifyModal} from './AddressVerifyModal'
 
 export const Modals = ({address, onDone}: {address: string; onDone: () => void}) => {
   const intl = useIntl()
-  const index = useSelector(externalAddressIndexSelector)
+  const index: number | undefined = useSelector(externalAddressIndexSelector)[address]
   const hwDeviceInfo = useSelector(hwDeviceInfoSelector)
   const wallet = useSelectedWallet()
   const dispatch = useDispatch()
@@ -112,8 +112,7 @@ export const Modals = ({address, onDone}: {address: string; onDone: () => void})
         onRequestClose={onDone}
         onConfirm={() => onVerifyAddress(address)}
         address={address}
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        path={formatPath(0, 'External', index as any, wallet.walletImplementationId)}
+        path={index !== undefined ? formatPath(0, 'External', index, wallet.walletImplementationId) : ''}
         isWaiting={isWaiting}
         useUSB={useUSB}
       />


### PR DESCRIPTION
Fixes AddressModal to don't display the path for addresses that don't belong to the current wallet.