### PR TITLE
Fix: counting only secondary amounts per tx

### DIFF
--- a/.storybook/storybook.requires.js
+++ b/.storybook/storybook.requires.js
@@ -99,7 +99,7 @@ const getStories = () => {
     "./src/features/Send/useCases/ListAmountsToSend/AddToken/AddToken.stories.tsx": require("../src/features/Send/useCases/ListAmountsToSend/AddToken/AddToken.stories.tsx"),
     "./src/features/Send/useCases/ListAmountsToSend/AddToken/SelectTokenFromListScreen.stories.tsx": require("../src/features/Send/useCases/ListAmountsToSend/AddToken/SelectTokenFromListScreen.stories.tsx"),
     "./src/features/Send/useCases/ListAmountsToSend/AddToken/Show/EmptySearchResult.stories.tsx": require("../src/features/Send/useCases/ListAmountsToSend/AddToken/Show/EmptySearchResult.stories.tsx"),
-    "./src/features/Send/useCases/ListAmountsToSend/AddToken/Show/MaxTokensPerTx.stories.tsx": require("../src/features/Send/useCases/ListAmountsToSend/AddToken/Show/MaxTokensPerTx.stories.tsx"),
+    "./src/features/Send/useCases/ListAmountsToSend/AddToken/Show/MaxAmountsPerTx.stories.tsx": require("../src/features/Send/useCases/ListAmountsToSend/AddToken/Show/MaxAmountsPerTx.stories.tsx"),
     "./src/features/Send/useCases/ListAmountsToSend/EditAmount/EditAmountScreen.stories.tsx": require("../src/features/Send/useCases/ListAmountsToSend/EditAmount/EditAmountScreen.stories.tsx"),
     "./src/features/Send/useCases/ListAmountsToSend/ListAmountsToSendScreen.stories.tsx": require("../src/features/Send/useCases/ListAmountsToSend/ListAmountsToSendScreen.stories.tsx"),
     "./src/features/Send/useCases/StartMultiTokenTx/InputReceiver/ReadQRCodeScreen.stories.tsx": require("../src/features/Send/useCases/StartMultiTokenTx/InputReceiver/ReadQRCodeScreen.stories.tsx"),

--- a/src/components/ErrorPanel/ErrorPanel.stories.tsx
+++ b/src/components/ErrorPanel/ErrorPanel.stories.tsx
@@ -4,11 +4,11 @@ import {defineMessages, useIntl} from 'react-intl'
 import {Text} from 'react-native'
 
 import globalMessages from '../../i18n/global-messages'
-import {maxTokensPerTx} from '../../yoroi-wallets/contants'
+import {limitOfSecondaryAmountsPerTx} from '../../yoroi-wallets/contants'
 import {ScreenBackground} from '../ScreenBackground'
 import {ErrorPanel} from './ErrorPanel'
 
-storiesOf('Components/ErrorPanel', module).add('with error message', () => {
+storiesOf('Error Panel', module).add('with error message', () => {
   const strings = useStrings()
   return (
     <ScreenBackground style={{padding: 16, backgroundColor: 'white'}}>
@@ -16,9 +16,9 @@ storiesOf('Components/ErrorPanel', module).add('with error message', () => {
         <Text>
           <Text
             style={{fontWeight: '500', fontFamily: 'Rubik-Medium'}}
-          >{`${maxTokensPerTx} ${strings.assets.toLocaleLowerCase()} `}</Text>
+          >{`${limitOfSecondaryAmountsPerTx} ${strings.assets.toLocaleLowerCase()} `}</Text>
 
-          {strings.maxTokenLimit}
+          {strings.maxAmountsPerTx}
         </Text>
       </ErrorPanel>
     </ScreenBackground>
@@ -26,7 +26,7 @@ storiesOf('Components/ErrorPanel', module).add('with error message', () => {
 })
 
 const messages = defineMessages({
-  maxTokenLimit: {
+  maxAmountsPerTx: {
     id: 'components.send.sendscreen.errorBannerMaxTokenLimit',
     defaultMessage: '!!!is the maximum number allowed to send in one transaction',
   },
@@ -36,7 +36,7 @@ const useStrings = () => {
   const intl = useIntl()
 
   return {
-    maxTokenLimit: intl.formatMessage(messages.maxTokenLimit),
+    maxAmountsPerTx: intl.formatMessage(messages.maxAmountsPerTx),
     assets: intl.formatMessage(globalMessages.assetsLabel),
   }
 }

--- a/src/features/Send/common/SendContext.test.tsx
+++ b/src/features/Send/common/SendContext.test.tsx
@@ -4,9 +4,10 @@ import * as React from 'react'
 import {TextInput} from 'react-native'
 
 import {Button} from '../../../components/Button/Button'
-import {mocks} from '../../../yoroi-wallets/mocks'
+import {mocks as walletMocks} from '../../../yoroi-wallets/mocks'
 import {Amounts} from '../../../yoroi-wallets/utils/utils'
-import {initialState, SendProvider, useSend} from './SendContext'
+import {mocks as sendMocks} from './mocks'
+import {initialState, SendProvider, useSelectedSecondaryAmountsCounter, useSend} from './SendContext'
 
 const wrapper = ({children}: {children: React.ReactNode}) => <SendProvider>{children}</SendProvider>
 
@@ -64,20 +65,20 @@ describe('SendContext :: hooks', () => {
     const {result} = renderHook(() => useSend(), {wrapper})
 
     act(() => {
-      result.current.tokenSelectedChanged(mocks.wallet.primaryTokenInfo.id)
+      result.current.tokenSelectedChanged(walletMocks.wallet.primaryTokenInfo.id)
     })
 
-    expect(result.current.selectedTokenId).toBe(mocks.wallet.primaryTokenInfo.id)
+    expect(result.current.selectedTokenId).toBe(walletMocks.wallet.primaryTokenInfo.id)
   })
 
   test('yoroiUnsignedTxChanged', () => {
     const {result} = renderHook(() => useSend(), {wrapper})
 
     act(() => {
-      result.current.yoroiUnsignedTxChanged(mocks.yoroiUnsignedTx)
+      result.current.yoroiUnsignedTxChanged(walletMocks.yoroiUnsignedTx)
     })
 
-    expect(result.current.yoroiUnsignedTx).toEqual(mocks.yoroiUnsignedTx)
+    expect(result.current.yoroiUnsignedTx).toEqual(walletMocks.yoroiUnsignedTx)
 
     act(() => {
       result.current.yoroiUnsignedTxChanged(undefined)
@@ -108,7 +109,7 @@ describe('SendContext :: hooks', () => {
 
   test('amountChanged', () => {
     const {result} = renderHook(() => useSend(), {wrapper})
-    const amount = Amounts.getAmount(mocks.balances, mocks.wallet.primaryTokenInfo.id)
+    const amount = Amounts.getAmount(walletMocks.balances, walletMocks.wallet.primaryTokenInfo.id)
 
     act(() => {
       result.current.tokenSelectedChanged(amount.tokenId)
@@ -123,7 +124,7 @@ describe('SendContext :: hooks', () => {
 
   test('amountRemoved', () => {
     const {result} = renderHook(() => useSend(), {wrapper})
-    const amount = Amounts.getAmount(mocks.balances, mocks.wallet.primaryTokenInfo.id)
+    const amount = Amounts.getAmount(walletMocks.balances, walletMocks.wallet.primaryTokenInfo.id)
 
     act(() => {
       result.current.tokenSelectedChanged(amount.tokenId)
@@ -160,3 +161,37 @@ const ResetFormTest = () => {
     </>
   )
 }
+
+describe('useSelectedSecondaryAmountsCounter', () => {
+  it('empty', () => {
+    const {result} = renderHook(() => useSelectedSecondaryAmountsCounter(walletMocks.wallet), {
+      wrapper: ({children}) => <SendProvider>{children}</SendProvider>,
+    })
+
+    expect(result.current).toEqual(0)
+  })
+
+  it('only secondary token(s)', () => {
+    const {result} = renderHook(() => useSelectedSecondaryAmountsCounter(walletMocks.wallet), {
+      wrapper: ({children}) => <SendProvider initialState={sendMocks.counters.onlySecondary}>{children}</SendProvider>,
+    })
+
+    expect(result.current).toEqual(3)
+  })
+
+  it('both token(s)', () => {
+    const {result} = renderHook(() => useSelectedSecondaryAmountsCounter(walletMocks.wallet), {
+      wrapper: ({children}) => <SendProvider initialState={sendMocks.counters.both}>{children}</SendProvider>,
+    })
+
+    expect(result.current).toEqual(4)
+  })
+
+  it('only primary token(s)', () => {
+    const {result} = renderHook(() => useSelectedSecondaryAmountsCounter(walletMocks.wallet), {
+      wrapper: ({children}) => <SendProvider initialState={sendMocks.counters.onlyPrimary}>{children}</SendProvider>,
+    })
+
+    expect(result.current).toEqual(0)
+  })
+})

--- a/src/features/Send/common/SendContext.tsx
+++ b/src/features/Send/common/SendContext.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react'
 
 import {useSelectedWallet} from '../../../SelectedWallet/Context/SelectedWalletContext'
+import {YoroiWallet} from '../../../yoroi-wallets'
 import {useBalance, useLockedAmount} from '../../../yoroi-wallets/hooks'
-import {Address, Quantity, YoroiTarget, YoroiUnsignedTx} from '../../../yoroi-wallets/types'
+import {Address, Quantity, YoroiAmount, YoroiTarget, YoroiUnsignedTx} from '../../../yoroi-wallets/types'
 import {Amounts, Quantities} from '../../../yoroi-wallets/utils/utils'
 
 export type SendState = {
@@ -274,11 +275,16 @@ const getTotalUsedByOtherTargets = ({
   }, Quantities.zero)
 }
 
-export const useSelectedTokensCounter = () => {
+export const useSelectedSecondaryAmountsCounter = (wallet: YoroiWallet) => {
   const {targets} = useSend()
-  const selectedTokensCounter = targets.reduce((acc, target) => {
-    return Amounts.toArray(target.entry.amounts).length + acc
-  }, 0)
+  const isSecondaryAmount = isSecondaryAmountFilter(wallet)
 
-  return selectedTokensCounter
+  return targets.reduce((acc, target) => {
+    return Amounts.toArray(target.entry.amounts).filter(isSecondaryAmount).length + acc
+  }, 0)
 }
+
+const isSecondaryAmountFilter =
+  (wallet: YoroiWallet) =>
+  ({tokenId}: YoroiAmount) =>
+    tokenId !== wallet.primaryTokenInfo.id

--- a/src/features/Send/common/mocks.ts
+++ b/src/features/Send/common/mocks.ts
@@ -137,4 +137,54 @@ export const mocks = {
       ],
     },
   },
+  counters: {
+    onlyPrimary: {
+      ...initialState,
+      targets: [
+        {
+          ...initialState.targets[0],
+          entry: {
+            ...initialState.targets[0].entry,
+            amounts: {
+              [walletMocks.wallet.primaryTokenInfo.id]: asQuantity(50000),
+            },
+          },
+        },
+      ],
+    },
+    onlySecondary: {
+      ...initialState,
+      targets: [
+        {
+          ...initialState.targets[0],
+          entry: {
+            ...initialState.targets[0].entry,
+            amounts: {
+              [secondaryTokenId]: asQuantity(1),
+              ['other.01']: asQuantity(2),
+              ['another.02']: asQuantity(3),
+            },
+          },
+        },
+      ],
+    },
+    both: {
+      ...initialState,
+      targets: [
+        {
+          ...initialState.targets[0],
+          entry: {
+            ...initialState.targets[0].entry,
+            amounts: {
+              [secondaryTokenId]: asQuantity(1),
+              ['other.01']: asQuantity(2),
+              ['another.02']: asQuantity(3),
+              ['more.03']: asQuantity(4),
+              [walletMocks.wallet.primaryTokenInfo.id]: asQuantity(50000),
+            },
+          },
+        },
+      ],
+    },
+  },
 }

--- a/src/features/Send/useCases/ListAmountsToSend/AddToken/SelectTokenFromListScreen.tsx
+++ b/src/features/Send/useCases/ListAmountsToSend/AddToken/SelectTokenFromListScreen.tsx
@@ -10,15 +10,15 @@ import {useSearch, useSearchOnNavBar} from '../../../../../Search/SearchContext'
 import {useSelectedWallet} from '../../../../../SelectedWallet/Context/SelectedWalletContext'
 import {sortTokenInfos} from '../../../../../utils'
 import {YoroiWallet} from '../../../../../yoroi-wallets/cardano/types'
-import {maxTokensPerTx} from '../../../../../yoroi-wallets/contants'
+import {limitOfSecondaryAmountsPerTx} from '../../../../../yoroi-wallets/contants'
 import {useBalances, useTokenInfos} from '../../../../../yoroi-wallets/hooks'
 import {TokenInfo} from '../../../../../yoroi-wallets/types'
 import {Amounts, Quantities} from '../../../../../yoroi-wallets/utils'
 import {filterAssets} from '../../../common/filterAssets'
-import {useSelectedTokensCounter, useSend, useTokenQuantities} from '../../../common/SendContext'
+import {useSelectedSecondaryAmountsCounter, useSend, useTokenQuantities} from '../../../common/SendContext'
 import {useStrings} from '../../../common/strings'
 import {EmptySearchResult} from './Show/EmptySearchResult'
-import {MaxTokensPerTx} from './Show/MaxTokensPerTx'
+import {MaxAmountsPerTx} from './Show/MaxAmountsPerTx'
 
 export const SelectTokenFromListScreen = () => {
   const strings = useStrings()
@@ -36,8 +36,8 @@ export const SelectTokenFromListScreen = () => {
     wallet,
     tokenIds: Amounts.toArray(balances).map(({tokenId}) => tokenId),
   })
-  const selectedTokensCounter = useSelectedTokensCounter()
-  const canAddToken = selectedTokensCounter < maxTokensPerTx
+  const secondaryAmountsCounter = useSelectedSecondaryAmountsCounter(wallet)
+  const canAddAmount = secondaryAmountsCounter < limitOfSecondaryAmountsPerTx
 
   const {search: assetSearchTerm} = useSearch()
   const sortedTokenInfos = sortTokenInfos({wallet, tokenInfos: filterAssets(assetSearchTerm, tokenInfos)})
@@ -45,9 +45,9 @@ export const SelectTokenFromListScreen = () => {
 
   return (
     <View style={styles.root}>
-      {!canAddToken && (
+      {!canAddAmount && (
         <View style={styles.panel}>
-          <MaxTokensPerTx />
+          <MaxAmountsPerTx />
 
           <Spacer height={16} />
         </View>
@@ -57,7 +57,7 @@ export const SelectTokenFromListScreen = () => {
         data={sortedTokenInfos}
         renderItem={({item: tokenInfo}: {item: TokenInfo}) => (
           <Boundary>
-            <SelectableAssetItem tokenInfo={tokenInfo} disabled={!canAddToken} wallet={wallet} />
+            <SelectableAssetItem tokenInfo={tokenInfo} disabled={!canAddAmount} wallet={wallet} />
           </Boundary>
         )}
         bounces={false}

--- a/src/features/Send/useCases/ListAmountsToSend/AddToken/Show/MaxAmountsPerTx.stories.tsx
+++ b/src/features/Send/useCases/ListAmountsToSend/AddToken/Show/MaxAmountsPerTx.stories.tsx
@@ -2,10 +2,10 @@ import {storiesOf} from '@storybook/react-native'
 import React from 'react'
 import {View} from 'react-native'
 
-import {MaxTokensPerTx} from './MaxTokensPerTx'
+import {MaxAmountsPerTx} from './MaxAmountsPerTx'
 
-storiesOf('Max Tokens Per Tx', module).add('initial', () => (
+storiesOf('Max Amounts Per Tx', module).add('initial', () => (
   <View style={{justifyContent: 'center', padding: 16}}>
-    <MaxTokensPerTx />
+    <MaxAmountsPerTx />
   </View>
 ))

--- a/src/features/Send/useCases/ListAmountsToSend/AddToken/Show/MaxAmountsPerTx.tsx
+++ b/src/features/Send/useCases/ListAmountsToSend/AddToken/Show/MaxAmountsPerTx.tsx
@@ -4,9 +4,9 @@ import {Text} from 'react-native'
 
 import {ErrorPanel} from '../../../../../../components/ErrorPanel/ErrorPanel'
 import globalMessages from '../../../../../../i18n/global-messages'
-import {maxTokensPerTx} from '../../../../../../yoroi-wallets/contants'
+import {limitOfSecondaryAmountsPerTx} from '../../../../../../yoroi-wallets/contants'
 
-export const MaxTokensPerTx = () => {
+export const MaxAmountsPerTx = () => {
   const strings = useStrings()
 
   return (
@@ -14,16 +14,16 @@ export const MaxTokensPerTx = () => {
       <Text>
         <Text
           style={{fontWeight: '500', fontFamily: 'Rubik-Medium'}}
-        >{`${maxTokensPerTx} ${strings.assets.toLocaleLowerCase()} `}</Text>
+        >{`${limitOfSecondaryAmountsPerTx} ${strings.assets.toLocaleLowerCase()} `}</Text>
 
-        {strings.maxTokenLimit}
+        {strings.maxAmountsPerTx}
       </Text>
     </ErrorPanel>
   )
 }
 
 const messages = defineMessages({
-  maxTokenLimit: {
+  maxAmountsPerTx: {
     id: 'components.send.sendscreen.errorBannerMaxTokenLimit',
     defaultMessage: '!!!is the maximum number allowed to send in one transaction',
   },
@@ -33,7 +33,7 @@ const useStrings = () => {
   const intl = useIntl()
 
   return {
-    maxTokenLimit: intl.formatMessage(messages.maxTokenLimit),
+    maxAmountsPerTx: intl.formatMessage(messages.maxAmountsPerTx),
     assets: intl.formatMessage(globalMessages.assetsLabel),
   }
 }

--- a/src/yoroi-wallets/contants.ts
+++ b/src/yoroi-wallets/contants.ts
@@ -1,1 +1,1 @@
-export const maxTokensPerTx = 10
+export const limitOfSecondaryAmountsPerTx = 10


### PR DESCRIPTION
-  It should not count the primary amounts in the MAT, so the limit right now is 10 secondary amounts.