### PR TITLE
feat(swap): define base storage type to be used for web & mobile

### DIFF
--- a/packages/swap/src/adapters/async-storage/storage.ts
+++ b/packages/swap/src/adapters/async-storage/storage.ts
@@ -1,9 +1,11 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
-import {Swap} from '@yoroi/types'
+import {Swap, BaseStorage} from '@yoroi/types'
 
 const initialDeps = {storage: AsyncStorage} as const
 
-export function swapStorageMaker(deps = initialDeps): Readonly<Swap.Storage> {
+export function swapStorageMaker(
+  deps: {storage: BaseStorage | typeof AsyncStorage} = initialDeps,
+): Readonly<Swap.Storage> {
   const {storage} = deps
 
   const slippage: Readonly<Swap.Storage['slippage']> = {

--- a/packages/types/src/helpers/storage.ts
+++ b/packages/types/src/helpers/storage.ts
@@ -1,0 +1,5 @@
+export interface BaseStorage {
+  getItem(key: string): Promise<string | null>
+  setItem(key: string, value: string): Promise<void>
+  removeItem(key: string): Promise<void>
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -70,3 +70,4 @@ export namespace Numbers {
 }
 
 export * from './helpers/types'
+export * from './helpers/storage'


### PR DESCRIPTION
```ts
// For mobile  
swapStorageMaker() // use async storage for react native 
// For web
swapStorageMaker({
   storage: {
     setItem: promisify(localStorage.setItem)
  }
})
```