### PR TITLE
fix(wallet-mobile): Removes tx history animate down

### DIFF
--- a/apps/wallet-mobile/src/TxHistory/useAnimatedTxHistory.ts
+++ b/apps/wallet-mobile/src/TxHistory/useAnimatedTxHistory.ts
@@ -1,4 +1,3 @@
-import {useNavigation} from '@react-navigation/native'
 import React from 'react'
 import {useAnimatedStyle, useSharedValue, withSpring} from 'react-native-reanimated'
 
@@ -10,8 +9,6 @@ const animatedConfig = {
 }
 
 const useAnimatedTxHistory = () => {
-  const navigation = useNavigation()
-
   const translateYOffset = useSharedValue(initialTranslateYOffset)
   const translateStyles = useAnimatedStyle(() => ({
     transform: [{translateY: translateYOffset.value}],
@@ -20,19 +17,6 @@ const useAnimatedTxHistory = () => {
   React.useLayoutEffect(() => {
     if (translateYOffset.value !== 0) {
       translateYOffset.value = withSpring(0, animatedConfig)
-    }
-
-    const cleanUpFocus = navigation.addListener('focus', () => {
-      translateYOffset.value = withSpring(0, animatedConfig)
-    })
-
-    const cleanUpBlur = navigation.addListener('blur', () => {
-      translateYOffset.value = withSpring(initialTranslateYOffset, animatedConfig)
-    })
-
-    return () => {
-      cleanUpFocus()
-      cleanUpBlur()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])


### PR DESCRIPTION
Looks like I was wrong with the cause of this. I have no idea why it breaks. It just does.
This removes the listeners. TxHistory Animates up, once, when you select a wallet. And stays up.
I've run it 10 times the QR camera in and out. Doesn't break anymore. 

realted: https://emurgo.atlassian.net/browse/YOMO-1222?focusedCommentId=21955