### PR TITLE
fix: More digits for market price

### DIFF
--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditLimitPrice.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditLimitPrice.tsx
@@ -12,7 +12,7 @@ import {useStrings} from '../../../common/strings'
 import {useSwapTouched} from '../../../common/SwapFormProvider'
 
 const BORDER_SIZE = 1
-const PRECISION = 10
+const PRECISION = 14
 
 export const EditLimitPrice = () => {
   const strings = useStrings()


### PR DESCRIPTION
A few tokens with veery low prices need more digits to show up.