### PR TITLE
fix(deserialization): Limit asset name to 32 bytes

### DIFF
--- a/src/yoroi-wallets/cardano/api/utils.test.ts
+++ b/src/yoroi-wallets/cardano/api/utils.test.ts
@@ -31,6 +31,9 @@ describe('api utils', () => {
     const noName = policyId
     expect(toPolicyId(noName)).toEqual(policyId)
     expect(toAssetName(noName)).toEqual(undefined)
+
+    const longName = '1'.repeat(128)
+    expect(toAssetName(policyId + '.' + asciiToHex(longName))).toEqual('1'.repeat(32))
   })
 
   describe('toTokenSubject', () => {

--- a/src/yoroi-wallets/cardano/api/utils.ts
+++ b/src/yoroi-wallets/cardano/api/utils.ts
@@ -53,15 +53,19 @@ export const toPolicyId = (tokenIdentifier: string) => {
   return tokenSubject.slice(0, 56)
 }
 export const toAssetName = (tokenIdentifier: string) => {
+  return hexToAscii(toAssetNameHex(tokenIdentifier)) || undefined
+}
+
+export const toAssetNameHex = (tokenIdentifier: string) => {
   const tokenSubject = toTokenSubject(tokenIdentifier)
-  const assetName = hexToAscii(tokenSubject.slice(56)) || undefined
-  return assetName
+  const maxAssetNameLengthInBytes = 32
+  return tokenSubject.slice(56, 56 + maxAssetNameLengthInBytes * 2)
 }
 
 export const toTokenSubject = (tokenIdentifier: string) => tokenIdentifier.replace('.', '')
 export const toTokenId = (tokenIdentifier: string) => {
   const tokenSubject = toTokenSubject(tokenIdentifier)
-  return `${tokenSubject.slice(0, 56)}.${tokenSubject.slice(56)}`
+  return `${tokenSubject.slice(0, 56)}.${toAssetNameHex(tokenIdentifier)}`
 }
 
 export const hexToAscii = (hex: string) => Buffer.from(hex, 'hex').toLocaleString()

--- a/src/yoroi-wallets/cardano/utils.ts
+++ b/src/yoroi-wallets/cardano/utils.ts
@@ -16,13 +16,12 @@ import {Token} from '../types/tokens'
 import {YoroiAmount, YoroiAmounts} from '../types/types'
 import {Amounts} from '../utils'
 import {
-  asciiToHex,
   CardanoHaskellShelleyNetwork,
   CardanoMobile,
   CardanoTypes,
   MultiToken,
   PRIMARY_ASSET_CONSTANTS,
-  toAssetName,
+  toAssetNameHex,
   toPolicyId,
   WalletImplementation,
 } from '.'
@@ -100,7 +99,7 @@ const identifierToCardanoAsset = async (
   name: CardanoTypes.AssetName
 }> => {
   const policyId = toPolicyId(tokenId)
-  const assetNameHex = asciiToHex(toAssetName(tokenId) ?? '')
+  const assetNameHex = toAssetNameHex(tokenId)
 
   return {
     policyId: await CardanoMobile.ScriptHash.fromBytes(Buffer.from(policyId, 'hex')),


### PR DESCRIPTION
Fixes [YOMO-528](https://emurgo.atlassian.net/jira/software/c/projects/YOMO/issues/YOMO-528)

Cardano asset name length can be max 32 bytes
- https://cardano.stackexchange.com/questions/531/is-the-length-in-characters-of-a-token-policy-id-always-the-same
- https://github.com/input-output-hk/cardano-ledger/blob/683bef2e40cbd10339452c9f2009867c855baf1a/shelley-ma/shelley-ma-test/cddl-files/shelley-ma.cddl#L252

[YOMO-528]: https://emurgo.atlassian.net/browse/YOMO-528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ