### PR TITLE
fix: avoid calc same token selection

### DIFF
--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditBuyAmount/SelectBuyTokenFromListScreen/SelectBuyTokenFromListScreen.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditBuyAmount/SelectBuyTokenFromListScreen/SelectBuyTokenFromListScreen.tsx
@@ -144,16 +144,19 @@ const SelectableToken = ({wallet, tokenInfo, walletTokenIds}: SelectableTokenPro
 
   const isDisabled = id === orderData.amounts.sell.tokenId && isSellTouched
   const inUserWallet = walletTokenIds.includes(tokenInfo.id)
+  const isSameToken = id === orderData.amounts.buy.tokenId
 
   const handleOnTokenSelection = () => {
     track.swapAssetToChanged({
       to_asset: [{asset_name: name, asset_ticker: ticker, policy_id: group}],
     })
-    buyTokenInfoChanged({
-      decimals: decimals ?? 0,
-      id: id,
-    })
-    buyTouched()
+    if (!isSameToken) {
+      buyTokenInfoChanged({
+        decimals: decimals ?? 0,
+        id: id,
+      })
+      buyTouched()
+    }
     navigateTo.startSwap()
     closeSearch()
   }

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditSellAmount/SelectSellTokenFromListScreen/SelectSellTokenFromListScreen.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditSellAmount/SelectSellTokenFromListScreen/SelectSellTokenFromListScreen.tsx
@@ -98,16 +98,19 @@ const SelectableToken = ({tokenInfo, wallet}: SelectableTokenProps) => {
 
   const balanceAvailable = useBalance({wallet, tokenId: tokenInfo.id})
   const isDisabled = tokenInfo.id === orderData.amounts.buy.tokenId && isBuyTouched
+  const isSameToken = tokenInfo.id === orderData.amounts.sell.tokenId
 
   const handleOnTokenSelection = () => {
     track.swapAssetFromChanged({
       from_asset: [{asset_name: tokenInfo.name, asset_ticker: tokenInfo.ticker, policy_id: tokenInfo.group}],
     })
-    sellTouched()
-    sellTokenInfoChanged({
-      id: tokenInfo.id,
-      decimals: tokenInfo.decimals ?? 0,
-    })
+    if (!isSameToken) {
+      sellTouched()
+      sellTokenInfoChanged({
+        id: tokenInfo.id,
+        decimals: tokenInfo.decimals ?? 0,
+      })
+    }
     navigateTo.startSwap()
     closeSearch()
   }


### PR DESCRIPTION
 - avoid recalculation when selecting the same token

Relates to YOMO-924