### PR TITLE
refactor: Tokens state

### DIFF
--- a/apps/wallet-mobile/src/features/Swap/SwapNavigator.tsx
+++ b/apps/wallet-mobile/src/features/Swap/SwapNavigator.tsx
@@ -21,8 +21,25 @@ export const SwapTabNavigator = () => {
 
   // state data
   const wallet = useSelectedWallet()
-  const {aggregatorTokenId, lpTokenHeldChanged, frontendFeeTiers, frontendFeeTiersChanged} = useSwap()
+  const {
+    aggregatorTokenId,
+    lpTokenHeldChanged,
+    frontendFeeTiers,
+    frontendFeeTiersChanged,
+    sellTokenInfoChanged,
+    primaryTokenInfoChanged,
+  } = useSwap()
   const lpTokenHeld = useBalance({wallet, tokenId: aggregatorTokenId})
+
+  // initialize sell with / and primary token
+  React.useEffect(() => {
+    const ptInfo = {
+      decimals: wallet.primaryTokenInfo.decimals ?? 0,
+      id: wallet.primaryTokenInfo.id,
+    }
+    sellTokenInfoChanged(ptInfo)
+    primaryTokenInfoChanged(ptInfo)
+  }, [primaryTokenInfoChanged, sellTokenInfoChanged, wallet.primaryTokenInfo.decimals, wallet.primaryTokenInfo.id])
 
   // update the fee tiers
   React.useEffect(() => {

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditBuyAmount/SelectBuyTokenFromListScreen/SelectBuyTokenFromListScreen.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditBuyAmount/SelectBuyTokenFromListScreen/SelectBuyTokenFromListScreen.tsx
@@ -134,7 +134,7 @@ type SelectableTokenProps = {
 const SelectableToken = ({wallet, token, walletTokenIds}: SelectableTokenProps) => {
   const balanceAvailable = useBalance({wallet, tokenId: token.info.id})
   const {closeSearch} = useSearch()
-  const {buyTokenIdChanged, orderData} = useSwap()
+  const {buyTokenInfoChanged, orderData} = useSwap()
   const {
     sellQuantity: {isTouched: isSellTouched},
     buyTouched,
@@ -150,7 +150,10 @@ const SelectableToken = ({wallet, token, walletTokenIds}: SelectableTokenProps) 
     track.swapAssetToChanged({
       to_asset: [{asset_name: token.info.name, asset_ticker: token.info.ticker, policy_id: token.info.group}],
     })
-    buyTokenIdChanged(token.info.id)
+    buyTokenInfoChanged({
+      decimals: token.info.decimals ?? 0,
+      id: token.info.id,
+    })
     buyTouched()
     navigateTo.startSwap()
     closeSearch()

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditSellAmount/SelectSellTokenFromListScreen/SelectSellTokenFromListScreen.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditSellAmount/SelectSellTokenFromListScreen/SelectSellTokenFromListScreen.tsx
@@ -88,7 +88,7 @@ const TokenList = () => {
 type SelectableTokenProps = {disabled?: boolean; tokenInfo: Balance.TokenInfo; wallet: YoroiWallet}
 const SelectableToken = ({tokenInfo, wallet}: SelectableTokenProps) => {
   const {closeSearch} = useSearch()
-  const {sellTokenIdChanged, orderData} = useSwap()
+  const {sellTokenInfoChanged, orderData} = useSwap()
   const {
     buyQuantity: {isTouched: isBuyTouched},
     sellTouched,
@@ -104,7 +104,10 @@ const SelectableToken = ({tokenInfo, wallet}: SelectableTokenProps) => {
       from_asset: [{asset_name: tokenInfo.name, asset_ticker: tokenInfo.ticker, policy_id: tokenInfo.group}],
     })
     sellTouched()
-    sellTokenIdChanged(tokenInfo.id)
+    sellTokenInfoChanged({
+      id: tokenInfo.id,
+      decimals: tokenInfo.decimals ?? 0,
+    })
     navigateTo.startSwap()
     closeSearch()
   }

--- a/packages/swap/src/helpers/orders/costs/getFrontendFee.test.ts
+++ b/packages/swap/src/helpers/orders/costs/getFrontendFee.test.ts
@@ -21,8 +21,7 @@ describe('getFrontendFee', () => {
       // act
       const fee = getFrontendFee({
         lpTokenHeld: {tokenId: 'lp.token', quantity: '999999999999999999'},
-        sellInPrimaryTokenValue: sell,
-        primaryTokenId,
+        ptAmount: sell,
         feeTiers: milkHoldersDiscountTiers,
       })
       // assert
@@ -43,9 +42,8 @@ describe('getFrontendFee', () => {
       }
       // act
       const fee = getFrontendFee({
-        sellInPrimaryTokenValue: sellPrimaryAmountOver99,
+        ptAmount: sellPrimaryAmountOver99,
         lpTokenHeld: {tokenId: 'lp.token', quantity: Quantities.zero},
-        primaryTokenId,
         feeTiers: milkHoldersDiscountTiers,
       })
       // assert
@@ -67,8 +65,7 @@ describe('getFrontendFee', () => {
       // act
       const fee = getFrontendFee({
         lpTokenHeld: {tokenId: 'lp.token', quantity: '499'},
-        sellInPrimaryTokenValue: sellPrimaryAmountOver99,
-        primaryTokenId,
+        ptAmount: sellPrimaryAmountOver99,
         feeTiers: milkHoldersDiscountTiers,
       })
       // assert
@@ -90,8 +87,7 @@ describe('getFrontendFee', () => {
       // act
       const fee = getFrontendFee({
         lpTokenHeld: {tokenId: 'lp.token', quantity: '500'},
-        sellInPrimaryTokenValue: sellPrimaryAmountOver99,
-        primaryTokenId,
+        ptAmount: sellPrimaryAmountOver99,
         feeTiers: milkHoldersDiscountTiers,
       })
       // assert
@@ -114,9 +110,8 @@ describe('getFrontendFee', () => {
       }
       // act
       const fee = getFrontendFee({
-        sellInPrimaryTokenValue: buyPrimaryTokenAmount,
+        ptAmount: buyPrimaryTokenAmount,
         lpTokenHeld: {tokenId: 'lp.token', quantity: '999999999999999999'},
-        primaryTokenId,
         feeTiers: milkHoldersDiscountTiers,
       })
       // assert
@@ -137,9 +132,8 @@ describe('getFrontendFee', () => {
       }
       // act
       const fee = getFrontendFee({
-        sellInPrimaryTokenValue: buyPrimaryAmountOver99,
+        ptAmount: buyPrimaryAmountOver99,
         lpTokenHeld: {tokenId: 'lp.token', quantity: Quantities.zero},
-        primaryTokenId,
         feeTiers: milkHoldersDiscountTiers,
       })
       // assert
@@ -161,8 +155,7 @@ describe('getFrontendFee', () => {
       // act
       const fee = getFrontendFee({
         lpTokenHeld: {tokenId: 'lp.token', quantity: '499'},
-        sellInPrimaryTokenValue: buyPrimaryAmountOver99,
-        primaryTokenId,
+        ptAmount: buyPrimaryAmountOver99,
         feeTiers: milkHoldersDiscountTiers,
       })
       // assert
@@ -184,8 +177,7 @@ describe('getFrontendFee', () => {
       // act
       const fee = getFrontendFee({
         lpTokenHeld: {tokenId: 'lp.token', quantity: '500'},
-        sellInPrimaryTokenValue: buyPrimaryAmountOver99,
-        primaryTokenId,
+        ptAmount: buyPrimaryAmountOver99,
         feeTiers: milkHoldersDiscountTiers,
       })
       // assert
@@ -207,8 +199,7 @@ describe('getFrontendFee', () => {
     // act
     const fee = getFrontendFee({
       lpTokenHeld: {tokenId: 'lp.token', quantity: '999999999999999'},
-      sellInPrimaryTokenValue: buyPrimaryAmountOver99,
-      primaryTokenId,
+      ptAmount: buyPrimaryAmountOver99,
       feeTiers: [],
     })
     // assert
@@ -230,8 +221,7 @@ describe('getFrontendFee', () => {
     // act
     const fee = getFrontendFee({
       lpTokenHeld: {tokenId: 'lp.token', quantity: '999999999999999'},
-      sellInPrimaryTokenValue: buyPrimaryAmountOver99,
-      primaryTokenId,
+      ptAmount: buyPrimaryAmountOver99,
       feeTiers: [
         {
           fixedFee: asQuantity(3_000_000),
@@ -265,9 +255,8 @@ describe('getFrontendFee', () => {
       }
       // act
       const fee = getFrontendFee({
-        sellInPrimaryTokenValue: sellValueInPrimaryToken,
+        ptAmount: sellValueInPrimaryToken,
         lpTokenHeld: {tokenId: 'lp.token', quantity: '999999999999999999'},
-        primaryTokenId,
         feeTiers: milkHoldersDiscountTiers,
       })
       // assert
@@ -287,9 +276,8 @@ describe('getFrontendFee', () => {
       }
       // act
       const fee = getFrontendFee({
-        sellInPrimaryTokenValue: sellValueInPrimaryToken,
+        ptAmount: sellValueInPrimaryToken,
         lpTokenHeld: {tokenId: 'lp.token', quantity: Quantities.zero},
-        primaryTokenId,
         feeTiers: milkHoldersDiscountTiers,
       })
       // assert
@@ -311,8 +299,7 @@ describe('getFrontendFee', () => {
       // act
       const fee = getFrontendFee({
         lpTokenHeld: {tokenId: 'lp.token', quantity: '499'},
-        sellInPrimaryTokenValue: sellValueInPrimaryToken,
-        primaryTokenId,
+        ptAmount: sellValueInPrimaryToken,
         feeTiers: milkHoldersDiscountTiers,
       })
       // assert
@@ -334,8 +321,7 @@ describe('getFrontendFee', () => {
       // act
       const fee = getFrontendFee({
         lpTokenHeld: {tokenId: 'lp.token', quantity: '500'},
-        sellInPrimaryTokenValue: sellValueInPrimaryToken,
-        primaryTokenId,
+        ptAmount: sellValueInPrimaryToken,
         feeTiers: milkHoldersDiscountTiers,
       })
       // assert

--- a/packages/swap/src/helpers/orders/costs/getFrontendFee.ts
+++ b/packages/swap/src/helpers/orders/costs/getFrontendFee.ts
@@ -16,14 +16,12 @@ import {asQuantity} from '../../../utils/asQuantity'
  */
 export const getFrontendFee = ({
   lpTokenHeld,
-  primaryTokenId,
-  sellInPrimaryTokenValue,
+  ptAmount,
   feeTiers,
 }: {
-  primaryTokenId: Balance.TokenInfo['id']
   lpTokenHeld?: Balance.Amount
   feeTiers: ReadonlyArray<App.FrontendFeeTier>
-  sellInPrimaryTokenValue: Balance.Amount
+  ptAmount: Balance.Amount
 }): Readonly<{
   fee: Balance.Amount
   discountTier: App.FrontendFeeTier | undefined
@@ -36,21 +34,21 @@ export const getFrontendFee = ({
         tier.secondaryTokenBalanceThreshold,
       ) &&
       Quantities.isGreaterThanOrEqualTo(
-        sellInPrimaryTokenValue.quantity,
+        ptAmount.quantity,
         tier.primaryTokenValueThreshold,
       ),
   )
 
   // calculate the fee
   const fee = asQuantity(
-    new BigNumber(sellInPrimaryTokenValue.quantity)
+    new BigNumber(ptAmount.quantity)
       .times(discountTier?.variableFeeMultiplier ?? 0)
       .integerValue(BigNumber.ROUND_CEIL)
       .plus(discountTier?.fixedFee ?? 0),
   )
 
   return {
-    fee: {tokenId: primaryTokenId, quantity: fee},
+    fee: {tokenId: ptAmount.tokenId, quantity: fee},
     discountTier,
   } as const
 }

--- a/packages/swap/src/helpers/orders/factories/makeOrderCalculations.test.ts
+++ b/packages/swap/src/helpers/orders/factories/makeOrderCalculations.test.ts
@@ -3389,4 +3389,126 @@ describe('makeOrderCalculations', () => {
     }
     expect(calculations[0]).toStrictEqual(expectedCalculation)
   })
+  it('should calculate fees and amounts correctly (case 28, pt at buy side)', () => {
+    const pool: Swap.Pool = mocks.mockedPools7[1]!
+    const pools = [pool]
+    const amounts = {
+      sell: {
+        quantity: '1000000',
+        tokenId: 'tokenB',
+      } as Balance.Amount,
+      buy: {
+        quantity: '0',
+        tokenId: 'tokenA',
+      } as Balance.Amount,
+    }
+    const slippage = 0
+    const calculations = makeOrderCalculations({
+      orderType: 'market',
+      amounts: amounts,
+      limitPrice: undefined,
+      slippage: slippage,
+      pools: pools,
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: 'tokenA',
+        },
+        priceDenomination: 0,
+      },
+      lpTokenHeld: {
+        quantity: '50',
+        tokenId: 'tokenX',
+      },
+      side: 'sell',
+      frontendFeeTiers,
+    })
+    const expectedCalculation: SwapOrderCalculation = {
+      order: {
+        side: 'sell',
+        slippage: 0,
+        orderType: 'market',
+        limitPrice: undefined,
+        amounts: {
+          sell: {
+            quantity: '1000000',
+            tokenId: 'tokenB',
+          },
+          buy: {
+            quantity: '0',
+            tokenId: 'tokenA',
+          },
+        },
+        lpTokenHeld: {
+          quantity: '50',
+          tokenId: 'tokenX',
+        },
+      },
+      sides: {
+        sell: {
+          quantity: '1000000',
+          tokenId: 'tokenB',
+        },
+        buy: {
+          quantity: '199',
+          tokenId: 'tokenA',
+        },
+      },
+      cost: {
+        batcherFee: {
+          quantity: '0',
+          tokenId: '',
+        },
+        deposit: {
+          quantity: '0',
+          tokenId: '',
+        },
+        frontendFeeInfo: {
+          discountTier: undefined,
+          fee: {
+            quantity: '0',
+            tokenId: 'tokenA',
+          },
+        },
+        liquidityFee: {
+          quantity: '0',
+          tokenId: 'tokenB',
+        },
+        ptTotalFeeNoFEF: {
+          tokenId: 'tokenA',
+          quantity: '0',
+        },
+        ptTotalFee: {
+          tokenId: 'tokenA',
+          quantity: '0',
+        },
+      },
+      buyAmountWithSlippage: {
+        quantity: '199',
+        tokenId: 'tokenA',
+      },
+      hasSupply: true,
+      prices: {
+        base: '0.5',
+        market: '0.5',
+        withSlippage: '5025.12562814070351758794',
+        withFees: '5025.12562814070351758794',
+        withFeesAndSlippage: '5025.12562814070351758794',
+        difference: '1004925.125628140703517588',
+        withFeesNoFEF: '5025.12562814070351758794',
+        withFeesAndSlippageNoFEF: '5025.12562814070351758794',
+        differenceNoFEF: '1004925.125628140703517588',
+      },
+      pool: pool,
+    }
+    expect(calculations[0]).toStrictEqual(expectedCalculation)
+  })
 })

--- a/packages/swap/src/helpers/orders/factories/makeOrderCalculations.test.ts
+++ b/packages/swap/src/helpers/orders/factories/makeOrderCalculations.test.ts
@@ -30,7 +30,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: undefined,
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: undefined,
       side: 'sell',
       frontendFeeTiers,
@@ -148,7 +162,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: undefined,
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: undefined,
       side: 'sell',
       frontendFeeTiers,
@@ -257,7 +285,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: undefined,
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: undefined,
       side: 'buy',
       frontendFeeTiers,
@@ -375,7 +417,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: undefined,
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: undefined,
       side: 'buy',
       frontendFeeTiers,
@@ -493,7 +549,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: undefined,
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: undefined,
       side: 'sell',
       frontendFeeTiers,
@@ -606,7 +676,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: undefined,
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: undefined,
       side: 'sell',
       frontendFeeTiers,
@@ -719,7 +803,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: undefined,
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: undefined,
       side: 'sell',
       frontendFeeTiers,
@@ -832,7 +930,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: undefined,
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: undefined,
       side: 'buy',
       frontendFeeTiers,
@@ -945,7 +1057,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: undefined,
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: undefined,
       side: 'sell',
       frontendFeeTiers,
@@ -1058,7 +1184,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: undefined,
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: undefined,
       side: 'sell',
       frontendFeeTiers,
@@ -1171,7 +1311,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: undefined,
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: undefined,
       side: 'buy',
       frontendFeeTiers,
@@ -1284,7 +1438,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: undefined,
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: undefined,
       side: 'buy',
       frontendFeeTiers,
@@ -1397,7 +1565,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: undefined,
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: undefined,
       side: 'sell',
       frontendFeeTiers,
@@ -1510,7 +1692,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: undefined,
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: undefined,
       side: 'sell',
       frontendFeeTiers,
@@ -1623,7 +1819,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: undefined,
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: undefined,
       side: 'buy',
       frontendFeeTiers,
@@ -1736,7 +1946,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: undefined,
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: undefined,
       side: 'buy',
       frontendFeeTiers,
@@ -1849,7 +2073,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: '2',
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: undefined,
       side: 'buy',
       frontendFeeTiers,
@@ -1952,7 +2190,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: '2',
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: undefined,
       side: 'sell',
       frontendFeeTiers,
@@ -2055,7 +2307,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: '2',
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: undefined,
       side: 'buy',
       frontendFeeTiers,
@@ -2158,7 +2424,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: '2',
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: undefined,
       side: 'sell',
       frontendFeeTiers,
@@ -2261,7 +2541,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: '1',
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: undefined,
       side: 'sell',
       frontendFeeTiers,
@@ -2364,7 +2658,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: '1',
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: {
         quantity: '50',
         tokenId: 'tokenX',
@@ -2478,7 +2786,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: '1',
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: {
         quantity: '100',
         tokenId: 'tokenX',
@@ -2592,7 +2914,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: '1',
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: {
         quantity: '500',
         tokenId: 'tokenX',
@@ -2706,7 +3042,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: '1',
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: {
         quantity: '50',
         tokenId: 'tokenX',
@@ -2815,7 +3165,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: '1',
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: {
         quantity: '50',
         tokenId: 'tokenX',
@@ -2923,7 +3287,21 @@ describe('makeOrderCalculations', () => {
       limitPrice: undefined,
       slippage: slippage,
       pools: pools,
-      primaryTokenId: '',
+      tokens: {
+        sellInfo: {
+          decimals: 0,
+          id: 'tokenB',
+        },
+        buyInfo: {
+          decimals: 0,
+          id: 'tokenA',
+        },
+        ptInfo: {
+          decimals: 6,
+          id: '',
+        },
+        priceDenomination: 0,
+      },
       lpTokenHeld: {
         quantity: '50',
         tokenId: 'tokenX',

--- a/packages/swap/src/helpers/orders/factories/makeOrderCalculations.ts
+++ b/packages/swap/src/helpers/orders/factories/makeOrderCalculations.ts
@@ -1,6 +1,9 @@
 import {App, Balance, Swap} from '@yoroi/types'
 import {BigNumber} from 'bignumber.js'
-import {SwapOrderCalculation} from '../../../translators/reactjs/state/state'
+import {
+  SwapOrderCalculation,
+  SwapState,
+} from '../../../translators/reactjs/state/state'
 import {getQuantityWithSlippage} from '../amounts/getQuantityWithSlippage'
 import {getLiquidityProviderFee} from '../costs/getLiquidityProviderFee'
 import {getFrontendFee} from '../costs/getFrontendFee'
@@ -16,10 +19,10 @@ export const makeOrderCalculations = ({
   limitPrice,
   slippage,
   pools,
-  primaryTokenId,
   lpTokenHeld,
   side,
   frontendFeeTiers,
+  tokens,
 }: Readonly<{
   orderType: Swap.OrderType
   amounts: {
@@ -30,9 +33,9 @@ export const makeOrderCalculations = ({
   pools: ReadonlyArray<Swap.Pool>
   lpTokenHeld?: Balance.Amount
   slippage: number
-  primaryTokenId: Balance.TokenInfo['id']
   side?: 'buy' | 'sell'
   frontendFeeTiers: ReadonlyArray<App.FrontendFeeTier>
+  tokens: SwapState['orderData']['tokens']
 }>): Array<SwapOrderCalculation> => {
   const isLimit = orderType === 'limit'
   const maybeLimitPrice = isLimit ? limitPrice : undefined
@@ -77,9 +80,9 @@ export const makeOrderCalculations = ({
     // TODO: it needs update, prices by muesli are provided in ADA, quantities in atomic units
     const frontendFeeInfo = getFrontendFee({
       lpTokenHeld,
-      primaryTokenId,
+      primaryTokenId: tokens.ptInfo.id,
       sellInPrimaryTokenValue: {
-        tokenId: primaryTokenId,
+        tokenId: tokens.ptInfo.id,
         quantity: ptPriceSell.isZero()
           ? Quantities.zero
           : asQuantity(
@@ -166,7 +169,7 @@ export const makeOrderCalculations = ({
     } = calculatePricesWithFees({withFrontendFee: false})
 
     const ptTotalFee: Balance.Amount = {
-      tokenId: primaryTokenId,
+      tokenId: tokens.ptInfo.id,
       quantity: Quantities.sum([
         pool.batcherFee.quantity,
         pool.deposit.quantity,
@@ -175,7 +178,7 @@ export const makeOrderCalculations = ({
     }
 
     const ptTotalFeeNoFEF: Balance.Amount = {
-      tokenId: primaryTokenId,
+      tokenId: tokens.ptInfo.id,
       quantity: Quantities.sum([
         pool.batcherFee.quantity,
         pool.deposit.quantity,

--- a/packages/swap/src/helpers/orders/factories/makeOrderCalculations.ts
+++ b/packages/swap/src/helpers/orders/factories/makeOrderCalculations.ts
@@ -39,6 +39,8 @@ export const makeOrderCalculations = ({
 }>): Array<SwapOrderCalculation> => {
   const isLimit = orderType === 'limit'
   const maybeLimitPrice = isLimit ? limitPrice : undefined
+  const isSellPt = amounts.sell.tokenId === tokens.ptInfo.id
+  const isBuyPt = amounts.buy.tokenId === tokens.ptInfo.id
 
   const calculations = pools.map<SwapOrderCalculation>((pool) => {
     const buy =
@@ -60,8 +62,9 @@ export const makeOrderCalculations = ({
       tokenId: buy.tokenId,
     }
 
-    // pools that with not enough supply will be filtered out
     const isBuyTokenA = buy.tokenId === pool.tokenA.tokenId
+
+    // pools that with not enough supply will be filtered out
     const poolSupply = isBuyTokenA ? pool.tokenA.quantity : pool.tokenB.quantity
     const supplyRequired =
       (!Quantities.isZero(buy.quantity) || !Quantities.isZero(sell.quantity)) &&
@@ -72,24 +75,32 @@ export const makeOrderCalculations = ({
     // lf is sell side % of quantity ie. XToken 100 * 1% = 1 XToken
     const liquidityFee: Balance.Amount = getLiquidityProviderFee(pool.fee, sell)
 
+    // whether sell or buy is PT, then we use the quantity as frontend fee base
+    // otherwise we derive from the ptPrice of the pool of the sell side
     const ptPriceSell = isBuyTokenA
       ? new BigNumber(pool.ptPriceTokenB)
       : new BigNumber(pool.ptPriceTokenA)
+    const sellQuantity = new BigNumber(sell.quantity)
+    const sellPrice = new BigNumber(ptPriceSell)
+    const sellInPtTerms = ptPriceSell.isZero()
+      ? Quantities.zero
+      : asQuantity(
+          sellQuantity
+            .dividedBy(new BigNumber(1).dividedBy(sellPrice))
+            .toString(),
+        )
+    const ptQuantity = isSellPt
+      ? sell.quantity
+      : isBuyPt
+      ? buy.quantity
+      : sellInPtTerms
 
-    // ffee is based on PT value range + LP holding range (sides may need conversion, when none is PT)
-    // TODO: it needs update, prices by muesli are provided in ADA, quantities in atomic units
+    // ffee is based on PT value range + LP holding range
     const frontendFeeInfo = getFrontendFee({
       lpTokenHeld,
-      primaryTokenId: tokens.ptInfo.id,
-      sellInPrimaryTokenValue: {
+      ptAmount: {
         tokenId: tokens.ptInfo.id,
-        quantity: ptPriceSell.isZero()
-          ? Quantities.zero
-          : asQuantity(
-              new BigNumber(sell.quantity)
-                .dividedBy(ptPriceSell)
-                .integerValue(BigNumber.ROUND_CEIL),
-            ),
+        quantity: ptQuantity,
       },
       feeTiers: frontendFeeTiers,
     })
@@ -101,12 +112,14 @@ export const makeOrderCalculations = ({
         ? Quantities.zero
         : new BigNumber(pool.batcherFee.quantity)
             .dividedBy(ptPriceSell)
-            .integerValue(BigNumber.ROUND_CEIL),
+            .integerValue(BigNumber.ROUND_CEIL)
+            .toString(),
       frontendFee: ptPriceSell.isZero()
         ? Quantities.zero
         : new BigNumber(frontendFeeInfo.fee.quantity)
             .dividedBy(ptPriceSell)
-            .integerValue(BigNumber.ROUND_CEIL),
+            .integerValue(BigNumber.ROUND_CEIL)
+            .toString(),
     }
 
     const priceWithSlippage = Quantities.isZero(buyAmountWithSlippage.quantity)

--- a/packages/swap/src/translators/reactjs/provider/SwapProvider.test.tsx
+++ b/packages/swap/src/translators/reactjs/provider/SwapProvider.test.tsx
@@ -466,7 +466,7 @@ describe('SwapProvider', () => {
     })
   })
 
-  it('BuyTokenIdChanged', () => {
+  it('BuyTokenInfoChanged', () => {
     const initialState: SwapState = {
       orderData: {
         ...defaultSwapState.orderData,
@@ -479,6 +479,21 @@ describe('SwapProvider', () => {
             quantity: '20',
             tokenId: 'policyId.buy',
           },
+        },
+        tokens: {
+          sellInfo: {
+            decimals: 6,
+            id: 'policyId.sell',
+          },
+          buyInfo: {
+            decimals: 6,
+            id: 'policyId.buy',
+          },
+          ptInfo: {
+            decimals: 6,
+            id: '',
+          },
+          priceDenomination: 0,
         },
       },
       unsignedTx: undefined,
@@ -496,16 +511,24 @@ describe('SwapProvider', () => {
     })
 
     act(() => {
-      result.current.buyTokenIdChanged('new.token')
+      result.current.buyTokenInfoChanged({
+        decimals: 4,
+        id: 'new.token',
+      })
     })
 
     expect(result.current.orderData.amounts.buy).toEqual({
       quantity: '20',
       tokenId: 'new.token',
     })
+    expect(result.current.orderData.tokens.buyInfo).toEqual({
+      decimals: 4,
+      id: 'new.token',
+    })
+    expect(result.current.orderData.tokens.priceDenomination).toBe(2)
   })
 
-  it('SellTokenIdChanged', () => {
+  it('SellTokenInfoChanged', () => {
     const initialState: SwapState = {
       orderData: {
         ...defaultSwapState.orderData,
@@ -518,6 +541,21 @@ describe('SwapProvider', () => {
             quantity: '20',
             tokenId: 'policyId.buy',
           },
+        },
+        tokens: {
+          sellInfo: {
+            decimals: 6,
+            id: 'policyId.sell',
+          },
+          buyInfo: {
+            decimals: 6,
+            id: 'policyId.buy',
+          },
+          ptInfo: {
+            decimals: 6,
+            id: '',
+          },
+          priceDenomination: 0,
         },
       },
       unsignedTx: undefined,
@@ -535,13 +573,21 @@ describe('SwapProvider', () => {
     })
 
     act(() => {
-      result.current.sellTokenIdChanged('new.token')
+      result.current.sellTokenInfoChanged({
+        decimals: 4,
+        id: 'new.token',
+      })
     })
 
     expect(result.current.orderData.amounts.sell).toEqual({
       quantity: '10',
       tokenId: 'new.token',
     })
+    expect(result.current.orderData.tokens.sellInfo).toEqual({
+      decimals: 4,
+      id: 'new.token',
+    })
+    expect(result.current.orderData.tokens.priceDenomination).toBe(-2)
   })
 
   it('PoolPairsChanged', () => {
@@ -590,10 +636,16 @@ describe('SwapProvider', () => {
     })
 
     act(() => {
-      result.current.primaryTokenIdChanged('primary.tokenId')
+      result.current.primaryTokenInfoChanged({
+        decimals: 6,
+        id: 'primary.tokenId',
+      })
     })
 
-    expect(result.current.orderData.primartyTokenId).toEqual('primary.tokenId')
+    expect(result.current.orderData.tokens.ptInfo).toEqual({
+      decimals: 6,
+      id: 'primary.tokenId',
+    })
   })
 
   it('FrontendFeeTiersChanged', () => {

--- a/packages/swap/src/translators/reactjs/provider/SwapProvider.tsx
+++ b/packages/swap/src/translators/reactjs/provider/SwapProvider.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {App, Balance, Swap} from '@yoroi/types'
+import {App, Balance, RemoveUndefined, Swap} from '@yoroi/types'
 
 import {
   SwapActionType,
@@ -79,17 +79,29 @@ export const SwapProvider = ({
     lpTokenHeldChanged: (amount: Balance.Amount | undefined) => {
       dispatch({type: SwapCreateOrderActionType.LpTokenHeldChanged, amount})
     },
-    buyTokenIdChanged: (tokenId: Balance.TokenInfo['id']) => {
-      dispatch({type: SwapCreateOrderActionType.BuyTokenIdChanged, tokenId})
+    buyTokenInfoChanged: (
+      tokenInfo: RemoveUndefined<Pick<Balance.TokenInfo, 'decimals' | 'id'>>,
+    ) => {
+      dispatch({type: SwapCreateOrderActionType.BuyTokenInfoChanged, tokenInfo})
     },
-    sellTokenIdChanged: (tokenId: Balance.TokenInfo['id']) => {
-      dispatch({type: SwapCreateOrderActionType.SellTokenIdChanged, tokenId})
+    sellTokenInfoChanged: (
+      tokenInfo: RemoveUndefined<Pick<Balance.TokenInfo, 'decimals' | 'id'>>,
+    ) => {
+      dispatch({
+        type: SwapCreateOrderActionType.SellTokenInfoChanged,
+        tokenInfo,
+      })
     },
     poolPairsChanged: (pools: ReadonlyArray<Swap.Pool>) => {
       dispatch({type: SwapCreateOrderActionType.PoolPairsChanged, pools})
     },
-    primaryTokenIdChanged: (tokenId: Balance.TokenInfo['id']) => {
-      dispatch({type: SwapCreateOrderActionType.PrimaryTokenIdChanged, tokenId})
+    primaryTokenInfoChanged: (
+      tokenInfo: RemoveUndefined<Pick<Balance.TokenInfo, 'decimals' | 'id'>>,
+    ) => {
+      dispatch({
+        type: SwapCreateOrderActionType.PrimaryTokenInfoChanged,
+        tokenInfo,
+      })
     },
     frontendFeeTiersChanged: (feeTiers: ReadonlyArray<App.FrontendFeeTier>) => {
       dispatch({

--- a/packages/swap/src/translators/reactjs/state/state.test.ts
+++ b/packages/swap/src/translators/reactjs/state/state.test.ts
@@ -326,11 +326,26 @@ describe('State Actions', () => {
     })
   })
 
-  describe('SellTokenIdChanged', () => {
+  describe('SellTokenInfoChanged', () => {
     it('should reset pools and the derived data', () => {
       const initialState = produce(mockSwapStateDefault, (draft) => {
         draft.orderData.amounts.sell.tokenId = 'tokenA'
         draft.orderData.amounts.buy.tokenId = 'tokenB'
+        draft.orderData.tokens = {
+          sellInfo: {
+            id: 'tokenA',
+            decimals: 6,
+          },
+          buyInfo: {
+            id: 'tokenB',
+            decimals: 6,
+          },
+          ptInfo: {
+            id: '',
+            decimals: 6,
+          },
+          priceDenomination: 0,
+        }
       })
       const updatedPools = combinedSwapReducers(initialState, {
         type: SwapCreateOrderActionType.PoolPairsChanged,
@@ -342,8 +357,11 @@ describe('State Actions', () => {
       })
 
       const state = combinedSwapReducers(updatedSellQuantity, {
-        type: SwapCreateOrderActionType.SellTokenIdChanged,
-        tokenId: 'x',
+        type: SwapCreateOrderActionType.SellTokenInfoChanged,
+        tokenInfo: {
+          id: 'x',
+          decimals: 6,
+        },
       })
 
       expect(state.orderData.amounts.sell.tokenId).toBe('x')
@@ -358,11 +376,26 @@ describe('State Actions', () => {
     })
   })
 
-  describe('BuyTokenIdChanged', () => {
+  describe('BuyTokenInfoChanged', () => {
     it('should reset pools and the derived data', () => {
       const initialState = produce(mockSwapStateDefault, (draft) => {
         draft.orderData.amounts.sell.tokenId = 'tokenA'
         draft.orderData.amounts.buy.tokenId = 'tokenB'
+        draft.orderData.tokens = {
+          sellInfo: {
+            id: 'tokenA',
+            decimals: 6,
+          },
+          buyInfo: {
+            id: 'tokenB',
+            decimals: 6,
+          },
+          ptInfo: {
+            id: '',
+            decimals: 6,
+          },
+          priceDenomination: 0,
+        }
       })
       const updatedPools = combinedSwapReducers(initialState, {
         type: SwapCreateOrderActionType.PoolPairsChanged,
@@ -374,8 +407,11 @@ describe('State Actions', () => {
       })
 
       const state = combinedSwapReducers(updatedSellQuantity, {
-        type: SwapCreateOrderActionType.BuyTokenIdChanged,
-        tokenId: 'x',
+        type: SwapCreateOrderActionType.BuyTokenInfoChanged,
+        tokenInfo: {
+          id: 'x',
+          decimals: 6,
+        },
       })
 
       expect(state.orderData.amounts.buy.tokenId).toBe('x')
@@ -512,12 +548,16 @@ describe('State Actions', () => {
 
   // NOTE: initialized only
   // designed to be triggered once only
-  it('PrimaryTokenIdChanged', () => {
+  it('PrimaryTokenInfoChanged', () => {
     const expectedState = combinedSwapReducers(mockSwapStateDefault, {
-      type: SwapCreateOrderActionType.PrimaryTokenIdChanged,
-      tokenId: 'brand.new',
+      type: SwapCreateOrderActionType.PrimaryTokenInfoChanged,
+      tokenInfo: {
+        id: 'brand.new',
+        decimals: 6,
+      },
     })
-    expect(expectedState.orderData.primartyTokenId).toBe('brand.new')
+    expect(expectedState.orderData.tokens.ptInfo.id).toBe('brand.new')
+    expect(expectedState.orderData.tokens.ptInfo.decimals).toBe(6)
   })
 
   it('LpTokenHeldChanged', () => {

--- a/packages/types/src/helpers/types.ts
+++ b/packages/types/src/helpers/types.ts
@@ -2,3 +2,6 @@ export type Nullable<T> = T | null | undefined
 export type Writable<T> = {
   -readonly [P in keyof T]: T[P] extends object ? Writable<T[P]> : T[P]
 }
+export type RemoveUndefined<T> = {
+  [K in keyof T]-?: Exclude<T[K], undefined>
+}


### PR DESCRIPTION
- [x] Add partial token info to the state
- [x] Update the actions on UI 
- [x] Apply the denomination on frontend fee calcs

--- 

Later the Portfolio manager will change it, and the amounts will carry all info required, for now adding extra data to state

Relates to YOMO-902

---

Prices pre-calc are incorrect it can't be used yet, when adding fees (fees are in Lovelace) it needs conversion when adding it counting as non pt. I.e how much 2 ADA would be as MIN. (apples + bananas)