### PR TITLE
fix: Only add event listeners once

### DIFF
--- a/apps/wallet-mobile/src/TxHistory/useAnimatedTxHistory.ts
+++ b/apps/wallet-mobile/src/TxHistory/useAnimatedTxHistory.ts
@@ -22,24 +22,21 @@ const useAnimatedTxHistory = () => {
 
   React.useLayoutEffect(() => {
     translateYOffset.value = withSpring(0, animatedConfig)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
 
-  React.useEffect(() => {
-    const focusListener = navigation.addListener('focus', () => {
+    const cleanUpFocus = navigation.addListener('focus', () => {
       translateYOffset.value = withSpring(0, animatedConfig)
     })
 
-    return focusListener
-  }, [navigation, translateYOffset])
-
-  React.useEffect(() => {
-    const blurListener = navigation.addListener('blur', () => {
+    const cleanUpBlur = navigation.addListener('blur', () => {
       translateYOffset.value = withSpring(initialTranslateYOffset, animatedConfig)
     })
 
-    return blurListener
-  }, [navigation, translateYOffset])
+    return () => {
+      cleanUpFocus()
+      cleanUpBlur()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return {translateStyles}
 }


### PR DESCRIPTION
related: https://emurgo.atlassian.net/browse/YOMO-1149

Adding listeners in useEffect that run multiple times is a no-go. Every time the dependencies in the array change, a new listener is added. The cleanup function to remove them only runs when the component unmounts, so only one of them is cleaned up. On top of that, having 2 effects adding listeners (focus, blur) makes it a race between them to see which one can add more listeners.
I assume QA hit the edge case where the blur listener won over the focus, making the animation hide the content every time.