### PR TITLE
fix(nft): iOS error image flickering

### DIFF
--- a/apps/wallet-mobile/src/components/NftPreview/NftPreview.tsx
+++ b/apps/wallet-mobile/src/components/NftPreview/NftPreview.tsx
@@ -56,7 +56,7 @@ export const NftPreview = ({
       <Image
         source={shouldShowPlaceholder ? placeholder : {uri, headers}}
         onError={onError}
-        onLoadEnd={onLoad}
+        onLoad={onLoad}
         style={[style, {width, height}]}
         resizeMode={contentFit}
         blurRadius={blurRadius}


### PR DESCRIPTION
When NftPreview fails (bad image) the retries seem to be flickering the loading state only in iOS (from QA testing).