### PR TITLE
fix(wallet-mobile): Change link color and align text to center

### DIFF
--- a/apps/wallet-mobile/src/features/Receive/common/SingleOrMultipleAddressesModal/SingleOrMultipleAddressesModal.tsx
+++ b/apps/wallet-mobile/src/features/Receive/common/SingleOrMultipleAddressesModal/SingleOrMultipleAddressesModal.tsx
@@ -51,7 +51,7 @@ export const SingleOrMultipleAddressesModal = ({onConfirm}: Props) => {
           outline
           title={strings.selectMultiple}
           textStyles={{
-            color: colors.details,
+            color: colors.selectMultipleInsteadTextColor,
           }}
           onPress={handleOnMultiple}
         />
@@ -82,6 +82,8 @@ const useStyles = () => {
     },
     details: {
       ...theme.typography['body-1-l-regular'],
+      justifyContent: 'center',
+      textAlign: 'center',
     },
 
     button: {
@@ -91,6 +93,7 @@ const useStyles = () => {
 
   const colors = {
     details: theme.color.gray[900],
+    selectMultipleInsteadTextColor: theme.color.primary[500],
   }
 
   return {styles, colors} as const


### PR DESCRIPTION
Fixes[ YOMO-1258](https://emurgo.atlassian.net/browse/YOMO-1258)

Product reported 2 issues in UI :

1) Text should be centred and aligned.

2) “Select multiple instead” - should be blue (as per design on figma)

After the fix, it will look like below:



<img src="https://github.com/Emurgo/yoroi/assets/62512215/69877381-d49c-4f33-b3d0-1b67e22bac05" alt="Image" width="300" height="700">

