### PR TITLE
fix(wallet-mobile): hardcoded status bar colors on android

### DIFF
--- a/apps/wallet-mobile/src/Dashboard/Dashboard.tsx
+++ b/apps/wallet-mobile/src/Dashboard/Dashboard.tsx
@@ -72,7 +72,7 @@ export const Dashboard = () => {
 
   return (
     <View style={styles.root}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <View style={styles.container}>
         {isOnline && error && <SyncErrorBanner showRefresh={!(isLoading || isSyncing)} />}

--- a/apps/wallet-mobile/src/Nfts/Nfts.tsx
+++ b/apps/wallet-mobile/src/Nfts/Nfts.tsx
@@ -137,7 +137,7 @@ const Wrapper = ({children}: {children: ReactNode}) => {
   const styles = useStyles()
   return (
     <SafeAreaView edges={['left', 'right', 'bottom']} style={styles.safeAreaView}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <View style={styles.container}>
         <Spacer height={16} />

--- a/apps/wallet-mobile/src/SelectedWallet/WalletSelection/WalletSelectionScreen.tsx
+++ b/apps/wallet-mobile/src/SelectedWallet/WalletSelection/WalletSelectionScreen.tsx
@@ -79,7 +79,7 @@ export const WalletSelectionScreen = () => {
 
   return (
     <SafeAreaView style={styles.safeAreaView}>
-      <StatusBar type="light" />
+      <StatusBar />
 
       <Text style={styles.title}>{strings.header}</Text>
 

--- a/apps/wallet-mobile/src/TxHistory/TxDetails/TxDetails.tsx
+++ b/apps/wallet-mobile/src/TxHistory/TxDetails/TxDetails.tsx
@@ -63,7 +63,7 @@ export const TxDetails = () => {
 
   return (
     <FadeIn style={styles.container}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <ScrollView contentContainerStyle={styles.contentContainer}>
         <Banner label={strings[transaction.direction]}>

--- a/apps/wallet-mobile/src/TxHistory/TxHistory.tsx
+++ b/apps/wallet-mobile/src/TxHistory/TxHistory.tsx
@@ -56,7 +56,7 @@ export const TxHistory = () => {
 
   return (
     <View style={styles.scrollView}>
-      <StatusBar type="dark" overrideColor="#E1EAF6" />
+      <StatusBar />
 
       <Animated.View style={[styles.container, translateStyles]}>
         <CollapsibleHeader expanded={expanded}>

--- a/apps/wallet-mobile/src/WalletInit/MnemonicCheck/MnemonicCheckScreen.tsx
+++ b/apps/wallet-mobile/src/WalletInit/MnemonicCheck/MnemonicCheckScreen.tsx
@@ -56,7 +56,7 @@ export const MnemonicCheckScreen = () => {
 
   return (
     <SafeAreaView edges={['left', 'right', 'bottom']} style={styles.safeAreaView}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <Spacer height={24} />
 

--- a/apps/wallet-mobile/src/WalletInit/MnemonicShow/MnemonicShowScreen.tsx
+++ b/apps/wallet-mobile/src/WalletInit/MnemonicShow/MnemonicShowScreen.tsx
@@ -40,7 +40,7 @@ export const MnemonicShowScreen = () => {
 
   return (
     <SafeAreaView edges={['left', 'right', 'bottom']} style={styles.safeAreaView}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <View style={styles.content}>
         <ScrollView contentContainerStyle={styles.scrollViewContentContainer} bounces={false}>

--- a/apps/wallet-mobile/src/WalletInit/RestoreWallet/RestoreWalletScreen.tsx
+++ b/apps/wallet-mobile/src/WalletInit/RestoreWallet/RestoreWalletScreen.tsx
@@ -27,7 +27,7 @@ export const RestoreWalletScreen = () => {
 
   return (
     <SafeAreaView edges={['left', 'right', 'bottom']} style={{flex: 1, backgroundColor: 'white'}}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <KeyboardAvoidingView style={{flex: 1}}>
         <ScrollableView bounces={false} style={{paddingHorizontal: 16}} keyboardShouldPersistTaps="always">

--- a/apps/wallet-mobile/src/WalletInit/SaveReadOnlyWallet/SaveReadOnlyWalletScreen.tsx
+++ b/apps/wallet-mobile/src/WalletInit/SaveReadOnlyWallet/SaveReadOnlyWalletScreen.tsx
@@ -64,7 +64,7 @@ export const SaveReadOnlyWalletScreen = () => {
 
   return (
     <SafeAreaView edges={['left', 'right', 'bottom']} style={styles.container} testID="saveReadOnlyWalletContainer">
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <WalletNameForm
         onSubmit={onSubmit}

--- a/apps/wallet-mobile/src/WalletInit/VerifyRestoredWallet/VerifyRestoredWalletScreen.tsx
+++ b/apps/wallet-mobile/src/WalletInit/VerifyRestoredWallet/VerifyRestoredWalletScreen.tsx
@@ -34,7 +34,7 @@ export const VerifyRestoredWalletScreen = () => {
 
   return (
     <SafeAreaView edges={['left', 'right', 'bottom']} style={styles.safeAreaView}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <ScrollView bounces={false} contentContainerStyle={styles.contentContainer}>
         <WalletInfo>

--- a/apps/wallet-mobile/src/WalletInit/WalletFreshInit/WalletFreshInitScreen.tsx
+++ b/apps/wallet-mobile/src/WalletInit/WalletFreshInit/WalletFreshInitScreen.tsx
@@ -19,7 +19,7 @@ export const WalletFreshInitScreen = () => {
 
   return (
     <SafeAreaView edges={['left', 'right', 'top', 'bottom']} style={styles.safeAreaView}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <View style={styles.banner}>
         <WalletDescription />

--- a/apps/wallet-mobile/src/WalletInit/WalletInit/WalletInitScreen.tsx
+++ b/apps/wallet-mobile/src/WalletInit/WalletInit/WalletInitScreen.tsx
@@ -28,7 +28,7 @@ export const WalletInitScreen = () => {
 
   return (
     <SafeAreaView style={styles.safeAreaView}>
-      <StatusBar type="light" />
+      <StatusBar />
 
       <ScreenBackground>
         <View style={styles.container}>

--- a/apps/wallet-mobile/src/auth/ChangePinScreen/ChangePinScreen.tsx
+++ b/apps/wallet-mobile/src/auth/ChangePinScreen/ChangePinScreen.tsx
@@ -11,7 +11,7 @@ export const ChangePinScreen = ({onDone}: {onDone: () => void}) => {
 
   return (
     <SafeAreaView edges={['left', 'right', 'bottom']} style={styles.container}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       {step === 'checkPin' ? <CheckPinInput onValid={() => setStep('newPin')} /> : <CreatePinInput onDone={onDone} />}
     </SafeAreaView>

--- a/apps/wallet-mobile/src/auth/CreatePinScreen/CreatePinScreen.tsx
+++ b/apps/wallet-mobile/src/auth/CreatePinScreen/CreatePinScreen.tsx
@@ -8,7 +8,7 @@ import {CreatePinInput} from '../CreatePinInput'
 export const CreatePinScreen = ({onDone}: {onDone: () => void}) => {
   return (
     <SafeAreaView edges={['left', 'right', 'bottom']} style={styles.container}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <CreatePinInput onDone={onDone} />
     </SafeAreaView>

--- a/apps/wallet-mobile/src/auth/OsAuthScreen/OsAuthScreen.tsx
+++ b/apps/wallet-mobile/src/auth/OsAuthScreen/OsAuthScreen.tsx
@@ -44,7 +44,7 @@ export const OsAuthScreen = ({
   return (
     <ScreenBackground style={styles.container}>
       <SafeAreaView style={{flex: 1}}>
-        <StatusBar type="dark" />
+        <StatusBar />
 
         <View style={[styles.main, onGoBack ? null : styles.mainPadded]}>
           {onGoBack && (

--- a/apps/wallet-mobile/src/auth/PinLoginScreen/PinLoginScreen.tsx
+++ b/apps/wallet-mobile/src/auth/PinLoginScreen/PinLoginScreen.tsx
@@ -29,7 +29,7 @@ export const PinLoginScreen = () => {
 
   return (
     <SafeAreaView edges={['left', 'right', 'bottom']} style={{flex: 1}}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <PinInput
         ref={pinInputRef}

--- a/apps/wallet-mobile/src/components/StatusBar.tsx
+++ b/apps/wallet-mobile/src/components/StatusBar.tsx
@@ -2,15 +2,9 @@ import {useFocusEffect} from '@react-navigation/native'
 import {useTheme} from '@yoroi/theme'
 import {Platform, StatusBar as StatusBarRN} from 'react-native'
 
-type Props = {
-  type: 'dark' | 'light'
-  overrideColor?: string
-}
-
 // TODO: it should be a hook
-export const StatusBar = ({overrideColor}: Props) => {
+export const StatusBar = () => {
   const {theme, isDark} = useTheme()
-  const backgroundColor = isDark ? theme.color['white-static'] : theme.color['black-static']
 
   useFocusEffect(() => {
     if (Platform.OS === 'android') {
@@ -18,7 +12,6 @@ export const StatusBar = ({overrideColor}: Props) => {
       StatusBarRN.setBarStyle('light-content')
     } else {
       StatusBarRN.setBarStyle(isDark ? 'light-content' : 'dark-content')
-      StatusBarRN.setBackgroundColor(overrideColor ?? backgroundColor)
     }
   })
 

--- a/apps/wallet-mobile/src/components/StatusBar.tsx
+++ b/apps/wallet-mobile/src/components/StatusBar.tsx
@@ -13,8 +13,13 @@ export const StatusBar = ({overrideColor}: Props) => {
   const backgroundColor = isDark ? theme.color['white-static'] : theme.color['black-static']
 
   useFocusEffect(() => {
-    if (Platform.OS === 'android') StatusBarRN.setBackgroundColor(overrideColor ?? backgroundColor)
-    StatusBarRN.setBarStyle(isDark ? 'light-content' : 'dark-content')
+    if (Platform.OS === 'android') {
+      StatusBarRN.setBackgroundColor(theme.color['black-static'])
+      StatusBarRN.setBarStyle('light-content')
+    } else {
+      StatusBarRN.setBarStyle(isDark ? 'light-content' : 'dark-content')
+      StatusBarRN.setBackgroundColor(overrideColor ?? backgroundColor)
+    }
   })
 
   return null

--- a/apps/wallet-mobile/src/features/Initialization/AnalyticsChangedScreen/AnalyticsChangedScreen.tsx
+++ b/apps/wallet-mobile/src/features/Initialization/AnalyticsChangedScreen/AnalyticsChangedScreen.tsx
@@ -17,7 +17,7 @@ export const AnalyticsChangedScreen = () => {
 
   return (
     <SafeAreaView style={styles.container}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <Analytics type="notice" onClose={handleClose} onReadMore={onReadMore} />
     </SafeAreaView>

--- a/apps/wallet-mobile/src/features/Initialization/AnalyticsNoticeScreen/AnalyticsNoticeScreen.tsx
+++ b/apps/wallet-mobile/src/features/Initialization/AnalyticsNoticeScreen/AnalyticsNoticeScreen.tsx
@@ -20,7 +20,7 @@ export const AnalyticsNoticeScreen = () => {
 
   return (
     <SafeAreaView style={styles.container}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <Analytics type="notice" onClose={onClose} onReadMore={onReadMore} />
     </SafeAreaView>

--- a/apps/wallet-mobile/src/features/Initialization/InitialScreen/InitialScreen.tsx
+++ b/apps/wallet-mobile/src/features/Initialization/InitialScreen/InitialScreen.tsx
@@ -43,7 +43,7 @@ export const InitialScreen = () => {
   return (
     <SafeAreaView style={styles.container}>
       <ScrollView bounces={false} contentContainerStyle={styles.scrollableContentContainer}>
-        <StatusBar type="dark" />
+        <StatusBar />
 
         <YoroiLogo />
 

--- a/apps/wallet-mobile/src/features/Initialization/LanguagePickerScreen/LanguagePickerScreen.tsx
+++ b/apps/wallet-mobile/src/features/Initialization/LanguagePickerScreen/LanguagePickerScreen.tsx
@@ -7,7 +7,7 @@ import {LanguagePicker, StatusBar} from '../../../components'
 export const LanguagePickerScreen = () => {
   return (
     <SafeAreaView edges={['left', 'right', 'bottom']} style={styles.safeAreaView}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <LanguagePicker />
     </SafeAreaView>

--- a/apps/wallet-mobile/src/features/Initialization/ReadPrivacyPolicyScreen/ReadPrivacyPolicyScreen.tsx
+++ b/apps/wallet-mobile/src/features/Initialization/ReadPrivacyPolicyScreen/ReadPrivacyPolicyScreen.tsx
@@ -11,7 +11,7 @@ export const ReadPrivacyPolicyScreen = () => {
 
   return (
     <SafeAreaView edges={['left', 'right', 'bottom']} style={styles.safeAreaView}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <ScrollView contentContainerStyle={styles.contentContainer}>
         <PrivacyPolicy languageCode={languageCode} />

--- a/apps/wallet-mobile/src/features/Initialization/ReadTermsOfServiceScreen/ReadTermsOfServiceScreen.tsx
+++ b/apps/wallet-mobile/src/features/Initialization/ReadTermsOfServiceScreen/ReadTermsOfServiceScreen.tsx
@@ -11,7 +11,7 @@ export const ReadTermsOfServiceScreen = () => {
 
   return (
     <SafeAreaView edges={['left', 'right', 'bottom']} style={styles.safeAreaView}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <ScrollView contentContainerStyle={styles.contentContainer}>
         <TermsOfService languageCode={languageCode} />

--- a/apps/wallet-mobile/src/features/Initialization/TermsOfServiceChangedScreen/TermsOfServiceChangedScreen.tsx
+++ b/apps/wallet-mobile/src/features/Initialization/TermsOfServiceChangedScreen/TermsOfServiceChangedScreen.tsx
@@ -30,7 +30,7 @@ export const TermsOfServiceChangedScreen = () => {
 
   return (
     <SafeAreaView style={styles.container}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <ScrollView bounces={false} contentContainerStyle={styles.scrollableContentContainer}>
         <YoroiLogo />

--- a/apps/wallet-mobile/src/features/RampOnOff/RampOnOffNavigator.tsx
+++ b/apps/wallet-mobile/src/features/RampOnOff/RampOnOffNavigator.tsx
@@ -22,7 +22,7 @@ export const RampOnOffScreen = () => {
 
   return (
     <SafeAreaView edges={['bottom', 'left', 'right']} style={[styles.root]}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <RampOnOffProvider>
         <Stack.Navigator

--- a/apps/wallet-mobile/src/features/Send/useCases/StartMultiTokenTx/StartMultiTokenTxScreen.tsx
+++ b/apps/wallet-mobile/src/features/Send/useCases/StartMultiTokenTx/StartMultiTokenTxScreen.tsx
@@ -80,7 +80,7 @@ export const StartMultiTokenTxScreen = () => {
 
   return (
     <View style={styles.container}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <KeyboardAvoidingView style={styles.flex}>
         <ScrollView

--- a/apps/wallet-mobile/src/features/Settings/ApplicationSettings/ApplicationSettingsScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/ApplicationSettings/ApplicationSettingsScreen.tsx
@@ -55,7 +55,7 @@ export const ApplicationSettingsScreen = () => {
   return (
     <SafeAreaView edges={['bottom', 'right', 'left']} style={styles.root}>
       <ScrollView bounces={false} style={styles.settings}>
-        <StatusBar type="dark" />
+        <StatusBar />
 
         <SettingsSection title={strings.general}>
           <NavigatedSettingsItem

--- a/apps/wallet-mobile/src/features/Settings/Currency/ChangeCurrencyScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/Currency/ChangeCurrencyScreen.tsx
@@ -10,7 +10,7 @@ export const ChangeCurrencyScreen = () => {
   const styles = useStyles()
   return (
     <SafeAreaView edges={['bottom', 'right', 'left']} style={styles.safeAreaView}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <Boundary>
         <CurrencyPickerList />

--- a/apps/wallet-mobile/src/features/Settings/EasyConfirmation/DisableEasyConfirmationScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/EasyConfirmation/DisableEasyConfirmationScreen.tsx
@@ -30,7 +30,7 @@ export const DisableEasyConfirmationScreen = () => {
 
   return (
     <SafeAreaView edges={['bottom']} style={styles.container}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <View style={[styles.disableSection]}>
         <Text style={styles.heading}>{strings.disableHeading}</Text>

--- a/apps/wallet-mobile/src/features/Settings/EasyConfirmation/EnableEasyConfirmationScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/EasyConfirmation/EnableEasyConfirmationScreen.tsx
@@ -40,7 +40,7 @@ export const EnableEasyConfirmationScreen = () => {
 
   return (
     <SafeAreaView edges={['bottom']} style={styles.container}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <KeyboardAvoidingView style={{flex: 1}}>
         <ScrollView keyboardShouldPersistTaps="always" contentContainerStyle={styles.contentContainer}>

--- a/apps/wallet-mobile/src/features/Settings/PrivacyPolicy/PrivacyPolicyScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/PrivacyPolicy/PrivacyPolicyScreen.tsx
@@ -13,7 +13,7 @@ export const PrivacyPolicyScreen = () => {
 
   return (
     <SafeAreaView edges={['left', 'right', 'bottom']} style={styles.safeAreaView}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <ScrollView contentContainerStyle={styles.contentContainer}>
         <PrivacyPolicy languageCode={languageCode} />

--- a/apps/wallet-mobile/src/features/Settings/RemoveWallet/RemoveWalletScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/RemoveWallet/RemoveWalletScreen.tsx
@@ -37,7 +37,7 @@ export const RemoveWalletScreen = () => {
 
   return (
     <SafeAreaView edges={['left', 'right', 'bottom']} style={styles.container}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <KeyboardAvoidingView style={{flex: 1}}>
         <ScrollView bounces={false} contentContainerStyle={styles.contentContainer}>

--- a/apps/wallet-mobile/src/features/Settings/TermsOfService/TermsOfServiceScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/TermsOfService/TermsOfServiceScreen.tsx
@@ -13,7 +13,7 @@ export const TermsOfServiceScreen = () => {
 
   return (
     <SafeAreaView edges={['left', 'right', 'bottom']} style={styles.safeAreaView}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <ScrollView contentContainerStyle={styles.contentContainer}>
         <TermsOfService languageCode={languageCode} />

--- a/apps/wallet-mobile/src/features/Settings/WalletSettings/WalletSettingsScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/WalletSettings/WalletSettingsScreen.tsx
@@ -62,7 +62,7 @@ export const WalletSettingsScreen = () => {
   return (
     <SafeAreaView edges={['bottom', 'right', 'left']} style={styles.root}>
       <ScrollView bounces={false} style={styles.settings}>
-        <StatusBar type="dark" />
+        <StatusBar />
 
         <SettingsSection title={strings.general}>
           <NavigatedSettingsItem

--- a/apps/wallet-mobile/src/features/Staking/Governance/GovernanceNavigator.tsx
+++ b/apps/wallet-mobile/src/features/Staking/Governance/GovernanceNavigator.tsx
@@ -15,7 +15,7 @@ export const GovernanceNavigator = () => {
   const {theme} = useTheme()
   return (
     <GovernanceProvider manager={manager}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <SafeArea>
         <Stack.Navigator screenOptions={screenOptions(theme)}>

--- a/apps/wallet-mobile/src/features/Swap/SwapNavigator.tsx
+++ b/apps/wallet-mobile/src/features/Swap/SwapNavigator.tsx
@@ -64,7 +64,7 @@ export const SwapTabNavigator = () => {
 
   return (
     <SafeAreaView edges={['bottom', 'left', 'right']} style={styles.root}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <Tab.Navigator
         screenOptions={({route}) => ({

--- a/apps/wallet-mobile/src/features/ToggleAnalyticsSettings/ToggleAnalyticsSettingsScreen.tsx
+++ b/apps/wallet-mobile/src/features/ToggleAnalyticsSettings/ToggleAnalyticsSettingsScreen.tsx
@@ -11,7 +11,7 @@ export const ToggleAnalyticsSettingsScreen = () => {
 
   return (
     <SafeAreaView edges={['left', 'right', 'bottom']} style={styles.container}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <Analytics type="settings" onReadMore={onReadMore} />
     </SafeAreaView>

--- a/apps/wallet-mobile/src/legacy/DeveloperScreen.tsx
+++ b/apps/wallet-mobile/src/legacy/DeveloperScreen.tsx
@@ -79,7 +79,7 @@ export const DeveloperScreen = () => {
 
   return (
     <SafeAreaView style={styles.safeAreaView}>
-      <StatusBar type="dark" />
+      <StatusBar />
 
       <ScrollView style={styles.container}>
         {routes.map((route) => (

--- a/apps/wallet-mobile/translations/messages/src/Dashboard/Dashboard.json
+++ b/apps/wallet-mobile/translations/messages/src/Dashboard/Dashboard.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 247,
       "column": 23,
-      "index": 7842
+      "index": 7830
     },
     "end": {
       "line": 250,
       "column": 3,
-      "index": 7975
+      "index": 7963
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/Nfts/Nfts.json
+++ b/apps/wallet-mobile/translations/messages/src/Nfts/Nfts.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 260,
       "column": 12,
-      "index": 6532
+      "index": 6520
     },
     "end": {
       "line": 263,
       "column": 3,
-      "index": 6605
+      "index": 6593
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 264,
       "column": 14,
-      "index": 6621
+      "index": 6609
     },
     "end": {
       "line": 267,
       "column": 3,
-      "index": 6692
+      "index": 6680
     }
   },
   {
@@ -36,12 +36,12 @@
     "start": {
       "line": 268,
       "column": 20,
-      "index": 6714
+      "index": 6702
     },
     "end": {
       "line": 271,
       "column": 3,
-      "index": 6807
+      "index": 6795
     }
   },
   {
@@ -51,12 +51,12 @@
     "start": {
       "line": 272,
       "column": 13,
-      "index": 6822
+      "index": 6810
     },
     "end": {
       "line": 275,
       "column": 3,
-      "index": 6910
+      "index": 6898
     }
   },
   {
@@ -66,12 +66,12 @@
     "start": {
       "line": 276,
       "column": 15,
-      "index": 6927
+      "index": 6915
     },
     "end": {
       "line": 279,
       "column": 3,
-      "index": 7007
+      "index": 6995
     }
   },
   {
@@ -81,12 +81,12 @@
     "start": {
       "line": 280,
       "column": 18,
-      "index": 7027
+      "index": 7015
     },
     "end": {
       "line": 283,
       "column": 3,
-      "index": 7129
+      "index": 7117
     }
   },
   {
@@ -96,12 +96,12 @@
     "start": {
       "line": 284,
       "column": 9,
-      "index": 7140
+      "index": 7128
     },
     "end": {
       "line": 287,
       "column": 3,
-      "index": 7215
+      "index": 7203
     }
   },
   {
@@ -111,12 +111,12 @@
     "start": {
       "line": 288,
       "column": 10,
-      "index": 7227
+      "index": 7215
     },
     "end": {
       "line": 291,
       "column": 3,
-      "index": 7302
+      "index": 7290
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/SelectedWallet/WalletSelection/WalletSelectionScreen.json
+++ b/apps/wallet-mobile/translations/messages/src/SelectedWallet/WalletSelection/WalletSelectionScreen.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 111,
       "column": 10,
-      "index": 4232
+      "index": 4219
     },
     "end": {
       "line": 114,
       "column": 3,
-      "index": 4341
+      "index": 4328
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 115,
       "column": 19,
-      "index": 4362
+      "index": 4349
     },
     "end": {
       "line": 118,
       "column": 3,
-      "index": 4480
+      "index": 4467
     }
   },
   {
@@ -36,12 +36,12 @@
     "start": {
       "line": 119,
       "column": 28,
-      "index": 4510
+      "index": 4497
     },
     "end": {
       "line": 122,
       "column": 3,
-      "index": 4655
+      "index": 4642
     }
   },
   {
@@ -51,12 +51,12 @@
     "start": {
       "line": 123,
       "column": 17,
-      "index": 4674
+      "index": 4661
     },
     "end": {
       "line": 126,
       "column": 3,
-      "index": 4794
+      "index": 4781
     }
   },
   {
@@ -66,12 +66,12 @@
     "start": {
       "line": 127,
       "column": 21,
-      "index": 4817
+      "index": 4804
     },
     "end": {
       "line": 130,
       "column": 3,
-      "index": 4947
+      "index": 4934
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/TxHistory/TxDetails/TxDetails.json
+++ b/apps/wallet-mobile/translations/messages/src/TxHistory/TxDetails/TxDetails.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 354,
       "column": 8,
-      "index": 12316
+      "index": 12304
     },
     "end": {
       "line": 357,
       "column": 3,
-      "index": 12411
+      "index": 12399
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 358,
       "column": 12,
-      "index": 12425
+      "index": 12413
     },
     "end": {
       "line": 361,
       "column": 3,
-      "index": 12528
+      "index": 12516
     }
   },
   {
@@ -36,12 +36,12 @@
     "start": {
       "line": 362,
       "column": 8,
-      "index": 12538
+      "index": 12526
     },
     "end": {
       "line": 365,
       "column": 3,
-      "index": 12646
+      "index": 12634
     }
   },
   {
@@ -51,12 +51,12 @@
     "start": {
       "line": 366,
       "column": 9,
-      "index": 12657
+      "index": 12645
     },
     "end": {
       "line": 369,
       "column": 3,
-      "index": 12766
+      "index": 12754
     }
   },
   {
@@ -66,12 +66,12 @@
     "start": {
       "line": 373,
       "column": 24,
-      "index": 12830
+      "index": 12818
     },
     "end": {
       "line": 376,
       "column": 3,
-      "index": 12931
+      "index": 12919
     }
   },
   {
@@ -81,12 +81,12 @@
     "start": {
       "line": 377,
       "column": 23,
-      "index": 12956
+      "index": 12944
     },
     "end": {
       "line": 380,
       "column": 3,
-      "index": 13057
+      "index": 13045
     }
   },
   {
@@ -96,12 +96,12 @@
     "start": {
       "line": 381,
       "column": 24,
-      "index": 13083
+      "index": 13071
     },
     "end": {
       "line": 384,
       "column": 3,
-      "index": 13186
+      "index": 13174
     }
   },
   {
@@ -111,12 +111,12 @@
     "start": {
       "line": 385,
       "column": 7,
-      "index": 13195
+      "index": 13183
     },
     "end": {
       "line": 388,
       "column": 3,
-      "index": 13278
+      "index": 13266
     }
   },
   {
@@ -126,12 +126,12 @@
     "start": {
       "line": 389,
       "column": 17,
-      "index": 13297
+      "index": 13285
     },
     "end": {
       "line": 392,
       "column": 3,
-      "index": 13399
+      "index": 13387
     }
   },
   {
@@ -141,12 +141,12 @@
     "start": {
       "line": 393,
       "column": 15,
-      "index": 13416
+      "index": 13404
     },
     "end": {
       "line": 396,
       "column": 3,
-      "index": 13514
+      "index": 13502
     }
   },
   {
@@ -156,12 +156,12 @@
     "start": {
       "line": 397,
       "column": 8,
-      "index": 13524
+      "index": 13512
     },
     "end": {
       "line": 400,
       "column": 3,
-      "index": 13607
+      "index": 13595
     }
   },
   {
@@ -171,12 +171,12 @@
     "start": {
       "line": 401,
       "column": 17,
-      "index": 13626
+      "index": 13614
     },
     "end": {
       "line": 404,
       "column": 3,
-      "index": 13728
+      "index": 13716
     }
   },
   {
@@ -186,12 +186,12 @@
     "start": {
       "line": 405,
       "column": 20,
-      "index": 13750
+      "index": 13738
     },
     "end": {
       "line": 408,
       "column": 3,
-      "index": 13868
+      "index": 13856
     }
   },
   {
@@ -201,12 +201,12 @@
     "start": {
       "line": 409,
       "column": 17,
-      "index": 13887
+      "index": 13875
     },
     "end": {
       "line": 412,
       "column": 3,
-      "index": 14036
+      "index": 14024
     }
   },
   {
@@ -216,12 +216,12 @@
     "start": {
       "line": 413,
       "column": 16,
-      "index": 14054
+      "index": 14042
     },
     "end": {
       "line": 416,
       "column": 3,
-      "index": 14203
+      "index": 14191
     }
   },
   {
@@ -231,12 +231,12 @@
     "start": {
       "line": 417,
       "column": 18,
-      "index": 14223
+      "index": 14211
     },
     "end": {
       "line": 420,
       "column": 3,
-      "index": 14304
+      "index": 14292
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/TxHistory/TxHistory.json
+++ b/apps/wallet-mobile/translations/messages/src/TxHistory/TxHistory.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 140,
       "column": 9,
-      "index": 4589
+      "index": 4553
     },
     "end": {
       "line": 143,
       "column": 3,
-      "index": 4688
+      "index": 4652
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 144,
       "column": 11,
-      "index": 4701
+      "index": 4665
     },
     "end": {
       "line": 147,
       "column": 3,
-      "index": 4883
+      "index": 4847
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/WalletInit/MnemonicCheck/MnemonicCheckScreen.json
+++ b/apps/wallet-mobile/translations/messages/src/WalletInit/MnemonicCheck/MnemonicCheckScreen.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 172,
       "column": 16,
-      "index": 5764
+      "index": 5752
     },
     "end": {
       "line": 175,
       "column": 3,
-      "index": 5940
+      "index": 5928
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 176,
       "column": 17,
-      "index": 5959
+      "index": 5947
     },
     "end": {
       "line": 179,
       "column": 3,
-      "index": 6078
+      "index": 6066
     }
   },
   {
@@ -36,12 +36,12 @@
     "start": {
       "line": 180,
       "column": 35,
-      "index": 6115
+      "index": 6103
     },
     "end": {
       "line": 183,
       "column": 3,
-      "index": 6275
+      "index": 6263
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/WalletInit/MnemonicShow/MnemonicShowScreen.json
+++ b/apps/wallet-mobile/translations/messages/src/WalletInit/MnemonicShow/MnemonicShowScreen.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 85,
       "column": 16,
-      "index": 3015
+      "index": 3003
     },
     "end": {
       "line": 92,
       "column": 3,
-      "index": 3334
+      "index": 3322
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 93,
       "column": 22,
-      "index": 3358
+      "index": 3346
     },
     "end": {
       "line": 96,
       "column": 3,
-      "index": 3501
+      "index": 3489
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/WalletInit/RestoreWallet/RestoreWalletScreen.json
+++ b/apps/wallet-mobile/translations/messages/src/WalletInit/RestoreWallet/RestoreWalletScreen.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 62,
       "column": 17,
-      "index": 2318
+      "index": 2306
     },
     "end": {
       "line": 65,
       "column": 3,
-      "index": 2445
+      "index": 2433
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 66,
       "column": 16,
-      "index": 2463
+      "index": 2451
     },
     "end": {
       "line": 72,
       "column": 3,
-      "index": 2744
+      "index": 2732
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/WalletInit/SaveReadOnlyWallet/SaveReadOnlyWalletScreen.json
+++ b/apps/wallet-mobile/translations/messages/src/WalletInit/SaveReadOnlyWallet/SaveReadOnlyWalletScreen.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 139,
       "column": 21,
-      "index": 4047
+      "index": 4035
     },
     "end": {
       "line": 142,
       "column": 3,
-      "index": 4174
+      "index": 4162
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 143,
       "column": 17,
-      "index": 4193
+      "index": 4181
     },
     "end": {
       "line": 146,
       "column": 3,
-      "index": 4307
+      "index": 4295
     }
   },
   {
@@ -36,12 +36,12 @@
     "start": {
       "line": 147,
       "column": 22,
-      "index": 4331
+      "index": 4319
     },
     "end": {
       "line": 150,
       "column": 3,
-      "index": 4455
+      "index": 4443
     }
   },
   {
@@ -51,12 +51,12 @@
     "start": {
       "line": 151,
       "column": 7,
-      "index": 4464
+      "index": 4452
     },
     "end": {
       "line": 154,
       "column": 3,
-      "index": 4562
+      "index": 4550
     }
   },
   {
@@ -66,12 +66,12 @@
     "start": {
       "line": 155,
       "column": 18,
-      "index": 4582
+      "index": 4570
     },
     "end": {
       "line": 158,
       "column": 3,
-      "index": 4703
+      "index": 4691
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/WalletInit/VerifyRestoredWallet/VerifyRestoredWalletScreen.json
+++ b/apps/wallet-mobile/translations/messages/src/WalletInit/VerifyRestoredWallet/VerifyRestoredWalletScreen.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 105,
       "column": 17,
-      "index": 3854
+      "index": 3842
     },
     "end": {
       "line": 108,
       "column": 3,
-      "index": 3968
+      "index": 3956
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 109,
       "column": 20,
-      "index": 3990
+      "index": 3978
     },
     "end": {
       "line": 112,
       "column": 3,
-      "index": 4129
+      "index": 4117
     }
   },
   {
@@ -36,12 +36,12 @@
     "start": {
       "line": 113,
       "column": 17,
-      "index": 4148
+      "index": 4136
     },
     "end": {
       "line": 116,
       "column": 3,
-      "index": 4325
+      "index": 4313
     }
   },
   {
@@ -51,12 +51,12 @@
     "start": {
       "line": 117,
       "column": 17,
-      "index": 4344
+      "index": 4332
     },
     "end": {
       "line": 120,
       "column": 3,
-      "index": 4498
+      "index": 4486
     }
   },
   {
@@ -66,12 +66,12 @@
     "start": {
       "line": 121,
       "column": 17,
-      "index": 4517
+      "index": 4505
     },
     "end": {
       "line": 126,
       "column": 3,
-      "index": 4761
+      "index": 4749
     }
   },
   {
@@ -81,12 +81,12 @@
     "start": {
       "line": 127,
       "column": 22,
-      "index": 4785
+      "index": 4773
     },
     "end": {
       "line": 130,
       "column": 3,
-      "index": 4909
+      "index": 4897
     }
   },
   {
@@ -96,12 +96,12 @@
     "start": {
       "line": 131,
       "column": 14,
-      "index": 4925
+      "index": 4913
     },
     "end": {
       "line": 134,
       "column": 3,
-      "index": 5030
+      "index": 5018
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/WalletInit/WalletFreshInit/WalletFreshInitScreen.json
+++ b/apps/wallet-mobile/translations/messages/src/WalletInit/WalletFreshInit/WalletFreshInitScreen.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 56,
       "column": 19,
-      "index": 2272
+      "index": 2260
     },
     "end": {
       "line": 59,
       "column": 3,
-      "index": 2385
+      "index": 2373
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 60,
       "column": 28,
-      "index": 2415
+      "index": 2403
     },
     "end": {
       "line": 63,
       "column": 3,
-      "index": 2555
+      "index": 2543
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/auth/OsAuthScreen/OsAuthScreen.json
+++ b/apps/wallet-mobile/translations/messages/src/auth/OsAuthScreen/OsAuthScreen.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 100,
       "column": 18,
-      "index": 3027
+      "index": 3015
     },
     "end": {
       "line": 103,
       "column": 3,
-      "index": 3137
+      "index": 3125
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/auth/PinLoginScreen/PinLoginScreen.json
+++ b/apps/wallet-mobile/translations/messages/src/auth/PinLoginScreen/PinLoginScreen.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 54,
       "column": 9,
-      "index": 1381
+      "index": 1369
     },
     "end": {
       "line": 57,
       "column": 3,
-      "index": 1471
+      "index": 1459
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/features/Settings/ApplicationSettings/ApplicationSettingsScreen.json
+++ b/apps/wallet-mobile/translations/messages/src/features/Settings/ApplicationSettings/ApplicationSettingsScreen.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 264,
       "column": 11,
-      "index": 9100
+      "index": 9088
     },
     "end": {
       "line": 267,
       "column": 3,
-      "index": 9210
+      "index": 9198
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 268,
       "column": 21,
-      "index": 9233
+      "index": 9221
     },
     "end": {
       "line": 271,
       "column": 3,
-      "index": 9366
+      "index": 9354
     }
   },
   {
@@ -36,12 +36,12 @@
     "start": {
       "line": 272,
       "column": 18,
-      "index": 9386
+      "index": 9374
     },
     "end": {
       "line": 275,
       "column": 3,
-      "index": 9498
+      "index": 9486
     }
   },
   {
@@ -51,12 +51,12 @@
     "start": {
       "line": 276,
       "column": 22,
-      "index": 9522
+      "index": 9510
     },
     "end": {
       "line": 279,
       "column": 3,
-      "index": 9643
+      "index": 9631
     }
   },
   {
@@ -66,12 +66,12 @@
     "start": {
       "line": 280,
       "column": 9,
-      "index": 9654
+      "index": 9642
     },
     "end": {
       "line": 283,
       "column": 3,
-      "index": 9754
+      "index": 9742
     }
   },
   {
@@ -81,12 +81,12 @@
     "start": {
       "line": 284,
       "column": 18,
-      "index": 9774
+      "index": 9762
     },
     "end": {
       "line": 287,
       "column": 3,
-      "index": 9901
+      "index": 9889
     }
   },
   {
@@ -96,12 +96,12 @@
     "start": {
       "line": 288,
       "column": 13,
-      "index": 9916
+      "index": 9904
     },
     "end": {
       "line": 291,
       "column": 3,
-      "index": 10025
+      "index": 10013
     }
   },
   {
@@ -111,12 +111,12 @@
     "start": {
       "line": 292,
       "column": 15,
-      "index": 10042
+      "index": 10030
     },
     "end": {
       "line": 295,
       "column": 3,
-      "index": 10155
+      "index": 10143
     }
   },
   {
@@ -126,12 +126,12 @@
     "start": {
       "line": 296,
       "column": 19,
-      "index": 10176
+      "index": 10164
     },
     "end": {
       "line": 299,
       "column": 3,
-      "index": 10337
+      "index": 10325
     }
   },
   {
@@ -141,12 +141,12 @@
     "start": {
       "line": 300,
       "column": 20,
-      "index": 10359
+      "index": 10347
     },
     "end": {
       "line": 303,
       "column": 3,
-      "index": 10493
+      "index": 10481
     }
   },
   {
@@ -156,12 +156,12 @@
     "start": {
       "line": 304,
       "column": 24,
-      "index": 10519
+      "index": 10507
     },
     "end": {
       "line": 307,
       "column": 3,
-      "index": 10702
+      "index": 10690
     }
   },
   {
@@ -171,12 +171,12 @@
     "start": {
       "line": 308,
       "column": 18,
-      "index": 10722
+      "index": 10710
     },
     "end": {
       "line": 311,
       "column": 3,
-      "index": 10853
+      "index": 10841
     }
   },
   {
@@ -186,12 +186,12 @@
     "start": {
       "line": 312,
       "column": 22,
-      "index": 10877
+      "index": 10865
     },
     "end": {
       "line": 315,
       "column": 3,
-      "index": 11058
+      "index": 11046
     }
   },
   {
@@ -201,12 +201,12 @@
     "start": {
       "line": 316,
       "column": 13,
-      "index": 11073
+      "index": 11061
     },
     "end": {
       "line": 319,
       "column": 3,
-      "index": 11181
+      "index": 11169
     }
   },
   {
@@ -216,12 +216,12 @@
     "start": {
       "line": 320,
       "column": 17,
-      "index": 11200
+      "index": 11188
     },
     "end": {
       "line": 323,
       "column": 3,
-      "index": 11317
+      "index": 11305
     }
   },
   {
@@ -231,12 +231,12 @@
     "start": {
       "line": 324,
       "column": 17,
-      "index": 11336
+      "index": 11324
     },
     "end": {
       "line": 327,
       "column": 3,
-      "index": 11459
+      "index": 11447
     }
   },
   {
@@ -246,12 +246,12 @@
     "start": {
       "line": 328,
       "column": 21,
-      "index": 11482
+      "index": 11470
     },
     "end": {
       "line": 332,
       "column": 3,
-      "index": 11700
+      "index": 11688
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/features/Settings/EasyConfirmation/DisableEasyConfirmationScreen.json
+++ b/apps/wallet-mobile/translations/messages/src/features/Settings/EasyConfirmation/DisableEasyConfirmationScreen.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 63,
       "column": 18,
-      "index": 1964
+      "index": 1952
     },
     "end": {
       "line": 66,
       "column": 3,
-      "index": 2166
+      "index": 2154
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 67,
       "column": 17,
-      "index": 2185
+      "index": 2173
     },
     "end": {
       "line": 70,
       "column": 3,
-      "index": 2299
+      "index": 2287
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/features/Settings/EasyConfirmation/EnableEasyConfirmationScreen.json
+++ b/apps/wallet-mobile/translations/messages/src/features/Settings/EasyConfirmation/EnableEasyConfirmationScreen.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 97,
       "column": 17,
-      "index": 3355
+      "index": 3343
     },
     "end": {
       "line": 105,
       "column": 3,
-      "index": 3751
+      "index": 3739
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 106,
       "column": 17,
-      "index": 3770
+      "index": 3758
     },
     "end": {
       "line": 111,
       "column": 3,
-      "index": 4007
+      "index": 3995
     }
   },
   {
@@ -36,12 +36,12 @@
     "start": {
       "line": 112,
       "column": 22,
-      "index": 4031
+      "index": 4019
     },
     "end": {
       "line": 115,
       "column": 3,
-      "index": 4159
+      "index": 4147
     }
   },
   {
@@ -51,12 +51,12 @@
     "start": {
       "line": 116,
       "column": 16,
-      "index": 4177
+      "index": 4165
     },
     "end": {
       "line": 119,
       "column": 3,
-      "index": 4288
+      "index": 4276
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/features/Settings/RemoveWallet/RemoveWalletScreen.json
+++ b/apps/wallet-mobile/translations/messages/src/features/Settings/RemoveWallet/RemoveWalletScreen.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 114,
       "column": 25,
-      "index": 3560
+      "index": 3548
     },
     "end": {
       "line": 117,
       "column": 3,
-      "index": 3754
+      "index": 3742
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 118,
       "column": 25,
-      "index": 3781
+      "index": 3769
     },
     "end": {
       "line": 121,
       "column": 3,
-      "index": 3938
+      "index": 3926
     }
   },
   {
@@ -36,12 +36,12 @@
     "start": {
       "line": 122,
       "column": 14,
-      "index": 3954
+      "index": 3942
     },
     "end": {
       "line": 125,
       "column": 3,
-      "index": 4058
+      "index": 4046
     }
   },
   {
@@ -51,12 +51,12 @@
     "start": {
       "line": 126,
       "column": 19,
-      "index": 4079
+      "index": 4067
     },
     "end": {
       "line": 129,
       "column": 3,
-      "index": 4188
+      "index": 4176
     }
   },
   {
@@ -66,12 +66,12 @@
     "start": {
       "line": 130,
       "column": 27,
-      "index": 4217
+      "index": 4205
     },
     "end": {
       "line": 133,
       "column": 3,
-      "index": 4349
+      "index": 4337
     }
   },
   {
@@ -81,12 +81,12 @@
     "start": {
       "line": 134,
       "column": 10,
-      "index": 4361
+      "index": 4349
     },
     "end": {
       "line": 137,
       "column": 3,
-      "index": 4463
+      "index": 4451
     }
   },
   {
@@ -96,12 +96,12 @@
     "start": {
       "line": 138,
       "column": 26,
-      "index": 4491
+      "index": 4479
     },
     "end": {
       "line": 142,
       "column": 3,
-      "index": 4705
+      "index": 4693
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/features/Settings/WalletSettings/WalletSettingsScreen.json
+++ b/apps/wallet-mobile/translations/messages/src/features/Settings/WalletSettings/WalletSettingsScreen.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 234,
       "column": 11,
-      "index": 7601
+      "index": 7589
     },
     "end": {
       "line": 237,
       "column": 3,
-      "index": 7699
+      "index": 7687
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 238,
       "column": 11,
-      "index": 7712
+      "index": 7700
     },
     "end": {
       "line": 241,
       "column": 3,
-      "index": 7810
+      "index": 7798
     }
   },
   {
@@ -36,12 +36,12 @@
     "start": {
       "line": 242,
       "column": 16,
-      "index": 7828
+      "index": 7816
     },
     "end": {
       "line": 245,
       "column": 3,
-      "index": 7937
+      "index": 7925
     }
   },
   {
@@ -51,12 +51,12 @@
     "start": {
       "line": 246,
       "column": 10,
-      "index": 7949
+      "index": 7937
     },
     "end": {
       "line": 249,
       "column": 3,
-      "index": 8045
+      "index": 8033
     }
   },
   {
@@ -66,12 +66,12 @@
     "start": {
       "line": 250,
       "column": 14,
-      "index": 8061
+      "index": 8049
     },
     "end": {
       "line": 253,
       "column": 3,
-      "index": 8166
+      "index": 8154
     }
   },
   {
@@ -81,12 +81,12 @@
     "start": {
       "line": 254,
       "column": 12,
-      "index": 8180
+      "index": 8168
     },
     "end": {
       "line": 257,
       "column": 3,
-      "index": 8280
+      "index": 8268
     }
   },
   {
@@ -96,12 +96,12 @@
     "start": {
       "line": 258,
       "column": 18,
-      "index": 8300
+      "index": 8288
     },
     "end": {
       "line": 261,
       "column": 3,
-      "index": 8422
+      "index": 8410
     }
   },
   {
@@ -111,12 +111,12 @@
     "start": {
       "line": 262,
       "column": 20,
-      "index": 8444
+      "index": 8432
     },
     "end": {
       "line": 265,
       "column": 3,
-      "index": 8573
+      "index": 8561
     }
   },
   {
@@ -126,12 +126,12 @@
     "start": {
       "line": 266,
       "column": 16,
-      "index": 8591
+      "index": 8579
     },
     "end": {
       "line": 269,
       "column": 3,
-      "index": 8700
+      "index": 8688
     }
   },
   {
@@ -141,12 +141,12 @@
     "start": {
       "line": 270,
       "column": 14,
-      "index": 8716
+      "index": 8704
     },
     "end": {
       "line": 273,
       "column": 3,
-      "index": 8787
+      "index": 8775
     }
   },
   {
@@ -156,12 +156,12 @@
     "start": {
       "line": 274,
       "column": 21,
-      "index": 8810
+      "index": 8798
     },
     "end": {
       "line": 277,
       "column": 3,
-      "index": 8896
+      "index": 8884
     }
   },
   {
@@ -171,12 +171,12 @@
     "start": {
       "line": 278,
       "column": 17,
-      "index": 8915
+      "index": 8903
     },
     "end": {
       "line": 281,
       "column": 3,
-      "index": 8993
+      "index": 8981
     }
   },
   {
@@ -186,12 +186,12 @@
     "start": {
       "line": 282,
       "column": 25,
-      "index": 9020
+      "index": 9008
     },
     "end": {
       "line": 285,
       "column": 3,
-      "index": 9151
+      "index": 9139
     }
   },
   {
@@ -201,12 +201,12 @@
     "start": {
       "line": 287,
       "column": 11,
-      "index": 9212
+      "index": 9200
     },
     "end": {
       "line": 290,
       "column": 3,
-      "index": 9278
+      "index": 9266
     }
   },
   {
@@ -216,12 +216,12 @@
     "start": {
       "line": 291,
       "column": 14,
-      "index": 9294
+      "index": 9282
     },
     "end": {
       "line": 294,
       "column": 3,
-      "index": 9400
+      "index": 9388
     }
   },
   {
@@ -231,12 +231,12 @@
     "start": {
       "line": 295,
       "column": 15,
-      "index": 9417
+      "index": 9405
     },
     "end": {
       "line": 298,
       "column": 3,
-      "index": 9528
+      "index": 9516
     }
   },
   {
@@ -246,12 +246,12 @@
     "start": {
       "line": 299,
       "column": 17,
-      "index": 9547
+      "index": 9535
     },
     "end": {
       "line": 302,
       "column": 3,
-      "index": 9662
+      "index": 9650
     }
   },
   {
@@ -261,12 +261,12 @@
     "start": {
       "line": 303,
       "column": 21,
-      "index": 9685
+      "index": 9673
     },
     "end": {
       "line": 306,
       "column": 3,
-      "index": 9805
+      "index": 9793
     }
   },
   {
@@ -276,12 +276,12 @@
     "start": {
       "line": 307,
       "column": 9,
-      "index": 9816
+      "index": 9804
     },
     "end": {
       "line": 310,
       "column": 3,
-      "index": 9910
+      "index": 9898
     }
   },
   {
@@ -291,12 +291,12 @@
     "start": {
       "line": 311,
       "column": 10,
-      "index": 9922
+      "index": 9910
     },
     "end": {
       "line": 314,
       "column": 3,
-      "index": 10024
+      "index": 10012
     }
   }
 ]


### PR DESCRIPTION
issue: https://emurgo.atlassian.net/browse/YOMO-1228

- for some reason when the background is white on Android the text color is `dark content`  --> the text color is gray. As a temporary fix on Android have hard-coded the status bar colors to always be black background with white text  
- have tried `setTranslucent ` as well but not doing anything- maybe we should add this in Android xml config files 

⚠️ This happens because of the theming part, hardcoded the colors  for now will make the app behave the same as before 

![Screenshot 2024-03-06 at 09 21 00](https://github.com/Emurgo/yoroi/assets/37213944/9bb59c19-005f-4d1e-9d26-5062c79942f9)
