### PR TITLE
fix: Clipped views

### DIFF
--- a/src/TxHistory/TxHistoryList/TxHistoryList.tsx
+++ b/src/TxHistory/TxHistoryList/TxHistoryList.tsx
@@ -50,7 +50,6 @@ export const TxHistoryList = ({onScrollUp, onScrollDown, ...props}: Props) => {
         keyExtractor={(item) => item.id}
         stickySectionHeadersEnabled={false}
         nestedScrollEnabled={true}
-        removeClippedSubviews={true}
         maxToRenderPerBatch={20}
         initialNumToRender={20}
       />

--- a/src/TxHistory/TxHistoryList/TxHistoryListItem.tsx
+++ b/src/TxHistory/TxHistoryList/TxHistoryListItem.tsx
@@ -97,51 +97,56 @@ export const TxHistoryListItem = ({transaction}: Props) => {
   const totalAssets = outputsToMyWallet.reduce((acc, {assets}) => acc + Number(assets.length), 0)
 
   return (
-    <TouchableOpacity onPress={showDetails} activeOpacity={0.5}>
-      <View style={[styles.root, {backgroundColor: rootBgColor}]}>
-        <View style={styles.iconRoot}>
-          <Icon.Direction transaction={transaction} />
-        </View>
-        <View style={styles.transactionRoot}>
-          <View style={styles.row}>
-            <Text small secondary={isPending}>
-              {strings.direction(transaction.direction as any)}
-            </Text>
-            {transaction.amount.length > 0 ? (
-              <View style={styles.amount}>
-                <Text style={amountStyle} secondary={isPending}>
-                  {formatTokenInteger(amountToDisplay, defaultAsset)}
-                </Text>
-                <Text small style={amountStyle} secondary={isPending}>
-                  {formatTokenFractional(amountToDisplay, defaultAsset)}
-                </Text>
-                <Text style={amountStyle}>{`${utfSymbols.NBSP}${assetSymbol}`}</Text>
-              </View>
-            ) : (
-              <Text style={amountStyle}>- -</Text>
-            )}
+    <View removeClippedSubviews style={styles.wrapper}>
+      <TouchableOpacity onPress={showDetails} activeOpacity={0.5}>
+        <View style={[styles.item, {backgroundColor: rootBgColor}]}>
+          <View style={styles.iconRoot}>
+            <Icon.Direction transaction={transaction} />
           </View>
-          {totalAssets !== 0 && (
+          <View style={styles.transactionRoot}>
             <View style={styles.row}>
-              <Text secondary small>
-                {submittedAt}
+              <Text small secondary={isPending}>
+                {strings.direction(transaction.direction as any)}
               </Text>
-              <Text>{strings.assets(totalAssets)}</Text>
+              {transaction.amount.length > 0 ? (
+                <View style={styles.amount}>
+                  <Text style={amountStyle} secondary={isPending}>
+                    {formatTokenInteger(amountToDisplay, defaultAsset)}
+                  </Text>
+                  <Text small style={amountStyle} secondary={isPending}>
+                    {formatTokenFractional(amountToDisplay, defaultAsset)}
+                  </Text>
+                  <Text style={amountStyle}>{`${utfSymbols.NBSP}${assetSymbol}`}</Text>
+                </View>
+              ) : (
+                <Text style={amountStyle}>- -</Text>
+              )}
             </View>
-          )}
-          <View style={styles.last}>
-            <Text secondary small>
-              {totalAssets === 0 && submittedAt}
-            </Text>
+            {totalAssets !== 0 && (
+              <View style={styles.row}>
+                <Text secondary small>
+                  {submittedAt}
+                </Text>
+                <Text>{strings.assets(totalAssets)}</Text>
+              </View>
+            )}
+            <View style={styles.last}>
+              <Text secondary small>
+                {totalAssets === 0 && submittedAt}
+              </Text>
+            </View>
           </View>
         </View>
-      </View>
-    </TouchableOpacity>
+      </TouchableOpacity>
+    </View>
   )
 }
 
 const styles = StyleSheet.create({
-  root: {
+  wrapper: {
+    overflow: 'hidden',
+  },
+  item: {
     flex: 1,
     flexDirection: 'row',
     borderRadius: 10,


### PR DESCRIPTION
- Updated the use of `removeClippedSubviews` [reference here](https://reactnative.dev/docs/view#removeclippedsubviews)
- It should be used together with `overflow: hidden`


####  Issue when rendering items
<img src="https://user-images.githubusercontent.com/30806844/186503041-ad9af9b8-24f5-4828-8023-a36f62e410e7.png" width="260" />

#### Stats before clipping
<img src="https://user-images.githubusercontent.com/30806844/186503058-00867f29-dad9-428b-ab5d-66e098369139.png" width="260" />

#### Stats after clipping
<img src="https://user-images.githubusercontent.com/30806844/186503057-e94d57f2-9e04-449f-9a06-abd7fc50531b.png" width="260" />


