### PR TITLE
chore: dropped sync on focus

### DIFF
--- a/apps/wallet-mobile/src/TxHistory/TxHistory.tsx
+++ b/apps/wallet-mobile/src/TxHistory/TxHistory.tsx
@@ -1,4 +1,3 @@
-import {useFocusEffect} from '@react-navigation/native'
 import React, {useState} from 'react'
 import {defineMessages, useIntl} from 'react-intl'
 import {LayoutAnimation, StyleSheet, TouchableOpacity, View} from 'react-native'
@@ -34,7 +33,6 @@ export const TxHistory = () => {
   }
 
   const {sync, isLoading} = useSync(wallet)
-  useFocusEffect(React.useCallback(() => sync(), [sync]))
 
   const [expanded, setExpanded] = useState(true)
   const onScroll = useOnScroll({

--- a/apps/wallet-mobile/src/yoroi-wallets/cardano/types.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/cardano/types.ts
@@ -156,10 +156,8 @@ export type YoroiWallet = {
   // Sync, Save
   resync(): Promise<void>
   clear(): Promise<void>
-  tryDoFullSync(): Promise<void>
   save(): Promise<void>
   sync(): Promise<void>
-  startSync: () => void
   stopSync: () => void
   saveMemo(txId: string, memo: string): Promise<void>
 
@@ -248,10 +246,8 @@ const yoroiWalletKeys: Array<keyof YoroiWallet> = [
   // Sync, Save
   'resync',
   'clear',
-  'tryDoFullSync',
   'save',
   'sync',
-  'startSync',
   'stopSync',
   'saveMemo',
 

--- a/apps/wallet-mobile/src/yoroi-wallets/mocks/wallet.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/mocks/wallet.ts
@@ -213,9 +213,6 @@ const wallet: YoroiWallet = {
   saveMemo: async (...args) => {
     action('saveMemo')(...args)
   },
-  tryDoFullSync: async (...args) => {
-    action('tryDoFullSync')(...args)
-  },
   clear: async (...args) => {
     action('clear')(...args)
   },
@@ -250,9 +247,6 @@ const wallet: YoroiWallet = {
 
   fetchFundInfo: () => {
     throw new Error('not implemented: fetchFundInfo')
-  },
-  startSync: () => {
-    throw new Error('not implemented: start')
   },
   stopSync: () => {
     throw new Error('not implemented: stop')

--- a/apps/wallet-mobile/src/yoroi-wallets/walletManager/walletManager.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/walletManager/walletManager.ts
@@ -168,7 +168,7 @@ export class WalletManager {
     })
 
     wallet.subscribe((event) => this._notify(event as any))
-    wallet.startSync()
+    await wallet.sync()
 
     return wallet
   }

--- a/apps/wallet-mobile/translations/messages/src/TxHistory/TxHistory.json
+++ b/apps/wallet-mobile/translations/messages/src/TxHistory/TxHistory.json
@@ -4,14 +4,14 @@
     "defaultMessage": "!!!Note:",
     "file": "src/TxHistory/TxHistory.tsx",
     "start": {
-      "line": 154,
+      "line": 152,
       "column": 9,
-      "index": 4995
+      "index": 4881
     },
     "end": {
-      "line": 157,
+      "line": 155,
       "column": 3,
-      "index": 5094
+      "index": 4980
     }
   },
   {
@@ -19,14 +19,14 @@
     "defaultMessage": "!!!The Shelley protocol upgrade adds a new Shelley wallet type which supports delegation.",
     "file": "src/TxHistory/TxHistory.tsx",
     "start": {
-      "line": 158,
+      "line": 156,
       "column": 11,
-      "index": 5107
+      "index": 4993
     },
     "end": {
-      "line": 161,
+      "line": 159,
       "column": 3,
-      "index": 5289
+      "index": 5175
     }
   }
 ]


### PR DESCRIPTION
#### Summary

Some of the funnels didn't work properly in the past and the app crashes if for example a token vanished from the wallet while the user was inside the funnel
Most of these crashes was handled and nothing new is showing up on Sentry
Community constantly complains about the spinning spinning while landing on tx history

#### To do
- [ ] Enable buttons while syncing 
- [ ] Lock Screen when the first sync is happening (UI rebuild, restore/create wallet)
- [x] Remove refresh on focus since it happens every 20s and the user can pull to refresh