### PR TITLE
Fix bio initializating

### DIFF
--- a/src/FirstRun/TermsOfServiceScreen/TermsOfServiceScreen.tsx
+++ b/src/FirstRun/TermsOfServiceScreen/TermsOfServiceScreen.tsx
@@ -23,7 +23,10 @@ export const TermsOfServiceScreen = () => {
   const {login} = useAuth()
   const authOsEnabled = useAuthOsEnabled()
   const storage = useStorage()
-  const {enableAuthWithOs, isLoading} = useEnableAuthWithOs({storage}, {onSuccess: login})
+  const {enableAuthWithOs, isLoading} = useEnableAuthWithOs(
+    {storage},
+    {onSuccess: login, onError: () => navigation.navigate('enable-login-with-pin')},
+  )
 
   const onAccept = () => {
     if (authOsEnabled) {


### PR DESCRIPTION
- While setting up bio at first run, if there is an error and is not possible to complete the operation, the app stuck, not allowing the user to finish the app setup
- Added a fallback to continue with PIN if something goes wrong with biometrics setup, or if the user decides to cancel the biometrics, both scenarios will fallback to PIN

[YOMO-449](https://emurgo.atlassian.net/browse/YOMO-449)

[YOMO-449]: https://emurgo.atlassian.net/browse/YOMO-449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ