### PR TITLE
fix(cdn): Refix the loading retries

### DIFF
--- a/apps/wallet-mobile/src/yoroi-wallets/hooks/index.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/hooks/index.ts
@@ -1036,7 +1036,7 @@ export const useNativeAssetImage = ({
       const requestUrl = `https://${network}.processed-media.yoroiwallet.com/${policy}/${name}?width=${width}&height=${height}&kind=${kind}&fit=${contentFit}${cache}`
 
       if (responseType === 'binary') {
-        setError(false)
+        setLoading(true)
         return requestUrl
       }
 
@@ -1057,10 +1057,11 @@ export const useNativeAssetImage = ({
   React.useEffect(() => () => clearTimeout(timerRef.current), [])
 
   const onError = useCallback(() => {
-    setError(true)
     const count = queryClient.getQueryState(queryKey)?.dataUpdateCount
     if (count && count < 10) {
       timerRef.current = setTimeout(query.refetch, count * 300)
+    } else {
+      setError(true)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query, queryClient])


### PR DESCRIPTION
Previous "fix" to the flicker was to only show skeleton once, but the placeholder also flickers very briefly due to the url change on the retries. 
Now the image will be considered as loading until all retries are done, then it'll error