### PR TITLE
fix qr reader when fails

### DIFF
--- a/apps/wallet-mobile/src/components/QRCodeScanner/QRCodeScanner.tsx
+++ b/apps/wallet-mobile/src/components/QRCodeScanner/QRCodeScanner.tsx
@@ -19,12 +19,13 @@ export const QRCodeScanner = ({onRead}: {onRead: ({data}: {data: string}) => voi
     setQrScanned(true)
   }
 
-  if (!granted || qrScanned) {
+  if (!granted || qrScanned /* to stop the scanning loop: https://github.com/expo/expo/issues/345 */) {
     return null
   }
 
   return (
     // expo-barcode-scanner issue in android https://github.com/expo/expo/issues/5212
+    // so expo-camera is used
     <Camera
       style={StyleSheet.absoluteFill}
       ratio="16:9"

--- a/apps/wallet-mobile/src/components/QRCodeScanner/QRCodeScanner.tsx
+++ b/apps/wallet-mobile/src/components/QRCodeScanner/QRCodeScanner.tsx
@@ -5,6 +5,7 @@ import {StyleSheet} from 'react-native'
 
 export const QRCodeScanner = ({onRead}: {onRead: ({data}: {data: string}) => void}) => {
   const [status, requestPermissions] = Camera.useCameraPermissions()
+  const [qrScanned, setQrScanned] = React.useState(false)
   const granted = status && status.granted
 
   React.useEffect(() => {
@@ -15,9 +16,10 @@ export const QRCodeScanner = ({onRead}: {onRead: ({data}: {data: string}) => voi
 
   const handleBarCodeScanned = (event) => {
     onRead(event)
+    setQrScanned(true)
   }
 
-  if (!granted) {
+  if (!granted || qrScanned) {
     return null
   }
 


### PR DESCRIPTION
Related to [YOMO-587](https://emurgo.atlassian.net/browse/YOMO-587)

There are an issue open in the expo-camera repo: [Barcode Scanner does not stop scanning · Issue #345 · expo/expo](https://github.com/expo/expo/issues/345) 

There is no way to stop the scan, so a loop is generated.

The idea I had is to remove the camera component when the qr has been read first time, either reading good or bad code. If it is correct, the user will go to the next screen. If it is bad, the user can go back and retry as I show in the video shared in the ticket.




[YOMO-587]: https://emurgo.atlassian.net/browse/YOMO-587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ