### PR TITLE
fix(swap): Prevent page viewed event from accidentally firing

### DIFF
--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/ListOrders/OpenOrders.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/ListOrders/OpenOrders.tsx
@@ -86,6 +86,8 @@ export const OpenOrders = () => {
   const navigation = useNavigation()
 
   const trackSwapConfirmPageViewed = React.useCallback(() => {
+    // Closing a modal triggers this callback.
+    // https://github.com/Emurgo/yoroi/pull/2913
     const currentState = navigation.getState()
     const previousState = navigationRef.current
     if (currentState === previousState) return

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/ListOrders/OpenOrders.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/ListOrders/OpenOrders.tsx
@@ -1,10 +1,11 @@
-import {useFocusEffect} from '@react-navigation/native'
+import {useNavigation} from '@react-navigation/core'
+import {NavigationState, useFocusEffect} from '@react-navigation/native'
 import {FlashList} from '@shopify/flash-list'
 import {isString} from '@yoroi/common'
 import {useSwap, useSwapOrdersByStatusOpen} from '@yoroi/swap'
 import {Buffer} from 'buffer'
 import _ from 'lodash'
-import React from 'react'
+import React, {useRef} from 'react'
 import {useIntl} from 'react-intl'
 import {Alert, Linking, StyleSheet, TouchableOpacity, View} from 'react-native'
 
@@ -62,6 +63,7 @@ export const OpenOrders = () => {
     () => mapOpenOrders(orders, tokenInfos, numberLocale, Object.values(transactionsInfos)),
     [orders, tokenInfos, numberLocale, transactionsInfos],
   )
+  const navigationRef = useRef<NavigationState | null>(null)
 
   const {closeModal, openModal} = useModal()
 
@@ -81,11 +83,17 @@ export const OpenOrders = () => {
 
   const {track} = useMetrics()
 
-  useFocusEffect(
-    React.useCallback(() => {
-      track.swapConfirmedPageViewed({swap_tab: 'Open Orders'})
-    }, [track]),
-  )
+  const navigation = useNavigation()
+
+  const trackSwapConfirmPageViewed = React.useCallback(() => {
+    const currentState = navigation.getState()
+    const previousState = navigationRef.current
+    if (currentState === previousState) return
+    track.swapConfirmedPageViewed({swap_tab: 'Open Orders'})
+    navigationRef.current = currentState
+  }, [track, navigation])
+
+  useFocusEffect(trackSwapConfirmPageViewed)
 
   const trackCancellationSubmitted = (order: MappedOpenOrder) => {
     track.swapCancelationSubmitted({


### PR DESCRIPTION
Resolves [YOMO-998](https://emurgo.atlassian.net/browse/YOMO-998)

The issue is that when opening a modal, we call `navigation.navigate('modal')` which then emits `blur` event used by `useFocusEffect`. The internal `focus` state inside the `useFocusEffect` is then reset. Once we close the modal, the original screen is focused again. That's why every time someone closes a modal, the `useFocusEffect` executes it's callback.

To fix the issue I've created a ref, that holds latest navigation state. The state does not change when opening/closing modal and that's why the check `if (currentState === previousState) return` resolves the issue.

[YOMO-998]: https://emurgo.atlassian.net/browse/YOMO-998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ