### PR TITLE
fix: Buy/sell price update when updating the other field

### DIFF
--- a/apps/wallet-mobile/src/features/Swap/common/AmountCard/AmountCard.tsx
+++ b/apps/wallet-mobile/src/features/Swap/common/AmountCard/AmountCard.tsx
@@ -19,12 +19,25 @@ type Props = {
   hasError?: boolean
   navigateTo?: () => void
   touched?: boolean
+  inputRef?: React.RefObject<TextInput>
+  inputEditable?: boolean
 }
 
-export const AmountCard = ({label, onChange, value, wallet, amount, navigateTo, hasError, touched}: Props) => {
+export const AmountCard = ({
+  label,
+  onChange,
+  value,
+  wallet,
+  amount,
+  navigateTo,
+  hasError,
+  touched,
+  inputRef,
+  inputEditable = true,
+}: Props) => {
   const strings = useStrings()
   const {quantity, tokenId} = amount
-  const amountInputRef = useRef<TextInput>(null)
+  const amountInputRef = useRef<TextInput>(inputRef?.current ?? null)
 
   const tokenInfo = useTokenInfo({wallet, tokenId})
   const noTokenSelected = !touched
@@ -45,7 +58,7 @@ export const AmountCard = ({label, onChange, value, wallet, amount, navigateTo, 
 
         <View style={styles.content}>
           <Pressable style={styles.amountWrapper} onPress={focusInput}>
-            <AmountInput onChange={onChange} value={value} inputRef={amountInputRef} />
+            <AmountInput onChange={onChange} value={value} inputRef={amountInputRef} editable={inputEditable} />
           </Pressable>
 
           <Spacer width={7} />
@@ -93,8 +106,9 @@ type AmountInputProps = {
   value?: string
   onChange(value: string): void
   inputRef?: React.RefObject<TextInput>
+  editable: boolean
 }
-const AmountInput = ({onChange, value, inputRef}: AmountInputProps) => {
+const AmountInput = ({onChange, value, inputRef, editable}: AmountInputProps) => {
   // TODO add more formatting if is the case
   const onChangeText = (text: string) => {
     onChange(text)
@@ -113,6 +127,7 @@ const AmountInput = ({onChange, value, inputRef}: AmountInputProps) => {
       style={styles.amountInput}
       underlineColorAndroid="transparent"
       ref={inputRef}
+      editable={editable}
     />
   )
 }

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditBuyAmount/EditBuyAmount.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditBuyAmount/EditBuyAmount.tsx
@@ -1,5 +1,6 @@
 import {getSellAmountByChangingReceive, useSwap} from '@yoroi/swap'
 import * as React from 'react'
+import {TextInput} from 'react-native'
 
 import {useLanguage} from '../../../../../../i18n'
 import {useSelectedWallet} from '../../../../../../SelectedWallet'
@@ -16,6 +17,7 @@ export const EditBuyAmount = () => {
   const navigate = useNavigateTo()
   const wallet = useSelectedWallet()
   const {numberLocale} = useLanguage()
+  const inputRef = React.useRef<TextInput>(null)
 
   const {createOrder, buyAmountChanged, sellAmountChanged} = useSwap()
   const {isBuyTouched} = useSwapTouched()
@@ -25,6 +27,12 @@ export const EditBuyAmount = () => {
   const balance = useBalance({wallet, tokenId})
 
   const [inputValue, setInputValue] = React.useState<string>(Quantities.denominated(quantity, tokenInfo.decimals ?? 0))
+
+  React.useEffect(() => {
+    if (isBuyTouched && !inputRef?.current?.isFocused()) {
+      setInputValue(Quantities.format(quantity, tokenInfo.decimals ?? 0))
+    }
+  }, [isBuyTouched, quantity, tokenInfo.decimals])
 
   const recalculateSellValue = (buyQuantity) => {
     const {sell} = getSellAmountByChangingReceive(createOrder?.selectedPool, {
@@ -57,6 +65,8 @@ export const EditBuyAmount = () => {
       wallet={wallet}
       navigateTo={navigate.selectBuyToken}
       touched={isBuyTouched}
+      inputRef={inputRef}
+      inputEditable={isBuyTouched}
     />
   )
 }

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditSellAmount/EditSellAmount.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditSellAmount/EditSellAmount.tsx
@@ -1,5 +1,6 @@
 import {getReceiveAmountbyChangingSell, useSwap} from '@yoroi/swap'
 import * as React from 'react'
+import {TextInput} from 'react-native'
 
 import {useLanguage} from '../../../../../../i18n'
 import {useSelectedWallet} from '../../../../../../SelectedWallet'
@@ -16,6 +17,7 @@ export const EditSellAmount = () => {
   const navigate = useNavigateTo()
   const wallet = useSelectedWallet()
   const {numberLocale} = useLanguage()
+  const inputRef = React.useRef<TextInput>(null)
 
   const {createOrder, sellAmountChanged, buyAmountChanged} = useSwap()
   const {isSellTouched} = useSwapTouched()
@@ -27,6 +29,12 @@ export const EditSellAmount = () => {
   const balance = useBalance({wallet, tokenId})
 
   const [inputValue, setInputValue] = React.useState<string>(Quantities.denominated(quantity, tokenInfo.decimals ?? 0))
+
+  React.useEffect(() => {
+    if (isSellTouched && !inputRef?.current?.isFocused()) {
+      setInputValue(Quantities.format(quantity, tokenInfo.decimals ?? 0))
+    }
+  }, [isSellTouched, quantity, tokenInfo.decimals])
 
   const hasBalance = !Quantities.isGreaterThan(quantity, balance)
   const showError = !Quantities.isZero(quantity) && !hasBalance
@@ -64,6 +72,8 @@ export const EditSellAmount = () => {
       hasError={showError}
       navigateTo={navigate.selectSellToken}
       touched={isSellTouched}
+      inputRef={inputRef}
+      inputEditable={isSellTouched}
     />
   )
 }

--- a/apps/wallet-mobile/src/yoroi-wallets/utils/utils.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/utils/utils.ts
@@ -149,6 +149,9 @@ export const Quantities = {
 
     return [input, quantity] as [string, Balance.Quantity]
   },
+  format: (quantity: Balance.Quantity, denomination: number) => {
+    return new BigNumber(Quantities.denominated(quantity, denomination)).toFormat()
+  },
 }
 
 export const asQuantity = (value: BigNumber | number | string) => {

--- a/apps/wallet-mobile/translations/messages/src/features/Swap/common/AmountCard/AmountCard.json
+++ b/apps/wallet-mobile/translations/messages/src/features/Swap/common/AmountCard/AmountCard.json
@@ -4,14 +4,14 @@
     "defaultMessage": "!!!Select token",
     "file": "src/features/Swap/common/AmountCard/AmountCard.tsx",
     "start": {
-      "line": 121,
+      "line": 136,
       "column": 15,
-      "index": 3819
+      "index": 4042
     },
     "end": {
-      "line": 124,
+      "line": 139,
       "column": 3,
-      "index": 3902
+      "index": 4125
     }
   }
 ]


### PR DESCRIPTION
Restored the useEffects that update the sell/buy fields, but only when not editing them.