### PR TITLE
refactor: tests unsupported pools

### DIFF
--- a/apps/wallet-mobile/src/features/Swap/common/mocks.ts
+++ b/apps/wallet-mobile/src/features/Swap/common/mocks.ts
@@ -1,9 +1,8 @@
-import {mockSwapStateDefault} from '@yoroi/swap'
+import {mockSwapStateDefault, SwapState} from '@yoroi/swap'
 
 import {mocks as walletMocks} from '../../../yoroi-wallets/mocks/wallet'
 import {asQuantity} from '../../../yoroi-wallets/utils'
 
-type ProviderType = 'sundaeswap' | 'minswap' | 'wingriders' | 'muesliswap_v1' | 'muesliswap_v2' | 'muesliswap_v3'
 type Type = 'market' | 'limit'
 
 export const mocks = {
@@ -34,7 +33,7 @@ export const mocks = {
         },
         poolId: '0029cb7c88c7567b63d1a512c0ed626aa169688ec980730c0473b913.702083',
         price: 0.0890390378168252,
-        provider: 'sundaeswap' as ProviderType,
+        provider: 'sundaeswap',
         tokenA: {quantity: asQuantity(20630071), tokenId: ''},
         tokenB: {
           quantity: asQuantity(231696922),
@@ -44,5 +43,5 @@ export const mocks = {
       slippage: 1,
       type: 'market' as Type,
     },
-  },
+  } as SwapState,
 }

--- a/packages/swap/src/adapters/openswap-api/openswap.mocks.ts
+++ b/packages/swap/src/adapters/openswap-api/openswap.mocks.ts
@@ -405,6 +405,38 @@ const getPools: OpenSwap.Pool[] = [
         'e4214b7cce62ac6fbba385d164df48e157eae5863521b4b67ca71d86.7339a8bcda85e2c997d9f16beddbeb3ad755f5202f5cfd9cb08db346a1292c01',
     },
   },
+  {
+    provider: 'spectrum', // unsupported pool
+    fee: '0.3',
+    tokenA: {
+      amount: '1233807687',
+      token: '.',
+    },
+    tokenB: {
+      amount: '780',
+      token:
+        'e16c2dc8ae937e8d3790c7fd7168d7b994621ba14ca11415f39fed72.43414b45',
+    },
+    price: 1581804.726923077,
+    batcherFee: {
+      amount: '2000000',
+      token: '.',
+    },
+    // depositFee: {
+    //   amount: '2000000',
+    //   token: '.',
+    // },
+    deposit: 2000000,
+    utxo: '0596860b5970ef989c56f7ae38b3c0f74bb4979ac15ee994c30760f7f4d908ce#0',
+    poolId:
+      '0be55d262b29f564998ff81efe21bdc0022621c12f15af08d0f2ddb1.7339a8bcda85e2c997d9f16beddbeb3ad755f5202f5cfd9cb08db346a1292c01',
+    timestamp: '2023-05-31 07:03:41',
+    lpToken: {
+      amount: '981004',
+      token:
+        'e4214b7cce62ac6fbba385d164df48e157eae5863521b4b67ca71d86.7339a8bcda85e2c997d9f16beddbeb3ad755f5202f5cfd9cb08db346a1292c01',
+    },
+  },
 ]
 
 export const openswapMocks = {

--- a/packages/swap/src/helpers/transformers.test.ts
+++ b/packages/swap/src/helpers/transformers.test.ts
@@ -188,10 +188,16 @@ describe('asYoroiPools', () => {
 })
 
 describe('asYoroiPool', () => {
-  it('success', () => {
+  it('success (supported pool)', () => {
     const result = transformers.asYoroiPool(openswapMocks.getPools[0]!)
 
     expect(result).toEqual<Swap.Pool>(apiMocks.getPools[0]!)
+  })
+
+  it('success (unsupported pool)', () => {
+    const result = transformers.asYoroiPool(openswapMocks.getPools[3]!)
+
+    expect(result).toBeNull()
   })
 })
 

--- a/packages/swap/src/helpers/transformers.test.ts
+++ b/packages/swap/src/helpers/transformers.test.ts
@@ -177,10 +177,13 @@ describe('asYoroiPools', () => {
     expect(result).toEqual<Array<Swap.Pool>>([])
   })
 
-  it('success', () => {
+  it('success (filter out unsupported pools)', () => {
     const result = transformers.asYoroiPools(openswapMocks.getPools)
 
     expect(result).toEqual<Array<Swap.Pool>>(apiMocks.getPools)
+
+    // should filter out unsupported pools
+    expect(result.length).toBe(openswapMocks.getPools.length - 1)
   })
 })
 

--- a/packages/swap/src/helpers/transformers.ts
+++ b/packages/swap/src/helpers/transformers.ts
@@ -107,7 +107,7 @@ export const transformersMaker = (
     return balanceToken
   }
 
-  const asYoroiPool = (openswapPool: OpenSwap.Pool): Swap.Pool => {
+  const asYoroiPool = (openswapPool: OpenSwap.Pool): Swap.Pool | null => {
     const {
       batcherFee,
       fee,
@@ -120,6 +120,9 @@ export const transformersMaker = (
       price,
       poolId,
     } = openswapPool
+
+    if (provider && !isSupportedProvider(provider)) return null
+
     const pool: Swap.Pool = {
       tokenA: asYoroiAmount(tokenA),
       tokenB: asYoroiAmount(tokenB),
@@ -160,7 +163,9 @@ export const transformersMaker = (
    */
   const asYoroiPools = (openswapPools: OpenSwap.Pool[]): Swap.Pool[] => {
     if (openswapPools?.length > 0)
-      return openswapPools.filter(filterBySupportedProviders).map(asYoroiPool)
+      return openswapPools
+        .map(asYoroiPool)
+        .filter((pool): pool is Swap.Pool => pool !== null)
 
     return []
   }
@@ -201,6 +206,8 @@ export const asTokenFingerprint = ({
 
 export const asUtf8 = (hex: string) => Buffer.from(hex, 'hex').toString('utf-8')
 
-function filterBySupportedProviders(pool: OpenSwap.Pool) {
-  return supportedProviders.includes(pool.provider as Swap.SupportedProvider)
+function isSupportedProvider(
+  provider: string,
+): provider is Swap.SupportedProvider {
+  return supportedProviders.includes(provider as Swap.SupportedProvider)
 }

--- a/packages/swap/src/helpers/transformers.ts
+++ b/packages/swap/src/helpers/transformers.ts
@@ -152,10 +152,17 @@ export const transformersMaker = (
     return {quantity: Quantities.zero, tokenId: ''} as const
   }
 
+  /**
+   *  Filter out pools that are not supported by Yoroi
+   *
+   * @param openswapPools
+   * @returns {Swap.Pool[]}
+   */
   const asYoroiPools = (openswapPools: OpenSwap.Pool[]): Swap.Pool[] => {
-    return openswapPools?.length > 0
-      ? filterBySupportedProviders(openswapPools).map(asYoroiPool)
-      : []
+    if (openswapPools?.length > 0)
+      return openswapPools.filter(filterBySupportedProviders).map(asYoroiPool)
+
+    return []
   }
 
   const asYoroiBalanceTokens = (
@@ -194,10 +201,6 @@ export const asTokenFingerprint = ({
 
 export const asUtf8 = (hex: string) => Buffer.from(hex, 'hex').toString('utf-8')
 
-const filterBySupportedProviders = (
-  pools: OpenSwap.Pool[],
-): OpenSwap.Pool[] => {
-  return pools.filter((pool) =>
-    supportedProviders.includes(pool.provider as Swap.SupportedProvider),
-  )
+function filterBySupportedProviders(pool: OpenSwap.Pool) {
+  return supportedProviders.includes(pool.provider as Swap.SupportedProvider)
 }

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -20,6 +20,7 @@ export {makeLimitOrder} from './helpers/orders/makeLimitOrder'
 export {getPoolUrlByProvider} from './helpers/pools/getPoolUrlByProvider'
 
 export {SwapProvider} from './translators/reactjs/provider/SwapProvider'
+export {SwapState} from './translators/reactjs/state/state'
 export {useSwapCreateOrder} from './translators/reactjs/hooks/useSwapCreateOrder'
 export {useSwapOrdersByStatusCompleted} from './translators/reactjs/hooks/useSwapOrdersByStatusCompleted'
 export {useSwapOrdersByStatusOpen} from './translators/reactjs/hooks/useSwapOrdersByStatusOpen'
@@ -37,3 +38,5 @@ export {
   swapStorageMaker,
   swapStorageSlippageKey,
 } from './adapters/async-storage/storage'
+
+export {supportedProviders} from './translators/constants'

--- a/packages/types/src/swap/order.ts
+++ b/packages/types/src/swap/order.ts
@@ -1,5 +1,5 @@
 import {BalanceAmount, BalanceQuantity} from '../balance/token'
-import {SwapPool} from './pool'
+import {SwapPool, SwapPoolProvider} from './pool'
 
 export type SwapOrderType = 'market' | 'limit'
 
@@ -29,7 +29,7 @@ export type SwapCreateOrderResponse = {
 }
 
 export type SwapOpenOrder = {
-  provider: SwapPool['provider']
+  provider: SwapPoolProvider
   from: BalanceAmount
   to: BalanceAmount
   deposit: BalanceAmount

--- a/packages/types/src/swap/pool.ts
+++ b/packages/types/src/swap/pool.ts
@@ -23,7 +23,7 @@ export type SwapSupportedProvider = Extract<
 >
 
 export type SwapPool = {
-  provider: SwapPoolProvider
+  provider: SwapSupportedProvider
   fee: string // % pool liquidity provider fee, usually 0.3.
   tokenA: BalanceAmount
   tokenB: BalanceAmount


### PR DESCRIPTION
- [x] Updated the SupportedProvider types around Order/Pool
- [x] Exported the SwapState so the client can mock with types
- [x] Typeguard for transformers 
- [x] Improved tests for supported x unsupported pools