### PR TITLE
fix: Remove screen transition top-to-bottom for buy/sell screen

### DIFF
--- a/apps/wallet-mobile/src/TxHistory/TxHistoryNavigator.tsx
+++ b/apps/wallet-mobile/src/TxHistory/TxHistoryNavigator.tsx
@@ -13,7 +13,6 @@ import {Resolver, Swap} from '@yoroi/types'
 import React from 'react'
 import {defineMessages, useIntl} from 'react-intl'
 import {StyleSheet, Text, TouchableOpacity, TouchableOpacityProps, View, ViewProps} from 'react-native'
-import {Easing} from 'react-native-reanimated'
 
 import {Boundary, Icon, Spacer} from '../components'
 import {claimApiMaker} from '../features/Claim/module/api'
@@ -165,8 +164,6 @@ export const TxHistoryNavigator = () => {
                   component={RampOnOffScreen}
                   options={{
                     headerShown: false,
-                    cardStyleInterpolator: rampOnOffCardStyleInterpolator,
-                    transitionSpec: rampOnOffTransitionSpec,
                   }}
                 />
 
@@ -501,39 +498,3 @@ const sendOptions = {
     backgroundColor: '#fff',
   },
 }
-
-const rampOnOffTransitionSpec = {
-  open: {
-    animation: 'spring',
-    config: {
-      stiffness: 300,
-      damping: 25,
-      mass: 1,
-      overshootClamping: false,
-      restDisplacementThreshold: 0.01,
-      restSpeedThreshold: 2,
-    },
-  },
-  close: {
-    animation: 'timing',
-    config: {
-      easing: Easing.inOut(Easing.sin),
-      duration: 300,
-    },
-  },
-} as const
-
-const rampOnOffCardStyleInterpolator = ({current, layouts}) =>
-  ({
-    cardStyle: {
-      opacity: current.progress,
-      transform: [
-        {
-          translateY: current.progress.interpolate({
-            inputRange: [0, 1],
-            outputRange: [-layouts.screen.height, 0],
-          }),
-        },
-      ],
-    },
-  } as const)

--- a/apps/wallet-mobile/src/theme/transitions/screenOptions.ts
+++ b/apps/wallet-mobile/src/theme/transitions/screenOptions.ts
@@ -1,0 +1,55 @@
+import {Easing} from 'react-native-reanimated'
+
+/**
+ * Options to be added in Stack.Screen to change transition
+ * see more: https://reactnavigation.org/docs/stack-navigator/#animations
+ */
+
+const topToBottomTransitionSpec = {
+  open: {
+    animation: 'spring',
+    config: {
+      stiffness: 300,
+      damping: 25,
+      mass: 1,
+      overshootClamping: false,
+      restDisplacementThreshold: 0.01,
+      restSpeedThreshold: 2,
+    },
+  },
+  close: {
+    animation: 'timing',
+    config: {
+      easing: Easing.inOut(Easing.sin),
+      duration: 300,
+    },
+  },
+} as const
+
+const topToBottomCardStyleInterpolator = ({current, layouts}) =>
+  ({
+    cardStyle: {
+      opacity: current.progress,
+      transform: [
+        {
+          translateY: current.progress.interpolate({
+            inputRange: [0, 1],
+            outputRange: [-layouts.screen.height, 0],
+          }),
+        },
+      ],
+    },
+  } as const)
+
+/**
+   * Usage:
+   *    <Stack.Screen
+            options={{
+                ...topToBottom
+            }}
+        />
+   */
+export const topToBottom = {
+  cardStyleInterpolator: topToBottomCardStyleInterpolator,
+  transitionSpec: topToBottomTransitionSpec,
+}

--- a/apps/wallet-mobile/translations/messages/src/TxHistory/TxHistoryNavigator.json
+++ b/apps/wallet-mobile/translations/messages/src/TxHistory/TxHistoryNavigator.json
@@ -4,14 +4,14 @@
     "defaultMessage": "!!!Receive",
     "file": "src/TxHistory/TxHistoryNavigator.tsx",
     "start": {
-      "line": 350,
+      "line": 349,
       "column": 16,
-      "index": 13147
+      "index": 13063
     },
     "end": {
-      "line": 353,
+      "line": 352,
       "column": 3,
-      "index": 13236
+      "index": 13152
     }
   },
   {
@@ -19,14 +19,14 @@
     "defaultMessage": "!!!Swap",
     "file": "src/TxHistory/TxHistoryNavigator.tsx",
     "start": {
-      "line": 354,
+      "line": 353,
       "column": 13,
-      "index": 13251
+      "index": 13167
     },
     "end": {
-      "line": 357,
+      "line": 356,
       "column": 3,
-      "index": 13324
+      "index": 13240
     }
   },
   {
@@ -34,14 +34,14 @@
     "defaultMessage": "!!!Swap from",
     "file": "src/TxHistory/TxHistoryNavigator.tsx",
     "start": {
-      "line": 358,
+      "line": 357,
       "column": 17,
-      "index": 13343
+      "index": 13259
     },
     "end": {
-      "line": 361,
+      "line": 360,
       "column": 3,
-      "index": 13420
+      "index": 13336
     }
   },
   {
@@ -49,14 +49,14 @@
     "defaultMessage": "!!!Swap to",
     "file": "src/TxHistory/TxHistoryNavigator.tsx",
     "start": {
-      "line": 362,
+      "line": 361,
       "column": 15,
-      "index": 13437
+      "index": 13353
     },
     "end": {
-      "line": 365,
+      "line": 364,
       "column": 3,
-      "index": 13510
+      "index": 13426
     }
   },
   {
@@ -64,14 +64,14 @@
     "defaultMessage": "!!!Slippage Tolerance",
     "file": "src/TxHistory/TxHistoryNavigator.tsx",
     "start": {
-      "line": 366,
+      "line": 365,
       "column": 21,
-      "index": 13533
+      "index": 13449
     },
     "end": {
-      "line": 369,
+      "line": 368,
       "column": 3,
-      "index": 13628
+      "index": 13544
     }
   },
   {
@@ -79,14 +79,14 @@
     "defaultMessage": "!!!Select pool",
     "file": "src/TxHistory/TxHistoryNavigator.tsx",
     "start": {
-      "line": 370,
+      "line": 369,
       "column": 14,
-      "index": 13644
+      "index": 13560
     },
     "end": {
-      "line": 373,
+      "line": 372,
       "column": 3,
-      "index": 13725
+      "index": 13641
     }
   },
   {
@@ -94,14 +94,14 @@
     "defaultMessage": "!!!Send",
     "file": "src/TxHistory/TxHistoryNavigator.tsx",
     "start": {
-      "line": 374,
+      "line": 373,
       "column": 13,
-      "index": 13740
+      "index": 13656
     },
     "end": {
-      "line": 377,
+      "line": 376,
       "column": 3,
-      "index": 13820
+      "index": 13736
     }
   },
   {
@@ -109,14 +109,14 @@
     "defaultMessage": "!!!Scan QR code address",
     "file": "src/TxHistory/TxHistoryNavigator.tsx",
     "start": {
-      "line": 378,
+      "line": 377,
       "column": 18,
-      "index": 13840
+      "index": 13756
     },
     "end": {
-      "line": 381,
+      "line": 380,
       "column": 3,
-      "index": 13941
+      "index": 13857
     }
   },
   {
@@ -124,14 +124,14 @@
     "defaultMessage": "!!!Select asset",
     "file": "src/TxHistory/TxHistoryNavigator.tsx",
     "start": {
-      "line": 382,
+      "line": 381,
       "column": 20,
-      "index": 13963
+      "index": 13879
     },
     "end": {
-      "line": 385,
+      "line": 384,
       "column": 3,
-      "index": 14052
+      "index": 13968
     }
   },
   {
@@ -139,14 +139,14 @@
     "defaultMessage": "!!!Selected tokens",
     "file": "src/TxHistory/TxHistoryNavigator.tsx",
     "start": {
-      "line": 386,
+      "line": 385,
       "column": 26,
-      "index": 14080
+      "index": 13996
     },
     "end": {
-      "line": 389,
+      "line": 388,
       "column": 3,
-      "index": 14184
+      "index": 14100
     }
   },
   {
@@ -154,14 +154,14 @@
     "defaultMessage": "!!!Edit amount",
     "file": "src/TxHistory/TxHistoryNavigator.tsx",
     "start": {
-      "line": 390,
+      "line": 389,
       "column": 19,
-      "index": 14205
+      "index": 14121
     },
     "end": {
-      "line": 393,
+      "line": 392,
       "column": 3,
-      "index": 14298
+      "index": 14214
     }
   },
   {
@@ -169,14 +169,14 @@
     "defaultMessage": "!!!Confirm",
     "file": "src/TxHistory/TxHistoryNavigator.tsx",
     "start": {
-      "line": 394,
+      "line": 393,
       "column": 16,
-      "index": 14316
+      "index": 14232
     },
     "end": {
-      "line": 397,
+      "line": 396,
       "column": 3,
-      "index": 14402
+      "index": 14318
     }
   },
   {
@@ -184,14 +184,14 @@
     "defaultMessage": "!!!Share this address to receive payments. To protect your privacy, new addresses are generated automatically once you use them.",
     "file": "src/TxHistory/TxHistoryNavigator.tsx",
     "start": {
-      "line": 398,
+      "line": 397,
       "column": 19,
-      "index": 14423
+      "index": 14339
     },
     "end": {
-      "line": 404,
+      "line": 403,
       "column": 3,
-      "index": 14661
+      "index": 14577
     }
   },
   {
@@ -199,14 +199,14 @@
     "defaultMessage": "!!!Confirm transaction",
     "file": "src/TxHistory/TxHistoryNavigator.tsx",
     "start": {
-      "line": 405,
+      "line": 404,
       "column": 27,
-      "index": 14690
+      "index": 14606
     },
     "end": {
-      "line": 408,
+      "line": 407,
       "column": 3,
-      "index": 14783
+      "index": 14699
     }
   },
   {
@@ -214,14 +214,14 @@
     "defaultMessage": "!!!Please scan a QR code",
     "file": "src/TxHistory/TxHistoryNavigator.tsx",
     "start": {
-      "line": 409,
+      "line": 408,
       "column": 13,
-      "index": 14798
+      "index": 14714
     },
     "end": {
-      "line": 412,
+      "line": 411,
       "column": 3,
-      "index": 14873
+      "index": 14789
     }
   },
   {
@@ -229,14 +229,14 @@
     "defaultMessage": "!!!Success",
     "file": "src/TxHistory/TxHistoryNavigator.tsx",
     "start": {
-      "line": 413,
+      "line": 412,
       "column": 25,
-      "index": 14900
+      "index": 14816
     },
     "end": {
-      "line": 416,
+      "line": 415,
       "column": 3,
-      "index": 14974
+      "index": 14890
     }
   }
 ]


### PR DESCRIPTION
realted: https://emurgo.atlassian.net/browse/YOMO-1045

> it was an experimental transition we agreed on to apply and test 
> ...
> Considering the fact that the rest transitions are right-to-left, I’d advice to re-use the right-to-left one


I'd like to point out that the default transition is not right-to-left for android. 

In any case, I saved up this top-to-bottom one in themes.