### PR TITLE
Refactor biometric auth confirm tx button

### DIFF
--- a/src/Send/ConfirmScreen/ConfirmScreen.tsx
+++ b/src/Send/ConfirmScreen/ConfirmScreen.tsx
@@ -6,7 +6,7 @@ import {useIntl} from 'react-intl'
 import {Keyboard, ScrollView, StyleSheet, View, ViewProps} from 'react-native'
 
 import {Boundary, KeyboardSpacer, Spacer, StatusBar, Text, ValidatedTextInput} from '../../components'
-import {ConfirmTx} from '../../components/ConfirmTx'
+import {ConfirmTx, ConfirmTxWithOSAndSubmit} from '../../components/ConfirmTx'
 import {useBalances, useTokenInfo} from '../../hooks'
 import globalMessages, {confirmationMessages, errorMessages, txLabels} from '../../i18n/global-messages'
 import {CONFIG} from '../../legacy/config'
@@ -89,15 +89,19 @@ export const ConfirmScreen = () => {
       </ScrollView>
 
       <Actions>
-        <ConfirmTx
-          onSuccess={onSuccess}
-          yoroiUnsignedTx={yoroiUnsignedTx}
-          useUSB={useUSB}
-          setUseUSB={setUseUSB}
-          isProvidingPassword
-          providedPassword={password}
-          chooseTransportOnConfirmation
-        />
+        {wallet.isEasyConfirmationEnabled ? (
+          <ConfirmTxWithOSAndSubmit wallet={wallet} unsignedTx={yoroiUnsignedTx} onSuccess={() => onSuccess()} />
+        ) : (
+          <ConfirmTx
+            onSuccess={onSuccess}
+            yoroiUnsignedTx={yoroiUnsignedTx}
+            useUSB={useUSB}
+            setUseUSB={setUseUSB}
+            isProvidingPassword
+            providedPassword={password}
+            chooseTransportOnConfirmation
+          />
+        )}
       </Actions>
     </View>
   )

--- a/src/auth/hooks.ts
+++ b/src/auth/hooks.ts
@@ -100,7 +100,7 @@ export const useAuthOsWithEasyConfirmation = (
   const strings = useStrings()
 
   const alert = (error: unknown) => {
-    if (error instanceof Keychain.Errors.CancelledByUser) return
+    if (error instanceof Keychain.Errors.CancelledByUser) return Alert.alert(strings.error, strings.biometricCancelled)
     if (error instanceof Keychain.Errors.TooManyAttempts) return Alert.alert(strings.error, strings.tooManyAttempts)
     return Alert.alert(strings.error, strings.unknownError)
   }
@@ -294,6 +294,7 @@ const useStrings = () => {
     error: intl.formatMessage(globalMessages.error),
     cancel: intl.formatMessage(globalMessages.cancel),
     authorize: intl.formatMessage(messages.authorize),
+    biometricCancelled: intl.formatMessage(messages.biometricCancelled),
   }
 }
 
@@ -309,6 +310,10 @@ const messages = defineMessages({
   unknownError: {
     id: 'components.send.biometricauthscreen.UNKNOWN_ERROR',
     defaultMessage: '!!!Unknown error!',
+  },
+  biometricCancelled: {
+    id: 'components.send.biometricauthscreen.biometricCancelled',
+    defaultMessage: '!!!Biometric cancelled',
   },
 })
 

--- a/src/components/ConfirmTx/ConfirmTx.tsx
+++ b/src/components/ConfirmTx/ConfirmTx.tsx
@@ -20,6 +20,8 @@ import {YoroiUnsignedTx} from '../../yoroi-wallets/types'
 import {Button, ButtonProps, ValidatedTextInput} from '..'
 import {Dialog, Step as DialogStep} from './Dialog'
 
+export {ConfirmTxWithOSAndSubmit} from './ConfirmTxWithOSAndSubmit'
+
 type ErrorData = {
   errorMessage: string
   errorLogs?: string

--- a/src/components/ConfirmTx/ConfirmTxWithOSAndSubmit.stories.tsx
+++ b/src/components/ConfirmTx/ConfirmTxWithOSAndSubmit.stories.tsx
@@ -1,0 +1,25 @@
+import {action} from '@storybook/addon-actions'
+import {storiesOf} from '@storybook/react-native'
+import React from 'react'
+
+import {mocks, WithModal} from '../../../storybook'
+import {Boundary} from '../../components'
+import {ConfirmTxWithOSAndSubmit} from './ConfirmTxWithOSAndSubmit'
+
+storiesOf('ConfirmTx/ConfirmTxWithOSAndSubmit', module).add('default', () => (
+  <WithModal>
+    <Boundary>
+      <ConfirmTxWithOSAndSubmit
+        wallet={{
+          ...mocks.wallet,
+          submitTransaction: async (yoroiSignedTx) => {
+            action('onSubmit')(yoroiSignedTx)
+            return []
+          },
+        }}
+        unsignedTx={mocks.yoroiUnsignedTx}
+        onSuccess={action('onSuccess')}
+      />
+    </Boundary>
+  </WithModal>
+))

--- a/src/components/ConfirmTx/ConfirmTxWithOSAndSubmit.tsx
+++ b/src/components/ConfirmTx/ConfirmTxWithOSAndSubmit.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import {useIntl} from 'react-intl'
+
+import {useAuthOsWithEasyConfirmation} from '../../auth'
+import {useSignAndSubmitTx} from '../../hooks'
+import {actionMessages} from '../../i18n/global-messages'
+import {YoroiWallet} from '../../yoroi-wallets'
+import {YoroiUnsignedTx} from '../../yoroi-wallets/types'
+import {Button} from '../Button'
+import {LoadingOverlay} from '../LoadingOverlay'
+
+type Props = {
+  wallet: YoroiWallet
+  unsignedTx: YoroiUnsignedTx
+  onSuccess: () => void
+}
+
+export const ConfirmTxWithOSAndSubmit = ({wallet, unsignedTx, onSuccess}: Props) => {
+  const strings = useStrings()
+
+  const {authWithOs, isLoading: authenticating} = useAuthOsWithEasyConfirmation(
+    {id: wallet.id},
+    {
+      onSuccess: async (rootKey) => {
+        const signed = await signAndSubmitTx({unsignedTx, rootKey})
+        signed
+      },
+    },
+  )
+
+  const {signAndSubmitTx, isLoading: processingTx} = useSignAndSubmitTx(
+    {wallet},
+    {
+      signTx: {useErrorBoundary: true},
+      submitTx: {onSuccess, useErrorBoundary: true},
+    },
+  )
+
+  const isLoading = authenticating || processingTx
+
+  return (
+    <>
+      <Button title={strings.sendButton} onPress={() => authWithOs()} shelleyTheme disabled={isLoading} />
+
+      <LoadingOverlay loading={isLoading} />
+    </>
+  )
+}
+
+const useStrings = () => {
+  const intl = useIntl()
+
+  return {
+    sendButton: intl.formatMessage(actionMessages.send),
+  }
+}

--- a/src/components/ConfirmTx/ConfirmTxWithOSAndSubmit.tsx
+++ b/src/components/ConfirmTx/ConfirmTxWithOSAndSubmit.tsx
@@ -20,12 +20,7 @@ export const ConfirmTxWithOSAndSubmit = ({wallet, unsignedTx, onSuccess}: Props)
 
   const {authWithOs, isLoading: authenticating} = useAuthOsWithEasyConfirmation(
     {id: wallet.id},
-    {
-      onSuccess: async (rootKey) => {
-        const signed = await signAndSubmitTx({unsignedTx, rootKey})
-        signed
-      },
-    },
+    {onSuccess: (rootKey) => signAndSubmitTx({unsignedTx, rootKey})},
   )
 
   const {signAndSubmitTx, isLoading: processingTx} = useSignAndSubmitTx(

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -84,6 +84,7 @@ function loadStories() {
 	require('../src/components/Button/Button.stories');
 	require('../src/components/Checkbox/Checkbox.stories');
 	require('../src/components/ConfirmTx/ConfirmTx.stories');
+	require('../src/components/ConfirmTx/ConfirmTxWithOSAndSubmit.stories');
 	require('../src/components/ConfirmTx/Dialog.stories');
 	require('../src/components/DangerousActionModal/DangerousActionModal.stories');
 	require('../src/components/ErrorBoundary/ErrorBoundary.stories');
@@ -184,6 +185,7 @@ const stories = [
 	'../src/components/Button/Button.stories',
 	'../src/components/Checkbox/Checkbox.stories',
 	'../src/components/ConfirmTx/ConfirmTx.stories',
+	'../src/components/ConfirmTx/ConfirmTxWithOSAndSubmit.stories',
 	'../src/components/ConfirmTx/Dialog.stories',
 	'../src/components/DangerousActionModal/DangerousActionModal.stories',
 	'../src/components/ErrorBoundary/ErrorBoundary.stories',


### PR DESCRIPTION
Create a new component `ConfirmTxWithOSAndSubmit.tsx` and simplify the logic behind signing and submitting transactions for wallets that have easy confirmation enabled. This is a gradual refactoring of the `ConfirmTx` button inspired by https://github.com/Emurgo/yoroi-mobile/pull/2224