### PR TITLE
fix: automatic address change

### DIFF
--- a/apps/wallet-mobile/src/features/Send/useCases/StartMultiTokenTx/StartMultiTokenTxScreen.tsx
+++ b/apps/wallet-mobile/src/features/Send/useCases/StartMultiTokenTx/StartMultiTokenTxScreen.tsx
@@ -1,3 +1,4 @@
+import {useIsFocused} from '@react-navigation/native'
 import _ from 'lodash'
 import React from 'react'
 import {ScrollView, StyleSheet, View, ViewProps} from 'react-native'
@@ -26,6 +27,7 @@ export const StartMultiTokenTxScreen = () => {
   const navigateTo = useNavigateTo()
   const wallet = useSelectedWallet()
   const {track} = useMetrics()
+  const isFocused = useIsFocused()
 
   React.useEffect(() => {
     track.sendInitiated()
@@ -62,7 +64,10 @@ export const StartMultiTokenTxScreen = () => {
       navigateTo.selectedTokens()
     }
   }
-  const handleOnChangeReceiver = (text: string) => receiverResolveChanged(text)
+  const handleOnChangeReceiver = (text: string) => {
+    if (!isFocused) return // prevent weird bug: automatic call when is unfocused
+    receiverResolveChanged(text)
+  }
   const handleOnChangeMemo = (text: string) => memoChanged(text)
 
   return (

--- a/apps/wallet-mobile/src/features/Send/useCases/StartMultiTokenTx/StartMultiTokenTxScreen.tsx
+++ b/apps/wallet-mobile/src/features/Send/useCases/StartMultiTokenTx/StartMultiTokenTxScreen.tsx
@@ -65,7 +65,7 @@ export const StartMultiTokenTxScreen = () => {
     }
   }
   const handleOnChangeReceiver = (text: string) => {
-    if (!isFocused) return // prevent weird bug: automatic call when is unfocused and using domains
+    if (!isFocused) return
     receiverResolveChanged(text)
   }
   const handleOnChangeMemo = (text: string) => memoChanged(text)

--- a/apps/wallet-mobile/src/features/Send/useCases/StartMultiTokenTx/StartMultiTokenTxScreen.tsx
+++ b/apps/wallet-mobile/src/features/Send/useCases/StartMultiTokenTx/StartMultiTokenTxScreen.tsx
@@ -65,7 +65,7 @@ export const StartMultiTokenTxScreen = () => {
     }
   }
   const handleOnChangeReceiver = (text: string) => {
-    if (!isFocused) return // prevent weird bug: automatic call when is unfocused
+    if (!isFocused) return // prevent weird bug: automatic call when is unfocused and using domains
     receiverResolveChanged(text)
   }
   const handleOnChangeMemo = (text: string) => memoChanged(text)

--- a/apps/wallet-mobile/src/features/Send/useCases/StartMultiTokenTx/StartMultiTokenTxScreen.tsx
+++ b/apps/wallet-mobile/src/features/Send/useCases/StartMultiTokenTx/StartMultiTokenTxScreen.tsx
@@ -65,7 +65,7 @@ export const StartMultiTokenTxScreen = () => {
     }
   }
   const handleOnChangeReceiver = (text: string) => {
-    if (!isFocused) return // prevent automatic calls. RN TextInput bug
+    if (!isFocused) return // prevent automatic calls when the screen is not focused. RN TextInput bug
     receiverResolveChanged(text)
   }
   const handleOnChangeMemo = (text: string) => memoChanged(text)

--- a/apps/wallet-mobile/src/features/Send/useCases/StartMultiTokenTx/StartMultiTokenTxScreen.tsx
+++ b/apps/wallet-mobile/src/features/Send/useCases/StartMultiTokenTx/StartMultiTokenTxScreen.tsx
@@ -65,7 +65,7 @@ export const StartMultiTokenTxScreen = () => {
     }
   }
   const handleOnChangeReceiver = (text: string) => {
-    if (!isFocused) return
+    if (!isFocused) return // prevent automatic calls. RN TextInput bug
     receiverResolveChanged(text)
   }
   const handleOnChangeMemo = (text: string) => memoChanged(text)


### PR DESCRIPTION
onChange text is called automatically when the screen is not focused.

The screen is rendered in intervals so the functions is called in every render.

In this case it caused the address to be overwritten when using domains. The reason is domains fetch the addresses independently once when that onChange is manually invoked.