### PR TITLE
fix(swap): Buy value recalculation race condition

### DIFF
--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditSellAmount/EditSellAmount.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditSellAmount/EditSellAmount.tsx
@@ -68,7 +68,7 @@ export const EditSellAmount = () => {
   }
 
   React.useEffect(() => {
-    recalculateBuyValue(quantity)
+    setTimeout(() => recalculateBuyValue(quantity), 100)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [buyTokenInfo?.id])
 

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditSellAmount/EditSellAmount.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditSellAmount/EditSellAmount.tsx
@@ -68,9 +68,9 @@ export const EditSellAmount = () => {
   }
 
   React.useEffect(() => {
-    setTimeout(() => recalculateBuyValue(quantity), 100)
+    recalculateBuyValue(quantity)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [buyTokenInfo?.id])
+  }, [buyTokenInfo?.id, createOrder?.selectedPool?.poolId])
 
   const onChangeQuantity = (text: string) => {
     try {


### PR DESCRIPTION
related: https://emurgo.atlassian.net/browse/YOMO-762

I don't love the solution, not sure if it may break for slow connection either. 
Problem is recalculation of fields happens in the form, instead of in the swap package.

When buyTokenInfo?.id changes, I want to recalculate its value based on the sell quantity. But when running immediately, the createOrder values are not yet updated to do the calculation.  