### PR TITLE
refactor: Internationalize numbers

### DIFF
--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditBuyAmount/EditBuyAmount.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditBuyAmount/EditBuyAmount.tsx
@@ -1,10 +1,11 @@
 import {getSellAmountByChangingReceive, useSwap} from '@yoroi/swap'
 import * as React from 'react'
 
+import {useLanguage} from '../../../../../../i18n'
 import {useSelectedWallet} from '../../../../../../SelectedWallet'
 import {useBalance, useTokenInfo} from '../../../../../../yoroi-wallets/hooks'
 import {Logger} from '../../../../../../yoroi-wallets/logging'
-import {asQuantity, Quantities} from '../../../../../../yoroi-wallets/utils'
+import {Quantities} from '../../../../../../yoroi-wallets/utils'
 import {AmountCard} from '../../../../common/AmountCard/AmountCard'
 import {useNavigateTo} from '../../../../common/navigation'
 import {useStrings} from '../../../../common/strings'
@@ -14,6 +15,7 @@ export const EditBuyAmount = () => {
   const strings = useStrings()
   const navigate = useNavigateTo()
   const wallet = useSelectedWallet()
+  const {numberLocale} = useLanguage()
 
   const {createOrder, buyAmountChanged, sellAmountChanged} = useSwap()
   const {isBuyTouched} = useSwapTouched()
@@ -23,10 +25,6 @@ export const EditBuyAmount = () => {
   const balance = useBalance({wallet, tokenId})
 
   const [inputValue, setInputValue] = React.useState<string>(Quantities.denominated(quantity, tokenInfo.decimals ?? 0))
-
-  React.useEffect(() => {
-    setInputValue(Quantities.denominated(quantity, tokenInfo.decimals ?? 0))
-  }, [quantity, tokenInfo.decimals])
 
   const recalculateSellValue = (buyQuantity) => {
     const {sell} = getSellAmountByChangingReceive(createOrder?.selectedPool, {
@@ -41,10 +39,9 @@ export const EditBuyAmount = () => {
 
   const onChangeQuantity = (text: string) => {
     try {
-      setInputValue(text)
-
-      const inputQuantity = asQuantity(text.length > 0 ? text : '0')
+      const [formatted, inputQuantity] = Quantities.fromInput(text, decimals ?? 0, numberLocale)
       const quantity = Quantities.integer(inputQuantity, decimals ?? 0)
+      setInputValue(formatted)
       buyAmountChanged({tokenId, quantity})
       recalculateSellValue(quantity)
     } catch (error) {

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditBuyAmount/EditBuyAmount.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditBuyAmount/EditBuyAmount.tsx
@@ -39,8 +39,8 @@ export const EditBuyAmount = () => {
 
   const onChangeQuantity = (text: string) => {
     try {
-      const [formatted, quantity] = Quantities.formatFromText(text, decimals ?? 0, numberLocale)
-      setInputValue(formatted)
+      const [input, quantity] = Quantities.parseFromText(text, decimals ?? 0, numberLocale)
+      setInputValue(input)
       buyAmountChanged({tokenId, quantity})
       recalculateSellValue(quantity)
     } catch (error) {

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditBuyAmount/EditBuyAmount.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditBuyAmount/EditBuyAmount.tsx
@@ -39,7 +39,7 @@ export const EditBuyAmount = () => {
 
   const onChangeQuantity = (text: string) => {
     try {
-      const [formatted, inputQuantity] = Quantities.fromInput(text, decimals ?? 0, numberLocale)
+      const [formatted, inputQuantity] = Quantities.formatFromText(text, decimals ?? 0, numberLocale)
       const quantity = Quantities.integer(inputQuantity, decimals ?? 0)
       setInputValue(formatted)
       buyAmountChanged({tokenId, quantity})

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditBuyAmount/EditBuyAmount.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditBuyAmount/EditBuyAmount.tsx
@@ -39,8 +39,7 @@ export const EditBuyAmount = () => {
 
   const onChangeQuantity = (text: string) => {
     try {
-      const [formatted, inputQuantity] = Quantities.formatFromText(text, decimals ?? 0, numberLocale)
-      const quantity = Quantities.integer(inputQuantity, decimals ?? 0)
+      const [formatted, quantity] = Quantities.formatFromText(text, decimals ?? 0, numberLocale)
       setInputValue(formatted)
       buyAmountChanged({tokenId, quantity})
       recalculateSellValue(quantity)

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditSellAmount/EditSellAmount.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditSellAmount/EditSellAmount.tsx
@@ -1,10 +1,11 @@
 import {getReceiveAmountbyChangingSell, useSwap} from '@yoroi/swap'
 import * as React from 'react'
 
+import {useLanguage} from '../../../../../../i18n'
 import {useSelectedWallet} from '../../../../../../SelectedWallet'
 import {useBalance, useTokenInfo} from '../../../../../../yoroi-wallets/hooks'
 import {Logger} from '../../../../../../yoroi-wallets/logging'
-import {asQuantity, Quantities} from '../../../../../../yoroi-wallets/utils'
+import {Quantities} from '../../../../../../yoroi-wallets/utils'
 import {AmountCard} from '../../../../common/AmountCard/AmountCard'
 import {useNavigateTo} from '../../../../common/navigation'
 import {useStrings} from '../../../../common/strings'
@@ -14,6 +15,7 @@ export const EditSellAmount = () => {
   const strings = useStrings()
   const navigate = useNavigateTo()
   const wallet = useSelectedWallet()
+  const {numberLocale} = useLanguage()
 
   const {createOrder, sellAmountChanged, buyAmountChanged} = useSwap()
   const {isSellTouched} = useSwapTouched()
@@ -42,14 +44,13 @@ export const EditSellAmount = () => {
   }
 
   React.useEffect(() => {
-    setInputValue(Quantities.denominated(quantity, tokenInfo.decimals ?? 0))
+    setInputValue(Quantities.format(Quantities.denominated(quantity, tokenInfo.decimals ?? 0)))
   }, [quantity, tokenInfo.decimals])
 
   const onChangeQuantity = (text: string) => {
     try {
-      setInputValue(text)
-
-      const inputQuantity = asQuantity(text.length > 0 ? text : '0')
+      const inputQuantity = Quantities.fromInput(text, decimals ?? 0, numberLocale)
+      setInputValue(inputQuantity)
       const quantity = Quantities.integer(inputQuantity, decimals ?? 0)
       sellAmountChanged({tokenId, quantity})
       recalculateBuyValue(quantity)

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditSellAmount/EditSellAmount.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditSellAmount/EditSellAmount.tsx
@@ -45,8 +45,7 @@ export const EditSellAmount = () => {
 
   const onChangeQuantity = (text: string) => {
     try {
-      const [formatted, inputQuantity] = Quantities.formatFromText(text, decimals ?? 0, numberLocale)
-      const quantity = Quantities.integer(inputQuantity, decimals ?? 0)
+      const [formatted, quantity] = Quantities.formatFromText(text, decimals ?? 0, numberLocale)
       setInputValue(formatted)
       sellAmountChanged({tokenId, quantity})
       recalculateBuyValue(quantity)

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditSellAmount/EditSellAmount.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditSellAmount/EditSellAmount.tsx
@@ -45,8 +45,8 @@ export const EditSellAmount = () => {
 
   const onChangeQuantity = (text: string) => {
     try {
-      const [formatted, quantity] = Quantities.formatFromText(text, decimals ?? 0, numberLocale)
-      setInputValue(formatted)
+      const [input, quantity] = Quantities.parseFromText(text, decimals ?? 0, numberLocale)
+      setInputValue(input)
       sellAmountChanged({tokenId, quantity})
       recalculateBuyValue(quantity)
     } catch (error) {

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditSellAmount/EditSellAmount.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditSellAmount/EditSellAmount.tsx
@@ -43,15 +43,11 @@ export const EditSellAmount = () => {
     })
   }
 
-  React.useEffect(() => {
-    setInputValue(Quantities.format(Quantities.denominated(quantity, tokenInfo.decimals ?? 0)))
-  }, [quantity, tokenInfo.decimals])
-
   const onChangeQuantity = (text: string) => {
     try {
-      const inputQuantity = Quantities.fromInput(text, decimals ?? 0, numberLocale)
-      setInputValue(inputQuantity)
+      const [formatted, inputQuantity] = Quantities.fromInput(text, decimals ?? 0, numberLocale)
       const quantity = Quantities.integer(inputQuantity, decimals ?? 0)
+      setInputValue(formatted)
       sellAmountChanged({tokenId, quantity})
       recalculateBuyValue(quantity)
     } catch (error) {

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditSellAmount/EditSellAmount.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditSellAmount/EditSellAmount.tsx
@@ -45,7 +45,7 @@ export const EditSellAmount = () => {
 
   const onChangeQuantity = (text: string) => {
     try {
-      const [formatted, inputQuantity] = Quantities.fromInput(text, decimals ?? 0, numberLocale)
+      const [formatted, inputQuantity] = Quantities.formatFromText(text, decimals ?? 0, numberLocale)
       const quantity = Quantities.integer(inputQuantity, decimals ?? 0)
       setInputValue(formatted)
       sellAmountChanged({tokenId, quantity})

--- a/apps/wallet-mobile/src/i18n/LanguageProvider.tsx
+++ b/apps/wallet-mobile/src/i18n/LanguageProvider.tsx
@@ -13,7 +13,7 @@ import {
   UseQueryOptions,
 } from 'react-query'
 
-import {LanguageCode, supportedLanguages, updateLanguageSettings} from './languages'
+import {LanguageCode, NumberLocale, numberLocales, supportedLanguages, updateLanguageSettings} from './languages'
 import translations from './translations'
 
 const LanguageContext = React.createContext<undefined | LanguageContext>(undefined)
@@ -28,7 +28,15 @@ export const LanguageProvider = ({children}: {children: React.ReactNode}) => {
   )
 
   return (
-    <LanguageContext.Provider value={{languageCode, selectLanguageCode, supportedLanguages, observer}}>
+    <LanguageContext.Provider
+      value={{
+        numberLocale: numberLocales[languageCode],
+        languageCode,
+        selectLanguageCode,
+        supportedLanguages,
+        observer,
+      }}
+    >
       <IntlProvider
         timeZone={timeZone}
         locale={languageCode}
@@ -118,6 +126,7 @@ const useSaveLanguageCode = ({onSuccess, ...options}: UseMutationOptions<void, E
 type SaveLanguageCode = ReturnType<typeof useSaveLanguageCode>
 type SupportedLanguages = typeof supportedLanguages
 type LanguageContext = {
+  numberLocale: NumberLocale
   languageCode: LanguageCode
   selectLanguageCode: SaveLanguageCode
   supportedLanguages: SupportedLanguages

--- a/apps/wallet-mobile/src/i18n/languages.ts
+++ b/apps/wallet-mobile/src/i18n/languages.ts
@@ -126,7 +126,18 @@ moment.updateLocale('en', {
   },
 })
 
-const defaultNumberFmt = {
+export type NumberLocale = {
+  prefix: string
+  decimalSeparator: string
+  groupSeparator: string
+  groupSize: number
+  secondaryGroupSize: number
+  fractionGroupSize: number
+  fractionGroupSeparator: string
+  suffix: string
+}
+
+const defaultNumberFmt: NumberLocale = {
   prefix: '',
   decimalSeparator: '.',
   groupSeparator: ',',
@@ -154,7 +165,7 @@ const spanishNumberFmt = {
   groupSeparator: '.',
 }
 
-const numberLocales = {
+export const numberLocales = {
   [LANGUAGES.BENGALI]: defaultCommaDecimalSeparatorFmt,
   [LANGUAGES.BRAZILIAN]: defaultCommaDecimalSeparatorFmt,
   [LANGUAGES.CHINESE_SIMPLIFIED]: defaultNumberFmt,

--- a/apps/wallet-mobile/src/yoroi-wallets/utils/utils.test.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/utils/utils.test.ts
@@ -85,7 +85,7 @@ describe('Quantities', () => {
     expect(Quantities.max('1', '1')).toEqual('1')
   })
   it('fromInput', () => {
-    const en = {
+    const english = {
       prefix: '',
       decimalSeparator: '.',
       groupSeparator: ',',
@@ -96,11 +96,35 @@ describe('Quantities', () => {
       suffix: '',
     }
 
-    expect(Quantities.fromInput('', 3, en)).toBe('0')
-    expect(Quantities.fromInput('1', 3, en)).toBe('1')
-    expect(Quantities.fromInput('123.55', 3, en)).toBe('123.55')
-    expect(Quantities.fromInput('1234.6666', 3, en)).toBe('1234.666')
-    expect(Quantities.fromInput('55.', 3, en)).toBe('55.')
+    const italian = {
+      ...english,
+      decimalSeparator: ',',
+      groupSeparator: ' ',
+    }
+
+    BigNumber.config({
+      FORMAT: italian,
+    })
+
+    expect(Quantities.fromInput('', 3, italian)).toEqual(['0', '0'])
+    expect(Quantities.fromInput('1', 3, italian)).toEqual(['1', '1'])
+    expect(Quantities.fromInput('123,55', 3, italian)).toEqual(['123,55', '123.55'])
+    expect(Quantities.fromInput('1234,6666', 3, italian)).toEqual(['1 234,666', '1234.666'])
+    expect(Quantities.fromInput('55,', 3, italian)).toEqual(['55,', '55'])
+
+    expect(Quantities.fromInput('ab1.5c,6.5', 3, italian)).toEqual(['15,65', '15.65'])
+
+    BigNumber.config({
+      FORMAT: english,
+    })
+
+    expect(Quantities.fromInput('', 3, english)).toEqual(['0', '0'])
+    expect(Quantities.fromInput('1', 3, english)).toEqual(['1', '1'])
+    expect(Quantities.fromInput('123.55', 3, english)).toEqual(['123.55', '123.55'])
+    expect(Quantities.fromInput('1234.6666', 3, english)).toEqual(['1,234.666', '1234.666'])
+    expect(Quantities.fromInput('55.', 3, english)).toEqual(['55.', '55'])
+
+    expect(Quantities.fromInput('ab1.5c,6.5', 3, english)).toEqual(['1.56', '1.56'])
   })
 })
 

--- a/apps/wallet-mobile/src/yoroi-wallets/utils/utils.test.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/utils/utils.test.ts
@@ -107,24 +107,24 @@ describe('Quantities', () => {
     })
 
     expect(Quantities.formatFromText('', 3, italian)).toEqual(['0', '0'])
-    expect(Quantities.formatFromText('1', 3, italian)).toEqual(['1', '1'])
-    expect(Quantities.formatFromText('123,55', 3, italian)).toEqual(['123,55', '123.55'])
-    expect(Quantities.formatFromText('1234,6666', 3, italian)).toEqual(['1 234,666', '1234.666'])
-    expect(Quantities.formatFromText('55,', 3, italian)).toEqual(['55,', '55'])
+    expect(Quantities.formatFromText('1', 3, italian)).toEqual(['1', '1000'])
+    expect(Quantities.formatFromText('123,55', 3, italian)).toEqual(['123,55', '123550'])
+    expect(Quantities.formatFromText('1234,6666', 3, italian)).toEqual(['1 234,666', '1234666'])
+    expect(Quantities.formatFromText('55,', 3, italian)).toEqual(['55,', '55000'])
 
-    expect(Quantities.formatFromText('ab1.5c,6.5', 3, italian)).toEqual(['15,65', '15.65'])
+    expect(Quantities.formatFromText('ab1.5c,6.5', 3, italian)).toEqual(['15,65', '15650'])
 
     BigNumber.config({
       FORMAT: english,
     })
 
     expect(Quantities.formatFromText('', 3, english)).toEqual(['0', '0'])
-    expect(Quantities.formatFromText('1', 3, english)).toEqual(['1', '1'])
-    expect(Quantities.formatFromText('123.55', 3, english)).toEqual(['123.55', '123.55'])
-    expect(Quantities.formatFromText('1234.6666', 3, english)).toEqual(['1,234.666', '1234.666'])
-    expect(Quantities.formatFromText('55.', 3, english)).toEqual(['55.', '55'])
+    expect(Quantities.formatFromText('1', 3, english)).toEqual(['1', '1000'])
+    expect(Quantities.formatFromText('123.55', 3, english)).toEqual(['123.55', '123550'])
+    expect(Quantities.formatFromText('1234.6666', 3, english)).toEqual(['1,234.666', '1234666'])
+    expect(Quantities.formatFromText('55.', 3, english)).toEqual(['55.', '55000'])
 
-    expect(Quantities.formatFromText('ab1.5c,6.5', 3, english)).toEqual(['1.56', '1.56'])
+    expect(Quantities.formatFromText('ab1.5c,6.5', 3, english)).toEqual(['1.56', '1560'])
   })
 })
 

--- a/apps/wallet-mobile/src/yoroi-wallets/utils/utils.test.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/utils/utils.test.ts
@@ -84,6 +84,24 @@ describe('Quantities', () => {
     expect(Quantities.max('3', '2', '1')).toEqual('3')
     expect(Quantities.max('1', '1')).toEqual('1')
   })
+  it('fromInput', () => {
+    const en = {
+      prefix: '',
+      decimalSeparator: '.',
+      groupSeparator: ',',
+      groupSize: 3,
+      secondaryGroupSize: 0,
+      fractionGroupSize: 0,
+      fractionGroupSeparator: ' ',
+      suffix: '',
+    }
+
+    expect(Quantities.fromInput('', 3, en)).toBe('0')
+    expect(Quantities.fromInput('1', 3, en)).toBe('1')
+    expect(Quantities.fromInput('123.55', 3, en)).toBe('123.55')
+    expect(Quantities.fromInput('1234.6666', 3, en)).toBe('1234.666')
+    expect(Quantities.fromInput('55.', 3, en)).toBe('55.')
+  })
 })
 
 describe('Amounts', () => {

--- a/apps/wallet-mobile/src/yoroi-wallets/utils/utils.test.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/utils/utils.test.ts
@@ -84,7 +84,7 @@ describe('Quantities', () => {
     expect(Quantities.max('3', '2', '1')).toEqual('3')
     expect(Quantities.max('1', '1')).toEqual('1')
   })
-  it('fromInput', () => {
+  it('formatFromText', () => {
     const english = {
       prefix: '',
       decimalSeparator: '.',
@@ -106,25 +106,25 @@ describe('Quantities', () => {
       FORMAT: italian,
     })
 
-    expect(Quantities.fromInput('', 3, italian)).toEqual(['0', '0'])
-    expect(Quantities.fromInput('1', 3, italian)).toEqual(['1', '1'])
-    expect(Quantities.fromInput('123,55', 3, italian)).toEqual(['123,55', '123.55'])
-    expect(Quantities.fromInput('1234,6666', 3, italian)).toEqual(['1 234,666', '1234.666'])
-    expect(Quantities.fromInput('55,', 3, italian)).toEqual(['55,', '55'])
+    expect(Quantities.formatFromText('', 3, italian)).toEqual(['0', '0'])
+    expect(Quantities.formatFromText('1', 3, italian)).toEqual(['1', '1'])
+    expect(Quantities.formatFromText('123,55', 3, italian)).toEqual(['123,55', '123.55'])
+    expect(Quantities.formatFromText('1234,6666', 3, italian)).toEqual(['1 234,666', '1234.666'])
+    expect(Quantities.formatFromText('55,', 3, italian)).toEqual(['55,', '55'])
 
-    expect(Quantities.fromInput('ab1.5c,6.5', 3, italian)).toEqual(['15,65', '15.65'])
+    expect(Quantities.formatFromText('ab1.5c,6.5', 3, italian)).toEqual(['15,65', '15.65'])
 
     BigNumber.config({
       FORMAT: english,
     })
 
-    expect(Quantities.fromInput('', 3, english)).toEqual(['0', '0'])
-    expect(Quantities.fromInput('1', 3, english)).toEqual(['1', '1'])
-    expect(Quantities.fromInput('123.55', 3, english)).toEqual(['123.55', '123.55'])
-    expect(Quantities.fromInput('1234.6666', 3, english)).toEqual(['1,234.666', '1234.666'])
-    expect(Quantities.fromInput('55.', 3, english)).toEqual(['55.', '55'])
+    expect(Quantities.formatFromText('', 3, english)).toEqual(['0', '0'])
+    expect(Quantities.formatFromText('1', 3, english)).toEqual(['1', '1'])
+    expect(Quantities.formatFromText('123.55', 3, english)).toEqual(['123.55', '123.55'])
+    expect(Quantities.formatFromText('1234.6666', 3, english)).toEqual(['1,234.666', '1234.666'])
+    expect(Quantities.formatFromText('55.', 3, english)).toEqual(['55.', '55'])
 
-    expect(Quantities.fromInput('ab1.5c,6.5', 3, english)).toEqual(['1.56', '1.56'])
+    expect(Quantities.formatFromText('ab1.5c,6.5', 3, english)).toEqual(['1.56', '1.56'])
   })
 })
 

--- a/apps/wallet-mobile/src/yoroi-wallets/utils/utils.test.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/utils/utils.test.ts
@@ -84,7 +84,7 @@ describe('Quantities', () => {
     expect(Quantities.max('3', '2', '1')).toEqual('3')
     expect(Quantities.max('1', '1')).toEqual('1')
   })
-  it('formatFromText', () => {
+  it('parseFromText', () => {
     const english = {
       prefix: '',
       decimalSeparator: '.',
@@ -106,25 +106,25 @@ describe('Quantities', () => {
       FORMAT: italian,
     })
 
-    expect(Quantities.formatFromText('', 3, italian)).toEqual(['0', '0'])
-    expect(Quantities.formatFromText('1', 3, italian)).toEqual(['1', '1000'])
-    expect(Quantities.formatFromText('123,55', 3, italian)).toEqual(['123,55', '123550'])
-    expect(Quantities.formatFromText('1234,6666', 3, italian)).toEqual(['1 234,666', '1234666'])
-    expect(Quantities.formatFromText('55,', 3, italian)).toEqual(['55,', '55000'])
+    expect(Quantities.parseFromText('', 3, italian)).toEqual(['0', '0'])
+    expect(Quantities.parseFromText('1', 3, italian)).toEqual(['1', '1000'])
+    expect(Quantities.parseFromText('123,55', 3, italian)).toEqual(['123,55', '123550'])
+    expect(Quantities.parseFromText('1234,6666', 3, italian)).toEqual(['1 234,666', '1234666'])
+    expect(Quantities.parseFromText('55,', 3, italian)).toEqual(['55,', '55000'])
 
-    expect(Quantities.formatFromText('ab1.5c,6.5', 3, italian)).toEqual(['15,65', '15650'])
+    expect(Quantities.parseFromText('ab1.5c,6.5', 3, italian)).toEqual(['15,65', '15650'])
 
     BigNumber.config({
       FORMAT: english,
     })
 
-    expect(Quantities.formatFromText('', 3, english)).toEqual(['0', '0'])
-    expect(Quantities.formatFromText('1', 3, english)).toEqual(['1', '1000'])
-    expect(Quantities.formatFromText('123.55', 3, english)).toEqual(['123.55', '123550'])
-    expect(Quantities.formatFromText('1234.6666', 3, english)).toEqual(['1,234.666', '1234666'])
-    expect(Quantities.formatFromText('55.', 3, english)).toEqual(['55.', '55000'])
+    expect(Quantities.parseFromText('', 3, english)).toEqual(['0', '0'])
+    expect(Quantities.parseFromText('1', 3, english)).toEqual(['1', '1000'])
+    expect(Quantities.parseFromText('123.55', 3, english)).toEqual(['123.55', '123550'])
+    expect(Quantities.parseFromText('1234.6666', 3, english)).toEqual(['1,234.666', '1234666'])
+    expect(Quantities.parseFromText('55.', 3, english)).toEqual(['55.', '55000'])
 
-    expect(Quantities.formatFromText('ab1.5c,6.5', 3, english)).toEqual(['1.56', '1560'])
+    expect(Quantities.parseFromText('ab1.5c,6.5', 3, english)).toEqual(['1.56', '1560'])
   })
 })
 

--- a/apps/wallet-mobile/src/yoroi-wallets/utils/utils.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/utils/utils.ts
@@ -131,7 +131,7 @@ export const Quantities = {
 
     return absoluteQuantity.isEqualTo(minimalFractionalPart)
   },
-  fromInput: (input: string, precision: number, format: NumberLocale) => {
+  formatFromText: (input: string, precision: number, format: NumberLocale) => {
     const {decimalSeparator} = format
     const invalid = new RegExp(`[^0-9${decimalSeparator}]`, 'g')
     const sanitized = input === '' ? '0' : input.replaceAll(invalid, '')

--- a/apps/wallet-mobile/src/yoroi-wallets/utils/utils.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/utils/utils.ts
@@ -1,5 +1,6 @@
 import {Balance} from '@yoroi/types'
 import BigNumber from 'bignumber.js'
+import {NumberLocale} from 'src/i18n/languages'
 
 import {RawUtxo, TokenId, YoroiEntries, YoroiEntry} from '../types'
 
@@ -130,6 +131,19 @@ export const Quantities = {
 
     return absoluteQuantity.isEqualTo(minimalFractionalPart)
   },
+  fromInput: (quantity: Balance.Quantity | string, precision: number, format: NumberLocale) => {
+    const {decimalSeparator} = format
+    const invalid = new RegExp(`[^0-9${decimalSeparator}]`, 'g')
+    const ungrouped = quantity === '' ? '0' : quantity.replaceAll(invalid, '')
+    const parts = ungrouped.split(decimalSeparator)
+
+    const valid = parts.length > 2 ? `${parts[0]}${decimalSeparator}${parts[1]}` : ungrouped
+
+    if (valid.slice(-1) === decimalSeparator) return valid as Balance.Quantity
+
+    return new BigNumber(valid).decimalPlaces(precision, BigNumber.ROUND_DOWN).toString(10) as Balance.Quantity
+  },
+  format: (quantity: Balance.Quantity) => new BigNumber(quantity).toFormat(),
 }
 
 export const asQuantity = (value: BigNumber | number | string) => {

--- a/apps/wallet-mobile/src/yoroi-wallets/utils/utils.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/utils/utils.ts
@@ -1,7 +1,7 @@
 import {Balance} from '@yoroi/types'
 import BigNumber from 'bignumber.js'
-import {NumberLocale} from 'src/i18n/languages'
 
+import {NumberLocale} from '../../i18n/languages'
 import {RawUtxo, TokenId, YoroiEntries, YoroiEntry} from '../types'
 
 export const Entries = {

--- a/apps/wallet-mobile/src/yoroi-wallets/utils/utils.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/utils/utils.ts
@@ -141,9 +141,11 @@ export const Quantities = {
 
     const trailing = valid.slice(-1) === decimalSeparator
 
-    const quantity = new BigNumber(valid.replace(format.decimalSeparator, '.')).toString(10)
+    const value = new BigNumber(valid.replace(format.decimalSeparator, '.'))
 
-    const formatted = `${new BigNumber(quantity).toFormat()}${trailing ? decimalSeparator : ''}`
+    const formatted = `${new BigNumber(value).toFormat()}${trailing ? decimalSeparator : ''}`
+
+    const quantity = new BigNumber(value).decimalPlaces(precision).shiftedBy(precision).toString(10)
 
     return [formatted, quantity] as [string, Balance.Quantity]
   },

--- a/apps/wallet-mobile/src/yoroi-wallets/utils/utils.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/utils/utils.ts
@@ -131,7 +131,7 @@ export const Quantities = {
 
     return absoluteQuantity.isEqualTo(minimalFractionalPart)
   },
-  fromInput: (quantity: Balance.Quantity | string, precision: number, format: NumberLocale) => {
+  fromInput: (quantity: string, precision: number, format: NumberLocale) => {
     const {decimalSeparator} = format
     const invalid = new RegExp(`[^0-9${decimalSeparator}]`, 'g')
     const ungrouped = quantity === '' ? '0' : quantity.replaceAll(invalid, '')

--- a/apps/wallet-mobile/src/yoroi-wallets/utils/utils.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/utils/utils.ts
@@ -131,10 +131,10 @@ export const Quantities = {
 
     return absoluteQuantity.isEqualTo(minimalFractionalPart)
   },
-  formatFromText: (input: string, precision: number, format: NumberLocale) => {
+  parseFromText: (text: string, precision: number, format: NumberLocale) => {
     const {decimalSeparator} = format
     const invalid = new RegExp(`[^0-9${decimalSeparator}]`, 'g')
-    const sanitized = input === '' ? '0' : input.replaceAll(invalid, '')
+    const sanitized = text === '' ? '0' : text.replaceAll(invalid, '')
     const parts = sanitized.split(decimalSeparator)
 
     const valid = parts.length >= 2 ? `${parts[0]}${decimalSeparator}${parts[1].slice(0, precision)}` : sanitized
@@ -143,11 +143,11 @@ export const Quantities = {
 
     const value = new BigNumber(valid.replace(format.decimalSeparator, '.'))
 
-    const formatted = `${new BigNumber(value).toFormat()}${trailing ? decimalSeparator : ''}`
+    const input = `${new BigNumber(value).toFormat()}${trailing ? decimalSeparator : ''}`
 
     const quantity = new BigNumber(value).decimalPlaces(precision).shiftedBy(precision).toString(10)
 
-    return [formatted, quantity] as [string, Balance.Quantity]
+    return [input, quantity] as [string, Balance.Quantity]
   },
 }
 

--- a/apps/wallet-mobile/translations/messages/src/features/Swap/common/strings.json
+++ b/apps/wallet-mobile/translations/messages/src/features/Swap/common/strings.json
@@ -4,14 +4,14 @@
     "defaultMessage": "!!!Swap",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 61,
+      "line": 68,
       "column": 13,
-      "index": 3243
+      "index": 3590
     },
     "end": {
-      "line": 64,
+      "line": 71,
       "column": 3,
-      "index": 3316
+      "index": 3663
     }
   },
   {
@@ -19,14 +19,14 @@
     "defaultMessage": "!!!Token swap",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 65,
+      "line": 72,
       "column": 13,
-      "index": 3331
+      "index": 3678
     },
     "end": {
-      "line": 68,
+      "line": 75,
       "column": 3,
-      "index": 3413
+      "index": 3760
     }
   },
   {
@@ -34,14 +34,14 @@
     "defaultMessage": "!!!Orders",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 69,
+      "line": 76,
       "column": 13,
-      "index": 3428
+      "index": 3775
     },
     "end": {
-      "line": 72,
+      "line": 79,
       "column": 3,
-      "index": 3507
+      "index": 3854
     }
   },
   {
@@ -49,14 +49,14 @@
     "defaultMessage": "!!!Market Button",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 73,
+      "line": 80,
       "column": 16,
-      "index": 3525
+      "index": 3872
     },
     "end": {
-      "line": 76,
+      "line": 83,
       "column": 3,
-      "index": 3610
+      "index": 3957
     }
   },
   {
@@ -64,14 +64,14 @@
     "defaultMessage": "!!!Limit",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 77,
+      "line": 84,
       "column": 15,
-      "index": 3627
+      "index": 3974
     },
     "end": {
-      "line": 80,
+      "line": 87,
       "column": 3,
-      "index": 3703
+      "index": 4050
     }
   },
   {
@@ -79,14 +79,14 @@
     "defaultMessage": "!!!Swap from",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 81,
+      "line": 88,
       "column": 12,
-      "index": 3717
+      "index": 4064
     },
     "end": {
-      "line": 84,
+      "line": 91,
       "column": 3,
-      "index": 3794
+      "index": 4141
     }
   },
   {
@@ -94,14 +94,14 @@
     "defaultMessage": "!!!Swap to",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 85,
+      "line": 92,
       "column": 10,
-      "index": 3806
+      "index": 4153
     },
     "end": {
-      "line": 88,
+      "line": 95,
       "column": 3,
-      "index": 3879
+      "index": 4226
     }
   },
   {
@@ -109,14 +109,14 @@
     "defaultMessage": "!!!Current Balance",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 89,
+      "line": 96,
       "column": 18,
-      "index": 3899
+      "index": 4246
     },
     "end": {
-      "line": 92,
+      "line": 99,
       "column": 3,
-      "index": 3988
+      "index": 4335
     }
   },
   {
@@ -124,14 +124,14 @@
     "defaultMessage": "!!!Select Token",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 93,
+      "line": 100,
       "column": 15,
-      "index": 4005
+      "index": 4352
     },
     "end": {
-      "line": 96,
+      "line": 103,
       "column": 3,
-      "index": 4088
+      "index": 4435
     }
   },
   {
@@ -139,14 +139,14 @@
     "defaultMessage": "!!!Market Price",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 97,
+      "line": 104,
       "column": 15,
-      "index": 4105
+      "index": 4452
     },
     "end": {
-      "line": 100,
+      "line": 107,
       "column": 3,
-      "index": 4188
+      "index": 4535
     }
   },
   {
@@ -154,14 +154,14 @@
     "defaultMessage": "!!!Limit Price",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 101,
+      "line": 108,
       "column": 14,
-      "index": 4204
+      "index": 4551
     },
     "end": {
-      "line": 104,
+      "line": 111,
       "column": 3,
-      "index": 4285
+      "index": 4632
     }
   },
   {
@@ -169,14 +169,14 @@
     "defaultMessage": "!!!Slippage Tolerance",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 105,
+      "line": 112,
       "column": 21,
-      "index": 4308
+      "index": 4655
     },
     "end": {
-      "line": 108,
+      "line": 115,
       "column": 3,
-      "index": 4403
+      "index": 4750
     }
   },
   {
@@ -184,14 +184,14 @@
     "defaultMessage": "!!!Slippage Tolerance Info",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 109,
+      "line": 116,
       "column": 25,
-      "index": 4430
+      "index": 4777
     },
     "end": {
-      "line": 112,
+      "line": 119,
       "column": 3,
-      "index": 4534
+      "index": 4881
     }
   },
   {
@@ -199,14 +199,14 @@
     "defaultMessage": "!!!Verified by {pool}",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 113,
+      "line": 120,
       "column": 14,
-      "index": 4550
+      "index": 4897
     },
     "end": {
-      "line": 116,
+      "line": 123,
       "column": 3,
-      "index": 4638
+      "index": 4985
     }
   },
   {
@@ -214,14 +214,14 @@
     "defaultMessage": "!!!This assets is in my portfolio",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 117,
+      "line": 124,
       "column": 12,
-      "index": 4652
+      "index": 4999
     },
     "end": {
-      "line": 120,
+      "line": 127,
       "column": 3,
-      "index": 4750
+      "index": 5097
     }
   },
   {
@@ -229,14 +229,14 @@
     "defaultMessage": "!!!Default Slippage Tolerance",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 121,
+      "line": 128,
       "column": 19,
-      "index": 4771
+      "index": 5118
     },
     "end": {
-      "line": 124,
+      "line": 131,
       "column": 3,
-      "index": 4872
+      "index": 5219
     }
   },
   {
@@ -244,14 +244,14 @@
     "defaultMessage": "!!!Slippage tolerance is set as a percentage of the total swap value.",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 125,
+      "line": 132,
       "column": 16,
-      "index": 4890
+      "index": 5237
     },
     "end": {
-      "line": 128,
+      "line": 135,
       "column": 3,
-      "index": 5028
+      "index": 5375
     }
   },
   {
@@ -259,14 +259,14 @@
     "defaultMessage": "!!!Min-ADA is the minimum ADA amount required to be contained when holding or sending Cardano native tokens.",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 129,
+      "line": 136,
       "column": 14,
-      "index": 5044
+      "index": 5391
     },
     "end": {
-      "line": 133,
+      "line": 140,
       "column": 3,
-      "index": 5225
+      "index": 5572
     }
   },
   {
@@ -274,14 +274,14 @@
     "defaultMessage": "!!!Min ADA",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 134,
+      "line": 141,
       "column": 19,
-      "index": 5246
+      "index": 5593
     },
     "end": {
-      "line": 146,
+      "line": 144,
       "column": 3,
-      "index": 5328
+      "index": 5675
     }
   },
   {
@@ -289,14 +289,14 @@
     "defaultMessage": "!!!Swap fees include the following:\n • Matchmaker Fee\n • Frontend Fee\n • Liquidity Provider Fee",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 138,
+      "line": 145,
       "column": 12,
-      "index": 5342
+      "index": 5689
     },
     "end": {
-      "line": 141,
+      "line": 148,
       "column": 3,
-      "index": 5505
+      "index": 5852
     }
   },
   {
@@ -304,14 +304,14 @@
     "defaultMessage": "!!!Fee",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 142,
+      "line": 149,
       "column": 17,
-      "index": 5524
+      "index": 5871
     },
     "end": {
-      "line": 145,
+      "line": 152,
       "column": 3,
-      "index": 5600
+      "index": 5947
     }
   },
   {
@@ -319,14 +319,14 @@
     "defaultMessage": "!!!Minimum amount of tokens you can get because of the slippage tolerance.",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 146,
+      "line": 153,
       "column": 19,
-      "index": 5621
+      "index": 5968
     },
     "end": {
-      "line": 149,
+      "line": 156,
       "column": 3,
-      "index": 5767
+      "index": 6114
     }
   },
   {
@@ -334,14 +334,14 @@
     "defaultMessage": "!!!Min Received",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 150,
+      "line": 157,
       "column": 24,
-      "index": 5793
+      "index": 6140
     },
     "end": {
-      "line": 153,
+      "line": 160,
       "column": 3,
-      "index": 5885
+      "index": 6232
     }
   },
   {
@@ -349,14 +349,14 @@
     "defaultMessage": "!!!Enter a value from 0% to 100%. You can also enter up to 1 decimal",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 154,
+      "line": 161,
       "column": 17,
-      "index": 5904
+      "index": 6251
     },
     "end": {
-      "line": 157,
+      "line": 164,
       "column": 3,
-      "index": 6042
+      "index": 6389
     }
   },
   {
@@ -364,14 +364,29 @@
     "defaultMessage": "!!!{pool} verification",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 158,
+      "line": 165,
       "column": 20,
-      "index": 6064
+      "index": 6411
     },
     "end": {
-      "line": 161,
+      "line": 168,
       "column": 3,
-      "index": 6159
+      "index": 6506
+    }
+  },
+  {
+    "id": "swap.swapScreen.volume",
+    "defaultMessage": "!!!Volume, 24h",
+    "file": "src/features/Swap/common/strings.ts",
+    "start": {
+      "line": 169,
+      "column": 10,
+      "index": 6518
+    },
+    "end": {
+      "line": 172,
+      "column": 3,
+      "index": 6595
     }
   },
   {
@@ -379,14 +394,29 @@
     "defaultMessage": "!!!Cardano projects that list their own tokens can apply for an additional {pool} verification. This verification is a manual validation that {pool} team performs with the help of Cardano Foundation.",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 162,
+      "line": 173,
       "column": 24,
-      "index": 6185
+      "index": 6621
     },
     "end": {
-      "line": 166,
+      "line": 177,
       "column": 3,
-      "index": 6467
+      "index": 6903
+    }
+  },
+  {
+    "id": "global,price",
+    "defaultMessage": "!!! Price",
+    "file": "src/features/Swap/common/strings.ts",
+    "start": {
+      "line": 178,
+      "column": 9,
+      "index": 6914
+    },
+    "end": {
+      "line": 181,
+      "column": 3,
+      "index": 6976
     }
   },
   {
@@ -394,14 +424,14 @@
     "defaultMessage": "!!!No assets found for this pair",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 167,
+      "line": 182,
       "column": 17,
-      "index": 6486
+      "index": 6995
     },
     "end": {
-      "line": 170,
+      "line": 185,
       "column": 3,
-      "index": 6588
+      "index": 7097
     }
   },
   {
@@ -409,14 +439,14 @@
     "defaultMessage": "!!!Each verified tokens gets",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 171,
+      "line": 186,
       "column": 21,
-      "index": 6611
+      "index": 7120
     },
     "end": {
-      "line": 174,
+      "line": 189,
       "column": 3,
-      "index": 6713
+      "index": 7222
     }
   },
   {
@@ -424,14 +454,14 @@
     "defaultMessage": "!!!verified badge",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 175,
+      "line": 190,
       "column": 17,
-      "index": 6732
+      "index": 7241
     },
     "end": {
-      "line": 178,
+      "line": 193,
       "column": 3,
-      "index": 6819
+      "index": 7328
     }
   },
   {
@@ -439,14 +469,14 @@
     "defaultMessage": "!!!Open orders",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 179,
+      "line": 194,
       "column": 14,
-      "index": 6835
+      "index": 7344
     },
     "end": {
-      "line": 182,
+      "line": 197,
       "column": 3,
-      "index": 6916
+      "index": 7425
     }
   },
   {
@@ -454,14 +484,59 @@
     "defaultMessage": "!!!Completed orders",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 183,
+      "line": 198,
       "column": 19,
-      "index": 6937
+      "index": 7446
     },
     "end": {
-      "line": 186,
+      "line": 201,
       "column": 3,
-      "index": 7028
+      "index": 7537
+    }
+  },
+  {
+    "id": "swap.swapScreen.tvl",
+    "defaultMessage": "!!!TVL",
+    "file": "src/features/Swap/common/strings.ts",
+    "start": {
+      "line": 202,
+      "column": 7,
+      "index": 7546
+    },
+    "end": {
+      "line": 205,
+      "column": 3,
+      "index": 7612
+    }
+  },
+  {
+    "id": "swap.swapScreen.poolFee",
+    "defaultMessage": "!!! Pool Fee",
+    "file": "src/features/Swap/common/strings.ts",
+    "start": {
+      "line": 206,
+      "column": 11,
+      "index": 7625
+    },
+    "end": {
+      "line": 209,
+      "column": 3,
+      "index": 7701
+    }
+  },
+  {
+    "id": "swap.swapScreen.batcherFee",
+    "defaultMessage": "!!! Batcher Fee",
+    "file": "src/features/Swap/common/strings.ts",
+    "start": {
+      "line": 210,
+      "column": 14,
+      "index": 7717
+    },
+    "end": {
+      "line": 213,
+      "column": 3,
+      "index": 7799
     }
   },
   {
@@ -469,14 +544,14 @@
     "defaultMessage": "!!!Asset",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 187,
+      "line": 214,
       "column": 9,
-      "index": 7039
+      "index": 7810
     },
     "end": {
-      "line": 190,
+      "line": 217,
       "column": 3,
-      "index": 7112
+      "index": 7883
     }
   },
   {
@@ -484,14 +559,14 @@
     "defaultMessage": "!!!Clear",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 191,
+      "line": 218,
       "column": 9,
-      "index": 7123
+      "index": 7894
     },
     "end": {
-      "line": 194,
+      "line": 221,
       "column": 3,
-      "index": 7184
+      "index": 7955
     }
   },
   {
@@ -499,14 +574,14 @@
     "defaultMessage": "!!!Sign transaction",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 195,
+      "line": 222,
       "column": 19,
-      "index": 7205
+      "index": 7976
     },
     "end": {
-      "line": 198,
+      "line": 225,
       "column": 3,
-      "index": 7287
+      "index": 8058
     }
   },
   {
@@ -514,14 +589,14 @@
     "defaultMessage": "!!!Spending Password",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 199,
+      "line": 226,
       "column": 20,
-      "index": 7309
+      "index": 8080
     },
     "end": {
-      "line": 202,
+      "line": 229,
       "column": 3,
-      "index": 7393
+      "index": 8164
     }
   },
   {
@@ -529,14 +604,14 @@
     "defaultMessage": "!!!Enter spending password to sign this transaction",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 203,
+      "line": 230,
       "column": 25,
-      "index": 7420
+      "index": 8191
     },
     "end": {
-      "line": 206,
+      "line": 233,
       "column": 3,
-      "index": 7540
+      "index": 8311
     }
   },
   {
@@ -544,14 +619,14 @@
     "defaultMessage": "!!!Sign",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 207,
+      "line": 234,
       "column": 8,
-      "index": 7550
+      "index": 8321
     },
     "end": {
-      "line": 210,
+      "line": 237,
       "column": 3,
-      "index": 7609
+      "index": 8380
     }
   },
   {
@@ -559,14 +634,14 @@
     "defaultMessage": "!!!Swap",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 211,
+      "line": 238,
       "column": 14,
-      "index": 7625
+      "index": 8396
     },
     "end": {
-      "line": 214,
+      "line": 241,
       "column": 3,
-      "index": 7684
+      "index": 8455
     }
   },
   {
@@ -574,14 +649,14 @@
     "defaultMessage": "!!!You have",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 217,
+      "line": 244,
       "column": 11,
-      "index": 7743
+      "index": 8514
     },
     "end": {
-      "line": 220,
+      "line": 247,
       "column": 3,
-      "index": 7838
+      "index": 8609
     }
   },
   {
@@ -589,14 +664,14 @@
     "defaultMessage": "!!!No assets found",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 221,
+      "line": 248,
       "column": 12,
-      "index": 7852
+      "index": 8623
     },
     "end": {
-      "line": 224,
+      "line": 251,
       "column": 3,
-      "index": 7955
+      "index": 8726
     }
   },
   {
@@ -604,14 +679,14 @@
     "defaultMessage": "!!!found",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 225,
+      "line": 252,
       "column": 9,
-      "index": 7966
+      "index": 8737
     },
     "end": {
-      "line": 228,
+      "line": 255,
       "column": 3,
-      "index": 8056
+      "index": 8827
     }
   },
   {
@@ -619,14 +694,14 @@
     "defaultMessage": "!!!Search tokens",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 229,
+      "line": 256,
       "column": 16,
-      "index": 8074
+      "index": 8845
     },
     "end": {
-      "line": 232,
+      "line": 259,
       "column": 3,
-      "index": 8170
+      "index": 8941
     }
   },
   {
@@ -634,14 +709,14 @@
     "defaultMessage": "!!!Select asset",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 233,
+      "line": 260,
       "column": 20,
-      "index": 8192
+      "index": 8963
     },
     "end": {
-      "line": 236,
+      "line": 263,
       "column": 3,
-      "index": 8281
+      "index": 9052
     }
   },
   {
@@ -649,14 +724,14 @@
     "defaultMessage": "!!!Confirm",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 237,
+      "line": 264,
       "column": 11,
-      "index": 8294
+      "index": 9065
     },
     "end": {
-      "line": 240,
+      "line": 267,
       "column": 3,
-      "index": 8388
+      "index": 9159
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/features/Swap/common/strings.json
+++ b/apps/wallet-mobile/translations/messages/src/features/Swap/common/strings.json
@@ -4,14 +4,14 @@
     "defaultMessage": "!!!Swap",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 69,
+      "line": 61,
       "column": 13,
-      "index": 3641
+      "index": 3243
     },
     "end": {
-      "line": 72,
+      "line": 64,
       "column": 3,
-      "index": 3714
+      "index": 3316
     }
   },
   {
@@ -19,14 +19,14 @@
     "defaultMessage": "!!!Token swap",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 73,
+      "line": 65,
       "column": 13,
-      "index": 3729
+      "index": 3331
     },
     "end": {
-      "line": 76,
+      "line": 68,
       "column": 3,
-      "index": 3811
+      "index": 3413
     }
   },
   {
@@ -34,14 +34,14 @@
     "defaultMessage": "!!!Orders",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 77,
+      "line": 69,
       "column": 13,
-      "index": 3826
+      "index": 3428
     },
     "end": {
-      "line": 80,
+      "line": 72,
       "column": 3,
-      "index": 3905
+      "index": 3507
     }
   },
   {
@@ -49,14 +49,14 @@
     "defaultMessage": "!!!Market Button",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 81,
+      "line": 73,
       "column": 16,
-      "index": 3923
+      "index": 3525
     },
     "end": {
-      "line": 84,
+      "line": 76,
       "column": 3,
-      "index": 4008
+      "index": 3610
     }
   },
   {
@@ -64,14 +64,14 @@
     "defaultMessage": "!!!Limit",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 85,
+      "line": 77,
       "column": 15,
-      "index": 4025
+      "index": 3627
     },
     "end": {
-      "line": 88,
+      "line": 80,
       "column": 3,
-      "index": 4101
+      "index": 3703
     }
   },
   {
@@ -79,14 +79,14 @@
     "defaultMessage": "!!!Swap from",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 89,
+      "line": 81,
       "column": 12,
-      "index": 4115
+      "index": 3717
     },
     "end": {
-      "line": 92,
+      "line": 84,
       "column": 3,
-      "index": 4192
+      "index": 3794
     }
   },
   {
@@ -94,14 +94,14 @@
     "defaultMessage": "!!!Swap to",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 93,
+      "line": 85,
       "column": 10,
-      "index": 4204
+      "index": 3806
     },
     "end": {
-      "line": 96,
+      "line": 88,
       "column": 3,
-      "index": 4277
+      "index": 3879
     }
   },
   {
@@ -109,29 +109,14 @@
     "defaultMessage": "!!!Current Balance",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 97,
+      "line": 89,
       "column": 18,
-      "index": 4297
+      "index": 3899
     },
     "end": {
-      "line": 100,
+      "line": 92,
       "column": 3,
-      "index": 4386
-    }
-  },
-  {
-    "id": "swap.swapScreen.balance",
-    "defaultMessage": "!!!Balance",
-    "file": "src/features/Swap/common/strings.ts",
-    "start": {
-      "line": 101,
-      "column": 11,
-      "index": 4399
-    },
-    "end": {
-      "line": 104,
-      "column": 3,
-      "index": 4473
+      "index": 3988
     }
   },
   {
@@ -139,14 +124,14 @@
     "defaultMessage": "!!!Select Token",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 105,
+      "line": 93,
       "column": 15,
-      "index": 4490
+      "index": 4005
     },
     "end": {
-      "line": 108,
+      "line": 96,
       "column": 3,
-      "index": 4573
+      "index": 4088
     }
   },
   {
@@ -154,14 +139,14 @@
     "defaultMessage": "!!!Market Price",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 109,
+      "line": 97,
       "column": 15,
-      "index": 4590
+      "index": 4105
     },
     "end": {
-      "line": 112,
+      "line": 100,
       "column": 3,
-      "index": 4673
+      "index": 4188
     }
   },
   {
@@ -169,14 +154,14 @@
     "defaultMessage": "!!!Limit Price",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 113,
+      "line": 101,
       "column": 14,
-      "index": 4689
+      "index": 4204
     },
     "end": {
-      "line": 116,
+      "line": 104,
       "column": 3,
-      "index": 4770
+      "index": 4285
     }
   },
   {
@@ -184,14 +169,14 @@
     "defaultMessage": "!!!Slippage Tolerance",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 117,
+      "line": 105,
       "column": 21,
-      "index": 4793
+      "index": 4308
     },
     "end": {
-      "line": 120,
+      "line": 108,
       "column": 3,
-      "index": 4888
+      "index": 4403
     }
   },
   {
@@ -199,14 +184,14 @@
     "defaultMessage": "!!!Slippage Tolerance Info",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 121,
+      "line": 109,
       "column": 25,
-      "index": 4915
+      "index": 4430
     },
     "end": {
-      "line": 124,
+      "line": 112,
       "column": 3,
-      "index": 5019
+      "index": 4534
     }
   },
   {
@@ -214,14 +199,14 @@
     "defaultMessage": "!!!Verified by {pool}",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 125,
+      "line": 113,
       "column": 14,
-      "index": 5035
+      "index": 4550
     },
     "end": {
-      "line": 128,
+      "line": 116,
       "column": 3,
-      "index": 5123
+      "index": 4638
     }
   },
   {
@@ -229,14 +214,14 @@
     "defaultMessage": "!!!This assets is in my portfolio",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 129,
+      "line": 117,
       "column": 12,
-      "index": 5137
+      "index": 4652
     },
     "end": {
-      "line": 132,
+      "line": 120,
       "column": 3,
-      "index": 5235
+      "index": 4750
     }
   },
   {
@@ -244,14 +229,14 @@
     "defaultMessage": "!!!Default Slippage Tolerance",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 133,
+      "line": 121,
       "column": 19,
-      "index": 5256
+      "index": 4771
     },
     "end": {
-      "line": 136,
+      "line": 124,
       "column": 3,
-      "index": 5357
+      "index": 4872
     }
   },
   {
@@ -259,14 +244,14 @@
     "defaultMessage": "!!!Slippage tolerance is set as a percentage of the total swap value.",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 137,
+      "line": 125,
       "column": 16,
-      "index": 5375
+      "index": 4890
     },
     "end": {
-      "line": 140,
+      "line": 128,
       "column": 3,
-      "index": 5513
+      "index": 5028
     }
   },
   {
@@ -274,14 +259,14 @@
     "defaultMessage": "!!!Min-ADA is the minimum ADA amount required to be contained when holding or sending Cardano native tokens.",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 141,
+      "line": 129,
       "column": 14,
-      "index": 5529
+      "index": 5044
     },
     "end": {
-      "line": 145,
+      "line": 133,
       "column": 3,
-      "index": 5710
+      "index": 5225
     }
   },
   {
@@ -289,14 +274,14 @@
     "defaultMessage": "!!!Min ADA",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 146,
+      "line": 134,
       "column": 19,
-      "index": 5731
+      "index": 5246
     },
     "end": {
-      "line": 149,
+      "line": 146,
       "column": 3,
-      "index": 5813
+      "index": 5328
     }
   },
   {
@@ -304,14 +289,14 @@
     "defaultMessage": "!!!Swap fees include the following:\n • Matchmaker Fee\n • Frontend Fee\n • Liquidity Provider Fee",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 150,
+      "line": 138,
       "column": 12,
-      "index": 5827
+      "index": 5342
     },
     "end": {
-      "line": 153,
+      "line": 141,
       "column": 3,
-      "index": 5990
+      "index": 5505
     }
   },
   {
@@ -319,14 +304,14 @@
     "defaultMessage": "!!!Fee",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 154,
+      "line": 142,
       "column": 17,
-      "index": 6009
+      "index": 5524
     },
     "end": {
-      "line": 157,
+      "line": 145,
       "column": 3,
-      "index": 6085
+      "index": 5600
     }
   },
   {
@@ -334,14 +319,14 @@
     "defaultMessage": "!!!Minimum amount of tokens you can get because of the slippage tolerance.",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 158,
+      "line": 146,
       "column": 19,
-      "index": 6106
+      "index": 5621
     },
     "end": {
-      "line": 161,
+      "line": 149,
       "column": 3,
-      "index": 6252
+      "index": 5767
     }
   },
   {
@@ -349,14 +334,14 @@
     "defaultMessage": "!!!Min Received",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 162,
+      "line": 150,
       "column": 24,
-      "index": 6278
+      "index": 5793
     },
     "end": {
-      "line": 165,
+      "line": 153,
       "column": 3,
-      "index": 6370
+      "index": 5885
     }
   },
   {
@@ -364,14 +349,14 @@
     "defaultMessage": "!!!Enter a value from 0% to 100%. You can also enter up to 1 decimal",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 166,
+      "line": 154,
       "column": 17,
-      "index": 6389
+      "index": 5904
     },
     "end": {
-      "line": 169,
+      "line": 157,
       "column": 3,
-      "index": 6527
+      "index": 6042
     }
   },
   {
@@ -379,29 +364,14 @@
     "defaultMessage": "!!!{pool} verification",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 170,
+      "line": 158,
       "column": 20,
-      "index": 6549
+      "index": 6064
     },
     "end": {
-      "line": 173,
+      "line": 161,
       "column": 3,
-      "index": 6644
-    }
-  },
-  {
-    "id": "swap.swapScreen.volume",
-    "defaultMessage": "!!!Volume, 24h",
-    "file": "src/features/Swap/common/strings.ts",
-    "start": {
-      "line": 174,
-      "column": 10,
-      "index": 6656
-    },
-    "end": {
-      "line": 177,
-      "column": 3,
-      "index": 6733
+      "index": 6159
     }
   },
   {
@@ -409,29 +379,14 @@
     "defaultMessage": "!!!Cardano projects that list their own tokens can apply for an additional {pool} verification. This verification is a manual validation that {pool} team performs with the help of Cardano Foundation.",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 178,
+      "line": 162,
       "column": 24,
-      "index": 6759
+      "index": 6185
     },
     "end": {
-      "line": 182,
+      "line": 166,
       "column": 3,
-      "index": 7041
-    }
-  },
-  {
-    "id": "global,price",
-    "defaultMessage": "!!! Price",
-    "file": "src/features/Swap/common/strings.ts",
-    "start": {
-      "line": 183,
-      "column": 9,
-      "index": 7052
-    },
-    "end": {
-      "line": 186,
-      "column": 3,
-      "index": 7114
+      "index": 6467
     }
   },
   {
@@ -439,14 +394,14 @@
     "defaultMessage": "!!!No assets found for this pair",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 187,
+      "line": 167,
       "column": 17,
-      "index": 7133
+      "index": 6486
     },
     "end": {
-      "line": 190,
+      "line": 170,
       "column": 3,
-      "index": 7235
+      "index": 6588
     }
   },
   {
@@ -454,14 +409,14 @@
     "defaultMessage": "!!!Each verified tokens gets",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 191,
+      "line": 171,
       "column": 21,
-      "index": 7258
+      "index": 6611
     },
     "end": {
-      "line": 194,
+      "line": 174,
       "column": 3,
-      "index": 7360
+      "index": 6713
     }
   },
   {
@@ -469,14 +424,14 @@
     "defaultMessage": "!!!verified badge",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 195,
+      "line": 175,
       "column": 17,
-      "index": 7379
+      "index": 6732
     },
     "end": {
-      "line": 198,
+      "line": 178,
       "column": 3,
-      "index": 7466
+      "index": 6819
     }
   },
   {
@@ -484,14 +439,14 @@
     "defaultMessage": "!!!Open orders",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 199,
+      "line": 179,
       "column": 14,
-      "index": 7482
+      "index": 6835
     },
     "end": {
-      "line": 202,
+      "line": 182,
       "column": 3,
-      "index": 7563
+      "index": 6916
     }
   },
   {
@@ -499,59 +454,14 @@
     "defaultMessage": "!!!Completed orders",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 203,
+      "line": 183,
       "column": 19,
-      "index": 7584
+      "index": 6937
     },
     "end": {
-      "line": 206,
+      "line": 186,
       "column": 3,
-      "index": 7675
-    }
-  },
-  {
-    "id": "swap.swapScreen.tvl",
-    "defaultMessage": "!!!TVL",
-    "file": "src/features/Swap/common/strings.ts",
-    "start": {
-      "line": 207,
-      "column": 7,
-      "index": 7684
-    },
-    "end": {
-      "line": 210,
-      "column": 3,
-      "index": 7750
-    }
-  },
-  {
-    "id": "swap.swapScreen.poolFee",
-    "defaultMessage": "!!! Pool Fee",
-    "file": "src/features/Swap/common/strings.ts",
-    "start": {
-      "line": 211,
-      "column": 11,
-      "index": 7763
-    },
-    "end": {
-      "line": 214,
-      "column": 3,
-      "index": 7839
-    }
-  },
-  {
-    "id": "swap.swapScreen.batcherFee",
-    "defaultMessage": "!!! Batcher Fee",
-    "file": "src/features/Swap/common/strings.ts",
-    "start": {
-      "line": 215,
-      "column": 14,
-      "index": 7855
-    },
-    "end": {
-      "line": 218,
-      "column": 3,
-      "index": 7937
+      "index": 7028
     }
   },
   {
@@ -559,14 +469,14 @@
     "defaultMessage": "!!!Asset",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 219,
+      "line": 187,
       "column": 9,
-      "index": 7948
+      "index": 7039
     },
     "end": {
-      "line": 222,
+      "line": 190,
       "column": 3,
-      "index": 8021
+      "index": 7112
     }
   },
   {
@@ -574,14 +484,14 @@
     "defaultMessage": "!!!Clear",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 223,
+      "line": 191,
       "column": 9,
-      "index": 8032
+      "index": 7123
     },
     "end": {
-      "line": 226,
+      "line": 194,
       "column": 3,
-      "index": 8093
+      "index": 7184
     }
   },
   {
@@ -589,14 +499,14 @@
     "defaultMessage": "!!!Sign transaction",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 227,
+      "line": 195,
       "column": 19,
-      "index": 8114
+      "index": 7205
     },
     "end": {
-      "line": 230,
+      "line": 198,
       "column": 3,
-      "index": 8196
+      "index": 7287
     }
   },
   {
@@ -604,14 +514,14 @@
     "defaultMessage": "!!!Spending Password",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 231,
+      "line": 199,
       "column": 20,
-      "index": 8218
+      "index": 7309
     },
     "end": {
-      "line": 234,
+      "line": 202,
       "column": 3,
-      "index": 8302
+      "index": 7393
     }
   },
   {
@@ -619,14 +529,14 @@
     "defaultMessage": "!!!Enter spending password to sign this transaction",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 235,
+      "line": 203,
       "column": 25,
-      "index": 8329
+      "index": 7420
     },
     "end": {
-      "line": 238,
+      "line": 206,
       "column": 3,
-      "index": 8449
+      "index": 7540
     }
   },
   {
@@ -634,14 +544,14 @@
     "defaultMessage": "!!!Sign",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 239,
+      "line": 207,
       "column": 8,
-      "index": 8459
+      "index": 7550
     },
     "end": {
-      "line": 242,
+      "line": 210,
       "column": 3,
-      "index": 8518
+      "index": 7609
     }
   },
   {
@@ -649,14 +559,14 @@
     "defaultMessage": "!!!Swap",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 243,
+      "line": 211,
       "column": 14,
-      "index": 8534
+      "index": 7625
     },
     "end": {
-      "line": 246,
+      "line": 214,
       "column": 3,
-      "index": 8593
+      "index": 7684
     }
   },
   {
@@ -664,14 +574,14 @@
     "defaultMessage": "!!!You have",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 249,
+      "line": 217,
       "column": 11,
-      "index": 8652
+      "index": 7743
     },
     "end": {
-      "line": 252,
+      "line": 220,
       "column": 3,
-      "index": 8747
+      "index": 7838
     }
   },
   {
@@ -679,14 +589,14 @@
     "defaultMessage": "!!!No assets found",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 253,
+      "line": 221,
       "column": 12,
-      "index": 8761
+      "index": 7852
     },
     "end": {
-      "line": 256,
+      "line": 224,
       "column": 3,
-      "index": 8864
+      "index": 7955
     }
   },
   {
@@ -694,14 +604,14 @@
     "defaultMessage": "!!!found",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 257,
+      "line": 225,
       "column": 9,
-      "index": 8875
+      "index": 7966
     },
     "end": {
-      "line": 260,
+      "line": 228,
       "column": 3,
-      "index": 8965
+      "index": 8056
     }
   },
   {
@@ -709,14 +619,14 @@
     "defaultMessage": "!!!Search tokens",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 261,
+      "line": 229,
       "column": 16,
-      "index": 8983
+      "index": 8074
     },
     "end": {
-      "line": 264,
+      "line": 232,
       "column": 3,
-      "index": 9079
+      "index": 8170
     }
   },
   {
@@ -724,14 +634,14 @@
     "defaultMessage": "!!!Select asset",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 265,
+      "line": 233,
       "column": 20,
-      "index": 9101
+      "index": 8192
     },
     "end": {
-      "line": 268,
+      "line": 236,
       "column": 3,
-      "index": 9190
+      "index": 8281
     }
   },
   {
@@ -739,14 +649,14 @@
     "defaultMessage": "!!!Confirm",
     "file": "src/features/Swap/common/strings.ts",
     "start": {
-      "line": 269,
+      "line": 237,
       "column": 11,
-      "index": 9203
+      "index": 8294
     },
     "end": {
-      "line": 272,
+      "line": 240,
       "column": 3,
-      "index": 9297
+      "index": 8388
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/features/Swap/common/strings.json
+++ b/apps/wallet-mobile/translations/messages/src/features/Swap/common/strings.json
@@ -405,7 +405,7 @@
     }
   },
   {
-    "id": "global,price",
+    "id": "global.price",
     "defaultMessage": "!!! Price",
     "file": "src/features/Swap/common/strings.ts",
     "start": {


### PR DESCRIPTION
Now the input shouldn't break in any case.

- Only numbers and decimal separator are valid inputs
- Any other input gets removed
- Decimal places after limit get removed
- Grouping separator added automatically
- Works in any locale


related:
https://emurgo.atlassian.net/browse/YOMO-734
https://emurgo.atlassian.net/browse/YOMO-735