### PR TITLE
fix(cdn): Only show load skeleton first time

### DIFF
--- a/apps/wallet-mobile/src/yoroi-wallets/hooks/index.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/hooks/index.ts
@@ -1022,7 +1022,7 @@ export const useNativeAssetImage = ({
   const queryClient = useQueryClient()
 
   const [isError, setError] = React.useState(false)
-  const [isLoading, setLoading] = React.useState(false)
+  const [isLoading, setLoading] = React.useState(responseType === 'binary')
 
   const queryKey = ['native-asset-img', policy, name, responseType, `${width}x${height}`, contentFit]
 
@@ -1036,7 +1036,6 @@ export const useNativeAssetImage = ({
       const requestUrl = `https://${network}.processed-media.yoroiwallet.com/${policy}/${name}?width=${width}&height=${height}&kind=${kind}&fit=${contentFit}${cache}`
 
       if (responseType === 'binary') {
-        setLoading(true)
         setError(false)
         return requestUrl
       }


### PR DESCRIPTION
Highlighted by the current bug of not having metadata, I see that error retries changed back and forth between the placeholder and the skeleton. This fix makes the skeleton only show once, if the image errors, retries won't show the skeleton again. 