### PR TITLE
fix: open order asset labels

### DIFF
--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/ListOrders/OpenOrders.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/ListOrders/OpenOrders.tsx
@@ -314,7 +314,7 @@ export const OpenOrders = () => {
               >
                 <MainInfo
                   tokenAmount={`${order.tokenAmount} ${order.assetToLabel}`}
-                  tokenPrice={`${order.tokenPrice} ${order.assetFromLabel}`}
+                  tokenPrice={`${order.tokenPrice} ${order.assetFromLabel}/${order.assetToLabel}`}
                   date={
                     isNaN(date.getTime())
                       ? ''


### PR DESCRIPTION
realted: https://emurgo.atlassian.net/browse/YOMO-983

![image](https://github.com/Emurgo/yoroi/assets/1725956/cb84aceb-7712-410f-900a-d0032bda50e6)
