### PR TITLE
Revert "fix: add refresh btn logic"

### DIFF
--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditLimitPrice.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditLimitPrice.tsx
@@ -8,7 +8,7 @@ import {useLanguage} from '../../../../../i18n'
 import {useSelectedWallet} from '../../../../../SelectedWallet'
 import {COLORS} from '../../../../../theme'
 import {useTokenInfo} from '../../../../../yoroi-wallets/hooks'
-import {asQuantity, Quantities} from '../../../../../yoroi-wallets/utils'
+import {Quantities} from '../../../../../yoroi-wallets/utils'
 import {useStrings} from '../../../common/strings'
 import {useSwapTouched} from '../../../common/SwapFormProvider'
 
@@ -18,6 +18,7 @@ const PRECISION = 10
 export const EditLimitPrice = () => {
   const strings = useStrings()
   const {numberLocale} = useLanguage()
+  const [text, setText] = React.useState('')
   const wallet = useSelectedWallet()
 
   const {createOrder, limitPriceChanged} = useSwap()
@@ -34,7 +35,7 @@ export const EditLimitPrice = () => {
     const defaultPrice = createOrder.marketPrice
 
     const formattedValue = BigNumber(defaultPrice).decimalPlaces(PRECISION).toFormat(numberLocale)
-    limitPriceChanged(asQuantity(formattedValue))
+    setText(formattedValue)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [createOrder.marketPrice])
 
@@ -44,14 +45,16 @@ export const EditLimitPrice = () => {
     const defaultPrice = createOrder.marketPrice
 
     const formattedValue = BigNumber(defaultPrice).decimalPlaces(PRECISION).toFormat(numberLocale)
-    limitPriceChanged(asQuantity(formattedValue))
+    setText(formattedValue)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [createOrder.type])
 
   const onChange = (text: string) => {
-    const [formattedPrice] = Quantities.parseFromText(text, PRECISION, numberLocale)
+    const [formattedPrice, price] = Quantities.parseFromText(text, PRECISION, numberLocale)
+    const value = Quantities.denominated(price, PRECISION)
 
-    limitPriceChanged(asQuantity(formattedPrice))
+    setText(formattedPrice)
+    limitPriceChanged(value)
   }
 
   return (
@@ -59,7 +62,7 @@ export const EditLimitPrice = () => {
       <Text style={styles.label}>{disabled ? strings.marketPrice : strings.limitPrice}</Text>
 
       <View style={styles.content}>
-        <AmountInput onChange={onChange} value={createOrder.limitPrice} editable={!disabled} />
+        <AmountInput onChange={onChange} value={text} editable={!disabled} />
 
         <View style={[styles.textWrapper, disabled && styles.disabled]}>
           <Text style={styles.text}>

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/ShowTokenActions/TopTokenActions.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/ShowTokenActions/TopTokenActions.tsx
@@ -1,49 +1,27 @@
 import {useSwap, useSwapPoolsByPair} from '@yoroi/swap'
-import {Swap} from '@yoroi/types'
-import BigNumber from 'bignumber.js'
 import React from 'react'
 import {StyleSheet, View} from 'react-native'
 import {TouchableOpacity} from 'react-native-gesture-handler'
 
 import {Icon} from '../../../../../../components'
 import {LoadingOverlay} from '../../../../../../components/LoadingOverlay'
-import {useLanguage} from '../../../../../../i18n'
 import {COLORS} from '../../../../../../theme'
-import {asQuantity} from '../../../../../../yoroi-wallets/utils'
 import {ButtonGroup} from '../../../../common/ButtonGroup/ButtonGroup'
 import {useStrings} from '../../../../common/strings'
 import {useSwapTouched} from '../../../../common/SwapFormProvider'
 
-const PRECISION = 10
-
 export const TopTokenActions = () => {
   const strings = useStrings()
-  const {numberLocale} = useLanguage()
   const orderTypeLabels = [strings.marketButton, strings.limitButton]
-  const {createOrder, orderTypeChanged, limitPriceChanged, selectedPoolChanged} = useSwap()
+  const {createOrder, orderTypeChanged} = useSwap()
   const {isBuyTouched, isSellTouched} = useSwapTouched()
   const isDisabled = !isBuyTouched || !isSellTouched || createOrder.selectedPool === undefined
   const orderTypeIndex = createOrder.type === 'market' ? 0 : 1
 
-  const {refetch, isLoading} = useSwapPoolsByPair(
-    {
-      tokenA: createOrder.amounts.sell.tokenId ?? '',
-      tokenB: createOrder.amounts.buy.tokenId ?? '',
-    },
-    {
-      onSuccess: (poolList: Swap.Pool[]) => {
-        const bestPool: Swap.Pool | undefined = poolList
-          .sort((a: Swap.Pool, b: Swap.Pool) => a.price - b.price)
-          .find(() => true)
-        if (bestPool !== undefined) {
-          const defaultPrice = createOrder.marketPrice
-          const formattedValue = BigNumber(defaultPrice).decimalPlaces(PRECISION).toFormat(numberLocale)
-          selectedPoolChanged(bestPool)
-          limitPriceChanged(asQuantity(formattedValue))
-        }
-      },
-    },
-  )
+  const {refetch, isLoading} = useSwapPoolsByPair({
+    tokenA: createOrder.amounts.sell.tokenId ?? '',
+    tokenB: createOrder.amounts.buy.tokenId ?? '',
+  })
 
   const handleSelectOrderType = (index: number) => {
     if (index === 0) {


### PR DESCRIPTION
Reverts Emurgo/yoroi#2722

```
asQuantity(formattedValue)
```
Is not ok. Formatted value can't be passed to asQuantity.

```
<AmountInput onChange={onChange} value={createOrder.limitPrice} editable={!disabled} />
```
createOrder.limitPrice is not directly assignable to the input


And

```
    {
      onSuccess: (poolList: Swap.Pool[]) => {
        const bestPool: Swap.Pool | undefined = poolList
          .sort((a: Swap.Pool, b: Swap.Pool) => a.price - b.price)
          .find(() => true)
        if (bestPool !== undefined) {
          const defaultPrice = createOrder.marketPrice
          const formattedValue = BigNumber(defaultPrice).decimalPlaces(PRECISION).toFormat(numberLocale)
          selectedPoolChanged(bestPool)
          limitPriceChanged(asQuantity(formattedValue))
        }
      },
    },
```
    
   
None of that should be modified from here. The pool change is already done on createOrder, and again limitPriceChanged can't receive that.