### PR TITLE
fix(swap): Non ada pair selection

### DIFF
--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -48,6 +48,7 @@
   "scripts": {
     "build": "yarn tsc && yarn lint && yarn test --ci --silent && yarn clean && bob build && yarn flow",
     "clean": "del-cli lib",
+    "dev": "yarn clean && bob build",
     "dgraph": "depcruise src --include-only \"^src\" --output-type dot | dot -T svg > dependency-graph.svg",
     "flow": ". ./scripts/flowgen.sh",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",

--- a/packages/swap/src/translators/reactjs/state/state.test.ts
+++ b/packages/swap/src/translators/reactjs/state/state.test.ts
@@ -46,6 +46,19 @@ describe('State Actions', () => {
     expect(state).toEqual(expectedState)
   })
 
+  it('SellAmountChanged zero', () => {
+    const action: SwapCreateOrderAction = {
+      type: SwapCreateOrderActionType.SellAmountChanged,
+      amount: {quantity: '0', tokenId: 'someTokenId'},
+    }
+    const expectedState = produce(mockSwapStateDefault, (draft) => {
+      draft.createOrder.amounts.sell = action.amount
+      draft.createOrder.amounts.buy.quantity = '0'
+    })
+    const state = combinedSwapReducers(mockSwapStateDefault, action)
+    expect(state).toEqual(expectedState)
+  })
+
   it('SellAmountChanged market', () => {
     const action: SwapCreateOrderAction = {
       type: SwapCreateOrderActionType.SellAmountChanged,
@@ -90,6 +103,19 @@ describe('State Actions', () => {
     const action: SwapAction = {type: SwapActionType.ResetState}
     const state = combinedSwapReducers(mockSwapStateDefault, action)
     expect(state).toEqual(defaultSwapState)
+  })
+
+  it('BuyAmountChanged zero', () => {
+    const action: SwapCreateOrderAction = {
+      type: SwapCreateOrderActionType.BuyAmountChanged,
+      amount: {quantity: '0', tokenId: 'someTokenId'},
+    }
+    const expectedState = produce(mockSwapStateDefault, (draft) => {
+      draft.createOrder.amounts.buy = action.amount
+      draft.createOrder.amounts.sell.quantity = `0`
+    })
+    const state = combinedSwapReducers(mockSwapStateDefault, action)
+    expect(state).toEqual(expectedState)
   })
 
   it('BuyAmountChanged market', () => {

--- a/packages/swap/src/translators/reactjs/state/state.ts
+++ b/packages/swap/src/translators/reactjs/state/state.ts
@@ -187,23 +187,31 @@ const createOrderReducer = (
         break
       case SwapCreateOrderActionType.SellAmountChanged:
         draft.createOrder.amounts.sell = action.amount
-        draft.createOrder.amounts.buy = getBuyAmount(
-          state.createOrder.selectedPool,
-          action.amount,
-          state.createOrder.type === 'limit'
-            ? state.createOrder.limitPrice
-            : undefined,
-        )
+        if (Quantities.isZero(action.amount.quantity)) {
+          draft.createOrder.amounts.buy.quantity = Quantities.zero
+        } else {
+          draft.createOrder.amounts.buy = getBuyAmount(
+            state.createOrder.selectedPool,
+            action.amount,
+            state.createOrder.type === 'limit'
+              ? state.createOrder.limitPrice
+              : undefined,
+          )
+        }
         break
       case SwapCreateOrderActionType.BuyAmountChanged:
         draft.createOrder.amounts.buy = action.amount
-        draft.createOrder.amounts.sell = getSellAmount(
-          state.createOrder.selectedPool,
-          action.amount,
-          state.createOrder.type === 'limit'
-            ? state.createOrder.limitPrice
-            : undefined,
-        )
+        if (Quantities.isZero(action.amount.quantity)) {
+          draft.createOrder.amounts.sell.quantity = Quantities.zero
+        } else {
+          draft.createOrder.amounts.sell = getSellAmount(
+            state.createOrder.selectedPool,
+            action.amount,
+            state.createOrder.type === 'limit'
+              ? state.createOrder.limitPrice
+              : undefined,
+          )
+        }
         break
       case SwapCreateOrderActionType.SelectedPoolChanged:
         draft.createOrder.selectedPool = action.pool


### PR DESCRIPTION
related: https://emurgo.atlassian.net/browse/YOMO-815

When the selection screen wants to select a new token, the only action it can perform is `SellAmountChanged` or `BuyAmountChanged`, which not only serve to modify the quantity, but the tokenId as well.
The reducer for those actions takes care of updating the amounts, but expects the selectedPool to be correct.
When selecting new tokens, the pool is still the old one, so the getBuyAmount/getSellAmount set the other amount to the other amount in the pool, which was always ada because we started with it in the pair.

This fix prevents calling getBuyAmount/getSellAmount if we are setting a quantity = 0, since the other one will be 0 as well. After that, the pair has changed, and the app in createOrder will pick up the change, request new pools, and update the selectedPool. Or that's the idea, I only have ada on my prod wallet. And the testnet wallet has a mocked pool list with only ada pairs, so I can't verify it works.