### PR TITLE
Bump lib to 0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@emurgo/cross-csl-mobile": "^1.0.0",
     "@emurgo/react-native-haskell-shelley": "4.0.0-beta.2",
     "@emurgo/react-native-hid": "^5.15.6",
-    "@emurgo/yoroi-lib": "0.2.0",
+    "@emurgo/yoroi-lib": "^0.3.0",
     "@formatjs/intl": "^1.14.1",
     "@formatjs/intl-datetimeformat": "^4.2.3",
     "@formatjs/intl-getcanonicallocales": "^1.7.3",

--- a/src/yoroi-wallets/cardano/ShelleyWallet.ts
+++ b/src/yoroi-wallets/cardano/ShelleyWallet.ts
@@ -1174,10 +1174,10 @@ export class ShelleyWallet implements WalletInterface {
     Logger.info('Discovery done, now syncing transactions')
 
     await this.discoverAddresses()
-    await this.syncUtxos()
-
-    // later only if utxos have changed
-    await this.transactionCache.doSync(this.getAddressesInBlocks(), this.getBackendConfig())
+    await Promise.all([
+      this.syncUtxos(),
+      this.transactionCache.doSync(this.getAddressesInBlocks(), this.getBackendConfig()),
+    ])
   }
 
   // ========== UI state ============= //

--- a/yarn.lock
+++ b/yarn.lock
@@ -1755,10 +1755,10 @@
     "@ledgerhq/logs" "^5.15.0"
     rxjs "^6.5.5"
 
-"@emurgo/yoroi-lib@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@emurgo/yoroi-lib/-/yoroi-lib-0.2.0.tgz#c51942a3cc2ef38e483fa23f75976f0ea86839c6"
-  integrity sha512-lcYFco0x7gxIrPXWxxw3Fz1AtWqY9do3l7cFZINH29FUSfu3yUR/pvU/TMlSZBROs3yXv7BsMuGWYVMdUoZ98w==
+"@emurgo/yoroi-lib@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@emurgo/yoroi-lib/-/yoroi-lib-0.3.0.tgz#543a21b025604e18d48a9927acbace13ed81caf1"
+  integrity sha512-+1WVLMBmJhqw3CUD1YdHvKl18ibT8zMmLD3nUw3tNZe0J4DSI6QIOdAeWOeOCRWn1nAJIgcj92CC0/f0nMaNYg==
   dependencies:
     "@cardano-foundation/ledgerjs-hw-app-cardano" "^5.1.0"
     "@emurgo/cross-csl-core" "^1.0.0"


### PR DESCRIPTION
- Bumped lib to a version that expands the number of addresses per request and the page size (it also exposes to the client these settings so the client can tune it according to the network conditions)
- Improved the syncing by not waiting for the utxos sync to finish