### PR TITLE
Fix: limit with undefined price

### DIFF
--- a/apps/wallet-mobile/src/features/Swap/common/SelectPool/SelectPoolFromList/SelectPoolFromList.tsx
+++ b/apps/wallet-mobile/src/features/Swap/common/SelectPool/SelectPoolFromList/SelectPoolFromList.tsx
@@ -58,7 +58,7 @@ export const SelectPoolFromList = ({pools = []}: Props) => {
         )
         const formattedTvl = Quantities.format(tvl, decimals, 0)
         const formattedBatcherFeeInPt = Quantities.format(pool.batcherFee.quantity, decimals, decimals)
-        const marketPrice = getMarketPrice(pool, orderData.amounts.sell)
+        const marketPrice = getMarketPrice(pool, orderData.amounts.sell.tokenId)
 
         return (
           <View key={pool.poolId}>

--- a/packages/swap/src/helpers/orders/amounts/getBuyAmount.test.ts
+++ b/packages/swap/src/helpers/orders/amounts/getBuyAmount.test.ts
@@ -27,9 +27,17 @@ describe('getBuyAmount', () => {
     expect(result.quantity).toBe('197')
     expect(result.tokenId).toBe('tokenB')
 
-    const limitedResult = getBuyAmount(pool, sell, '2.1')
+    const limitedResult = getBuyAmount(pool, sell, true, '2.1')
     expect(limitedResult.quantity).toBe('47')
     expect(limitedResult.tokenId).toBe('tokenB')
+
+    const zeroLimitResult = getBuyAmount(
+      {...pool, tokenA: {quantity: '0', tokenId: 'tokenA'}},
+      sell,
+      true,
+    )
+    expect(zeroLimitResult.quantity).toBe('0')
+    expect(zeroLimitResult.tokenId).toBe('tokenB')
   })
 
   it('should calculate the correct buy amount when selling tokenA (muesli example)', () => {
@@ -56,7 +64,7 @@ describe('getBuyAmount', () => {
     expect(result.quantity).toBe('136')
     expect(result.tokenId).toBe('tokenB')
 
-    const limitedResult = getBuyAmount(pool, sell, '2.1')
+    const limitedResult = getBuyAmount(pool, sell, true, '2.1')
     //expect(limitedResult.quantity).toBe('47')
     expect(limitedResult.tokenId).toBe('tokenB')
   })
@@ -85,7 +93,7 @@ describe('getBuyAmount', () => {
     expect(result.quantity).toBe('49')
     expect(result.tokenId).toBe('tokenA')
 
-    const limitedResult = getBuyAmount(pool, sell, '2.1')
+    const limitedResult = getBuyAmount(pool, sell, true, '2.1')
     expect(limitedResult.quantity).toBe('47')
     expect(limitedResult.tokenId).toBe('tokenA')
   })
@@ -110,11 +118,11 @@ describe('getBuyAmount', () => {
       quantity: '100',
       tokenId: 'tokenA',
     }
-    const limitResult = getBuyAmount(pool, sell, undefined, true)
+    const limitResult = getBuyAmount(pool, sell, true)
     const marketResult = getBuyAmount(pool, sell)
 
     // buy more (fee not included)
-    expect(limitResult.quantity).toBe('999')
+    expect(limitResult.quantity).toBe('1000')
     expect(limitResult.tokenId).toBe('tokenB')
 
     // buy less (fee included)

--- a/packages/swap/src/helpers/orders/amounts/getBuyAmount.ts
+++ b/packages/swap/src/helpers/orders/amounts/getBuyAmount.ts
@@ -12,7 +12,7 @@ import {getMarketPrice} from '../../prices/getMarketPrice'
  * @param pool - The liquidity pool.
  * @param sell - The desired sell amount.
  * @param isLimit - Optional limit type.
- * @param limit - Limit value, required if isLimit is true.
+ * @param limit - Optional limit price
  *
  * @returns The calculated buy amount
  * if the balance in the pool is insuficient it wont throw an error

--- a/packages/swap/src/helpers/orders/amounts/getSellAmount.test.ts
+++ b/packages/swap/src/helpers/orders/amounts/getSellAmount.test.ts
@@ -31,9 +31,17 @@ describe('getSellAmount', () => {
     expect(zeroResult.quantity).toBe('0')
     expect(zeroResult.tokenId).toBe('tokenB')
 
-    const limitedResult = getSellAmount(pool, buy, '2.1')
+    const limitedResult = getSellAmount(pool, buy, true, '2.1')
     expect(limitedResult.quantity).toBe('210')
     expect(limitedResult.tokenId).toBe('tokenB')
+
+    const zeroLimitResult = getSellAmount(
+      {...pool, tokenA: {quantity: '0', tokenId: 'tokenA'}},
+      buy,
+      true,
+    )
+    expect(zeroLimitResult.quantity).toBe('0')
+    expect(zeroLimitResult.tokenId).toBe('tokenB')
   })
 
   it('should calculate the correct sell amount when buying tokenB', () => {
@@ -60,7 +68,7 @@ describe('getSellAmount', () => {
     expect(result.quantity).toBe('53')
     expect(result.tokenId).toBe('tokenA')
 
-    const limitedResult = getSellAmount(pool, buy, '2.1')
+    const limitedResult = getSellAmount(pool, buy, true, '2.1')
     expect(limitedResult.quantity).toBe('210')
     expect(limitedResult.tokenId).toBe('tokenA')
   })
@@ -110,11 +118,11 @@ describe('getSellAmount', () => {
       quantity: '100',
       tokenId: 'tokenA',
     }
-    const limitResult = getSellAmount(pool, buy, undefined, true)
+    const limitResult = getSellAmount(pool, buy, true)
     const marketResult = getSellAmount(pool, buy)
 
     // need less on sell side (fee is not included)
-    expect(limitResult.quantity).toBe('1002')
+    expect(limitResult.quantity).toBe('1000')
     expect(limitResult.tokenId).toBe('tokenB')
 
     // need more on sell side (fee is included)

--- a/packages/swap/src/helpers/orders/amounts/getSellAmount.ts
+++ b/packages/swap/src/helpers/orders/amounts/getSellAmount.ts
@@ -12,7 +12,7 @@ import {getMarketPrice} from '../../prices/getMarketPrice'
  * @param pool - The liquidity pool.
  * @param buy - The desired buy amount.
  * @param isLimit - Optional limit type.
- * @param limit - Limit value, required if isLimit is true.
+ * @param limit - Optional limit price.
  *
  * @returns The calculated sell amount
  * if the balance in the pool is insuficient it wont throw an error

--- a/packages/swap/src/helpers/orders/amounts/getSellAmount.ts
+++ b/packages/swap/src/helpers/orders/amounts/getSellAmount.ts
@@ -4,13 +4,15 @@ import {Balance, Swap} from '@yoroi/types'
 import {ceilDivision} from '../../../utils/ceilDivision'
 import {Quantities} from '../../../utils/quantities'
 import {asQuantity} from '../../../utils/asQuantity'
+import {getMarketPrice} from '../../prices/getMarketPrice'
 
 /**
  * Calculate the amount to sell based on the desired buy amount in a liquidity pool.
  *
  * @param pool - The liquidity pool.
  * @param buy - The desired buy amount.
- * @param limit - Optional limit value.
+ * @param isLimit - Optional limit type.
+ * @param limit - Limit value, required if isLimit is true.
  *
  * @returns The calculated sell amount
  * if the balance in the pool is insuficient it wont throw an error
@@ -18,8 +20,8 @@ import {asQuantity} from '../../../utils/asQuantity'
 export const getSellAmount = (
   pool: Swap.Pool,
   buy: Balance.Amount,
-  limit?: Balance.Quantity,
   isLimit?: boolean,
+  limit: Balance.Quantity = Quantities.zero,
 ): Balance.Amount => {
   const isBuyTokenA = buy.tokenId === pool.tokenA.tokenId
 
@@ -28,16 +30,23 @@ export const getSellAmount = (
   if (Quantities.isZero(buy.quantity))
     return {tokenId, quantity: Quantities.zero}
 
-  if (!(!limit || Quantities.isZero(limit)))
+  if (isLimit) {
+    const limitPrice = Quantities.isZero(limit)
+      ? getMarketPrice(pool, tokenId)
+      : limit
+
     return {
       tokenId,
-      quantity: asQuantity(
-        new BigNumber(buy.quantity)
-          .times(new BigNumber(limit))
-          .integerValue(BigNumber.ROUND_CEIL)
-          .toString(),
-      ),
+      quantity: Quantities.isZero(limitPrice)
+        ? Quantities.zero
+        : asQuantity(
+            new BigNumber(buy.quantity)
+              .times(new BigNumber(limitPrice))
+              .integerValue(BigNumber.ROUND_CEIL)
+              .toString(),
+          ),
     }
+  }
 
   const A = BigInt(pool.tokenA.quantity)
   const B = BigInt(pool.tokenB.quantity)
@@ -46,8 +55,7 @@ export const getSellAmount = (
 
   const buyQuantity = BigInt(buy.quantity)
 
-  // if limit order for the initial price when limit is undefined
-  const fee = BigInt(100 * 1000) - BigInt(Number(isLimit ? 0 : pool.fee) * 1000)
+  const fee = BigInt(100 * 1000) - BigInt(Number(pool.fee) * 1000)
 
   const maxBuyQuantity =
     firstToken -

--- a/packages/swap/src/helpers/orders/factories/makeOrderCalculations.ts
+++ b/packages/swap/src/helpers/orders/factories/makeOrderCalculations.ts
@@ -43,14 +43,14 @@ export const makeOrderCalculations = ({
   const calculations = pools.map<SwapOrderCalculation>((pool) => {
     const buy =
       side === 'sell'
-        ? getBuyAmount(pool, amounts.sell, maybeLimitPrice, isLimit)
+        ? getBuyAmount(pool, amounts.sell, isLimit, maybeLimitPrice)
         : amounts.buy
     const sell =
       side === 'buy'
-        ? getSellAmount(pool, amounts.buy, maybeLimitPrice, isLimit)
+        ? getSellAmount(pool, amounts.buy, isLimit, maybeLimitPrice)
         : amounts.sell
 
-    const marketPrice = getMarketPrice(pool, sell)
+    const marketPrice = getMarketPrice(pool, sell.tokenId)
     // recalculate price base, limit is user's input, market from pool
     const priceBase = maybeLimitPrice ?? marketPrice
 

--- a/packages/swap/src/helpers/prices/getMarketPrice.test.ts
+++ b/packages/swap/src/helpers/prices/getMarketPrice.test.ts
@@ -24,7 +24,7 @@ describe('getMarketPrice', () => {
       quantity: '100',
       tokenId: 'tokenA',
     }
-    const result = getMarketPrice(pool, sell)
+    const result = getMarketPrice(pool, sell.tokenId)
     expect(result).toBe('0.5')
   })
 
@@ -49,7 +49,7 @@ describe('getMarketPrice', () => {
       quantity: '100',
       tokenId: 'tokenB',
     }
-    const result = getMarketPrice(pool, sell)
+    const result = getMarketPrice(pool, sell.tokenId)
     expect(result).toBe('2')
   })
 })

--- a/packages/swap/src/helpers/prices/getMarketPrice.ts
+++ b/packages/swap/src/helpers/prices/getMarketPrice.ts
@@ -7,15 +7,15 @@ import {asQuantity} from '../../utils/asQuantity'
  * Calculate the market price based on the desired sell amount in a liquidity pool.
  *
  * @param pool - The liquidity pool.
- * @param sell - The desired sell amount.
+ * @param sellTokenId - The desired sell token id.
  *
  * @returns The market price
  */
 export const getMarketPrice = (
   pool: Swap.Pool,
-  sell: Balance.Amount,
+  sellTokenId: string,
 ): Balance.Quantity => {
-  const isSellTokenA = sell.tokenId === pool.tokenA.tokenId
+  const isSellTokenA = sellTokenId === pool.tokenA.tokenId
 
   const A = new BigNumber(pool.tokenA.quantity)
   const B = new BigNumber(pool.tokenB.quantity)

--- a/packages/swap/src/translators/reactjs/state/state.test.ts
+++ b/packages/swap/src/translators/reactjs/state/state.test.ts
@@ -92,7 +92,7 @@ describe('State Actions', () => {
           ...mockSwapStateDefault.orderData,
           amounts: {
             sell: {
-              quantity: '10000',
+              quantity: '100',
               tokenId: 'tokenA',
             },
             buy: {
@@ -125,7 +125,7 @@ describe('State Actions', () => {
 
       expect(state.orderData.type).toBe('limit')
       expect(state.orderData.limitPrice).toBe('0.5')
-      expect(state.orderData.amounts.buy.quantity).toBe('198')
+      expect(state.orderData.amounts.buy.quantity).toBe('200')
 
       const actionMarket: SwapCreateOrderAction = {
         type: SwapCreateOrderActionType.OrderTypeChanged,
@@ -486,7 +486,7 @@ describe('State Actions', () => {
         })
         const updatedSellQuantity = combinedSwapReducers(updatedPools, {
           type: SwapCreateOrderActionType.SellQuantityChanged,
-          quantity: '10000',
+          quantity: '100',
         })
         const updatedType = combinedSwapReducers(updatedSellQuantity, {
           type: SwapCreateOrderActionType.OrderTypeChanged,


### PR DESCRIPTION
Edge cases on edge cases.

Use the same formula for limit calculation regardless of the limit price. If it's zero or undefined, calculate the market one for the pool. If it's also zero because there's no tvl, then return zero.

Refactored getMarketPrice to just ask for the sellTokenId, since that's all it needs and it makes it easier to use than asking for the sell amount.