### PR TITLE
chore: avoid notifying no changes

### DIFF
--- a/apps/wallet-mobile/src/yoroi-wallets/cardano/byron/ByronWallet.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/cardano/byron/ByronWallet.ts
@@ -1007,10 +1007,29 @@ export class ByronWallet implements YoroiWallet {
 
     await this.utxoManager.sync(addresses)
 
-    this._utxos = await this.utxoManager.getCachedUtxos()
+    const newUtxos = await this.utxoManager.getCachedUtxos()
 
-    // notifying always -> sync from lib need to flag if something has changed
-    this.notify({type: 'utxos', utxos: this.utxos})
+    if (this.hasUtxoUpdated(this._utxos, newUtxos)) {
+      this._utxos = newUtxos
+
+      this.notify({type: 'utxos', utxos: this.utxos})
+    }
+  }
+
+  private hasUtxoUpdated(oldUtxos: RawUtxo[], newUtxos: RawUtxo[]): boolean {
+    if (oldUtxos.length !== newUtxos.length) {
+      return true
+    }
+
+    const oldUtxoIds = new Set(oldUtxos.map((utxo) => utxo.utxo_id))
+
+    for (const newUtxo of newUtxos) {
+      if (!oldUtxoIds.has(newUtxo.utxo_id)) {
+        return true
+      }
+    }
+
+    return false
   }
 
   async fetchAccountState(): Promise<AccountStateResponse> {

--- a/apps/wallet-mobile/src/yoroi-wallets/cardano/shelley/ShelleyWallet.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/cardano/shelley/ShelleyWallet.ts
@@ -919,10 +919,29 @@ export const makeShelleyWallet = (constants: typeof MAINNET | typeof TESTNET) =>
 
       await this.utxoManager.sync(addresses)
 
-      this._utxos = await this.utxoManager.getCachedUtxos()
+      const newUtxos = await this.utxoManager.getCachedUtxos()
 
-      // notifying always -> sync from lib need to flag if something has changed
-      this.notify({type: 'utxos', utxos: this.utxos})
+      if (this.hasUtxoUpdated(this._utxos, newUtxos)) {
+        this._utxos = newUtxos
+
+        this.notify({type: 'utxos', utxos: this.utxos})
+      }
+    }
+
+    private hasUtxoUpdated(oldUtxos: RawUtxo[], newUtxos: RawUtxo[]): boolean {
+      if (oldUtxos.length !== newUtxos.length) {
+        return true
+      }
+
+      const oldUtxoIds = new Set(oldUtxos.map((utxo) => utxo.utxo_id))
+
+      for (const newUtxo of newUtxos) {
+        if (!oldUtxoIds.has(newUtxo.utxo_id)) {
+          return true
+        }
+      }
+
+      return false
     }
 
     async fetchAccountState(): Promise<AccountStateResponse> {


### PR DESCRIPTION
- [x] avoid firing 'utxos' event that causes many screens to rerender when there is no update in the utxos.