### PR TITLE
fix(debugger): Override buffer's subarray and remove react-native-buffer

### DIFF
--- a/apps/wallet-mobile/global.js
+++ b/apps/wallet-mobile/global.js
@@ -1,8 +1,12 @@
-import {Buffer} from '@craftzdog/react-native-buffer'
+import {Buffer} from 'buffer'
 import {decode, encode} from 'base-64'
 
-if (!global.btoa) { global.btoa = encode }
-if (!global.atob) { global.atob = decode }
+if (!global.btoa) {
+  global.btoa = encode
+}
+if (!global.atob) {
+  global.atob = decode
+}
 
 global.Buffer = Buffer
 global.process = require('process')

--- a/apps/wallet-mobile/package.json
+++ b/apps/wallet-mobile/package.json
@@ -71,7 +71,6 @@
   },
   "dependencies": {
     "@cardano-foundation/ledgerjs-hw-app-cardano": "^6.0.0",
-    "@craftzdog/react-native-buffer": "^6.0.5",
     "@emurgo/cip14-js": "^3.0.1",
     "@emurgo/cip4-js": "1.0.7",
     "@emurgo/cross-csl-mobile": "^2.3.0",
@@ -106,6 +105,7 @@
     "bip39": "2.5.0",
     "blake2b": "2.1.3",
     "bs58": "^4.0.1",
+    "buffer": "^6.0.3",
     "chacha": "2.1.0",
     "crypto-random-string": "3.3.0",
     "es6-error": "^4.1.1",

--- a/apps/wallet-mobile/polyfills.ts
+++ b/apps/wallet-mobile/polyfills.ts
@@ -1,3 +1,12 @@
+import {Buffer} from 'buffer'
+
 Object.fromEntries = Object.fromEntries || ((arr) => arr.reduce((acc, [k, v]) => ((acc[k] = v), acc), {}))
+
+Buffer.prototype.subarray = function subarray(start, end) {
+  const newBuf = Uint8Array.prototype.subarray.call(this, start, end)
+  Object.setPrototypeOf(newBuf, Buffer.prototype)
+
+  return newBuf
+}
 
 export {}

--- a/metro.config.js
+++ b/metro.config.js
@@ -13,7 +13,6 @@ module.exports = {
     sourceExts: ["js", "jsx", "ts", "tsx", "json", "md"],
     assetExts: ["png", "jpg", "jpeg", "ttf", "otf", "woff", "woff2"],
     extraNodeModules: {
-      buffer: require.resolve("@craftzdog/react-native-buffer"),
       crypto: require.resolve("react-native-crypto"),
       stream: require.resolve("stream-browserify"),
       url: require.resolve("url"),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1449,14 +1449,6 @@
   dependencies:
     chalk "^4.1.0"
 
-"@craftzdog/react-native-buffer@^6.0.5":
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/@craftzdog/react-native-buffer/-/react-native-buffer-6.0.5.tgz#0d4fbe0dd104186d2806655e3c0d25cebdae91d3"
-  integrity sha512-Av+YqfwA9e7jhgI9GFE/gTpwl/H+dRRLmZyJPOpKTy107j9Oj7oXlm3/YiMNz+C/CEGqcKAOqnXDLs4OL6AAFw==
-  dependencies:
-    ieee754 "^1.2.1"
-    react-native-quick-base64 "^2.0.5"
-
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
@@ -16361,7 +16353,7 @@ react-native-qrcode-svg@6.0.6:
     prop-types "^15.5.10"
     qrcode "^1.3.2"
 
-react-native-quick-base64@^2.0.5, react-native-quick-base64@^2.0.6:
+react-native-quick-base64@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/react-native-quick-base64/-/react-native-quick-base64-2.0.6.tgz#be5d02186697dafea9cce6b982ba6a2322f2ce42"
   integrity sha512-sCHsp4EzOL5OZF+77UfMolhgFDo1nM9TbwNFNExVqOFbMwj13KTGwStwjM9diunCHR9hKEt4LEGf9Afq3FOXzA==


### PR DESCRIPTION
Launching a debugger makes the app crash.

The issue was the `react-native-quick-base64` used by `@craftzdog/react-native-buffer` initializes a module synchronously which is not possible in debugger. I’ve removed `@craftzdog/react-native-buffer` and added a polyfill `Buffer.prototype.subarray = … `(a copy from `@craftzdog/react-native-buffer`) and this seems to solve the issue. I’ve tested the ledger bt connection and it works well. I would have kept the `@craftzdog/react-native-buffer`  if they did not import the `react-native-quick-base64` but this seems to be the core issue in the module.

Resolves YOMO-551
![Screenshot 2023-05-18 at 16 42 28 (1)](https://github.com/Emurgo/yoroi/assets/19684576/6ed54a38-f6f5-44db-9e64-2b3452492968)
