### PR TITLE
fix(wallet-mobile): Add copy tool tip on address details

### DIFF
--- a/apps/wallet-mobile/src/components/CopyButton.tsx
+++ b/apps/wallet-mobile/src/components/CopyButton.tsx
@@ -4,6 +4,7 @@ import {StyleProp, StyleSheet, TouchableOpacity, View, ViewStyle} from 'react-na
 import Animated, {FadeInDown, FadeOutDown, Layout} from 'react-native-reanimated'
 
 import {Text} from '../../../wallet-mobile/src/components'
+import {isEmptyString} from '../../../wallet-mobile/src/utils/utils'
 import {Icon} from '../components/Icon'
 import {useCopy} from '../legacy/useCopy'
 
@@ -46,7 +47,7 @@ const AnimatedCopyButton = ({
     <TouchableOpacity onPress={onCopy} disabled={isCopying} testID="copyButton" style={style}>
       {isCopying ? (
         <View style={styles.rowContainer}>
-          {message != null ? (
+          {!isEmptyString(message) ? (
             <Animated.View layout={Layout} entering={FadeInDown} exiting={FadeOutDown} style={styles.isCopying}>
               <Text style={styles.copiedText}>{message}</Text>
             </Animated.View>

--- a/apps/wallet-mobile/src/components/CopyButton.tsx
+++ b/apps/wallet-mobile/src/components/CopyButton.tsx
@@ -1,8 +1,11 @@
 import {useTheme} from '@yoroi/theme'
 import React from 'react'
-import {StyleProp, TouchableOpacity, ViewStyle} from 'react-native'
+import {StyleProp, StyleSheet, TouchableOpacity, View, ViewStyle} from 'react-native'
+import Animated, {FadeInDown, FadeOutDown, Layout} from 'react-native-reanimated'
 
+import {Text} from '../../../wallet-mobile/src/components'
 import {Icon} from '../components/Icon'
+import {useStrings} from '../features/Receive/common/useStrings'
 import {useCopy} from '../legacy/useCopy'
 
 export type CopyButtonProps = {
@@ -35,11 +38,51 @@ const AnimatedCopyButton = ({
   style,
   isCopying,
 }: Omit<CopyButtonProps, 'value'> & {isCopying: boolean}) => {
-  const {colors} = useStyles()
+  const strings = useStrings()
+  const {styles, colors} = useStyles()
 
   return (
     <TouchableOpacity onPress={onCopy} disabled={isCopying} testID="copyButton" style={style}>
-      {isCopying ? <Icon.CopySuccess size={26} color={colors.gray} /> : <Icon.Copy size={26} color={colors.gray} />}
+      {isCopying ? (
+        <View style={styles.rowContainer}>
+          <Animated.View layout={Layout} entering={FadeInDown} exiting={FadeOutDown} style={styles.isCopying}>
+            <Text style={styles.copiedText}>{strings.addressCopiedMsg}</Text>
+          </Animated.View>
+
+          <Icon.CopySuccess size={26} color={colors.gray} />
+        </View>
+      ) : (
+        <Icon.Copy size={26} color={colors.gray} />
+      )}
+
+      {children}
+    </TouchableOpacity>
+  )
+}
+
+
+export const AnimatedCopyButtonWithMessage = ({
+  onCopy,
+  children,
+  style,
+  isCopying,
+}: Omit<CopyButtonProps, 'value'> & {isCopying: boolean}) => {
+  const strings = useStrings()
+  const {styles, colors} = useStyles()
+
+  return (
+    <TouchableOpacity onPress={onCopy} disabled={isCopying} testID="copyButton" style={style}>
+      {isCopying ? (
+        <View style={styles.rowContainer}>
+          <Animated.View layout={Layout} entering={FadeInDown} exiting={FadeOutDown} style={styles.isCopying}>
+            <Text style={styles.copiedText}>{strings.addressCopiedMsg}</Text>
+          </Animated.View>
+
+          <Icon.CopySuccess size={26} color={colors.gray} />
+        </View>
+      ) : (
+        <Icon.Copy size={26} color={colors.gray} />
+      )}
 
       {children}
     </TouchableOpacity>
@@ -48,11 +91,36 @@ const AnimatedCopyButton = ({
 
 const useStyles = () => {
   const {theme} = useTheme()
-  const {color} = theme
+  const {color, typography} = theme
 
   const colors = {
     gray: color.gray[900],
   }
 
-  return {colors} as const
+  const styles = StyleSheet.create({
+    isCopying: {
+      position: 'absolute',
+      backgroundColor: color.gray.max,
+      alignItems: 'center',
+      justifyContent: 'center',
+      bottom: 20,
+      right: 10,
+      alignSelf: 'center',
+      borderRadius: 4,
+      zIndex: 10,
+    },
+    copiedText: {
+      color: color.gray.min,
+      textAlign: 'center',
+      padding: 8,
+      flex: 1,
+      ...typography['body-2-m-medium'],
+    },
+    rowContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+  })
+
+  return {styles, colors} as const
 }

--- a/apps/wallet-mobile/src/components/CopyButton.tsx
+++ b/apps/wallet-mobile/src/components/CopyButton.tsx
@@ -5,7 +5,6 @@ import Animated, {FadeInDown, FadeOutDown, Layout} from 'react-native-reanimated
 
 import {Text} from '../../../wallet-mobile/src/components'
 import {Icon} from '../components/Icon'
-import {useStrings} from '../features/Receive/common/useStrings'
 import {useCopy} from '../legacy/useCopy'
 
 export type CopyButtonProps = {
@@ -13,15 +12,17 @@ export type CopyButtonProps = {
   onCopy?: () => void
   children?: React.ReactNode
   style?: StyleProp<ViewStyle>
+  message?: string
 }
 
-export const CopyButton = ({value, onCopy, children, style}: CopyButtonProps) => {
+export const CopyButton = ({value, onCopy, children, style, message}: CopyButtonProps) => {
   const [isCopying, copy] = useCopy()
 
   return (
     <AnimatedCopyButton
       style={style}
       isCopying={isCopying}
+      message={message}
       onCopy={() => {
         copy(value)
         onCopy?.()
@@ -32,51 +33,26 @@ export const CopyButton = ({value, onCopy, children, style}: CopyButtonProps) =>
   )
 }
 
-const AnimatedCopyButton = ({
+export const AnimatedCopyButton = ({
   onCopy,
   children,
   style,
   isCopying,
-}: Omit<CopyButtonProps, 'value'> & {isCopying: boolean}) => {
-  const strings = useStrings()
+  message,
+}: Omit<CopyButtonProps, 'value'> & {isCopying: boolean; message?: string | null | undefined}) => {
   const {styles, colors} = useStyles()
 
   return (
     <TouchableOpacity onPress={onCopy} disabled={isCopying} testID="copyButton" style={style}>
       {isCopying ? (
         <View style={styles.rowContainer}>
-          <Animated.View layout={Layout} entering={FadeInDown} exiting={FadeOutDown} style={styles.isCopying}>
-            <Text style={styles.copiedText}>{strings.addressCopiedMsg}</Text>
-          </Animated.View>
-
-          <Icon.CopySuccess size={26} color={colors.gray} />
-        </View>
-      ) : (
-        <Icon.Copy size={26} color={colors.gray} />
-      )}
-
-      {children}
-    </TouchableOpacity>
-  )
-}
-
-
-export const AnimatedCopyButtonWithMessage = ({
-  onCopy,
-  children,
-  style,
-  isCopying,
-}: Omit<CopyButtonProps, 'value'> & {isCopying: boolean}) => {
-  const strings = useStrings()
-  const {styles, colors} = useStyles()
-
-  return (
-    <TouchableOpacity onPress={onCopy} disabled={isCopying} testID="copyButton" style={style}>
-      {isCopying ? (
-        <View style={styles.rowContainer}>
-          <Animated.View layout={Layout} entering={FadeInDown} exiting={FadeOutDown} style={styles.isCopying}>
-            <Text style={styles.copiedText}>{strings.addressCopiedMsg}</Text>
-          </Animated.View>
+          {message != null ? (
+            <Animated.View layout={Layout} entering={FadeInDown} exiting={FadeOutDown} style={styles.isCopying}>
+              <Text style={styles.copiedText}>{message}</Text>
+            </Animated.View>
+          ) : (
+            <View />
+          )}
 
           <Icon.CopySuccess size={26} color={colors.gray} />
         </View>

--- a/apps/wallet-mobile/src/components/CopyButton.tsx
+++ b/apps/wallet-mobile/src/components/CopyButton.tsx
@@ -33,13 +33,13 @@ export const CopyButton = ({value, onCopy, children, style, message}: CopyButton
   )
 }
 
-export const AnimatedCopyButton = ({
+const AnimatedCopyButton = ({
   onCopy,
   children,
   style,
   isCopying,
   message,
-}: Omit<CopyButtonProps, 'value'> & {isCopying: boolean; message?: string | null | undefined}) => {
+}: Omit<CopyButtonProps, 'value'> & {isCopying: boolean; message?: string}) => {
   const {styles, colors} = useStyles()
 
   return (

--- a/apps/wallet-mobile/src/features/Receive/common/ShareDetailsCard/ShareDetailsCard.tsx
+++ b/apps/wallet-mobile/src/features/Receive/common/ShareDetailsCard/ShareDetailsCard.tsx
@@ -45,7 +45,7 @@ export const ShareDetailsCard = ({address, spendingHash, stakingHash}: AddressDe
         <View style={styles.textRow}>
           <Text style={styles.textAddressDetails}>{address}</Text>
 
-          <CopyButton value={address} onCopy={handleAddressOnCopy} />
+          <CopyButton value={address} onCopy={handleAddressOnCopy} message={strings.addressCopiedMsg} />
         </View>
       </View>
 
@@ -56,7 +56,7 @@ export const ShareDetailsCard = ({address, spendingHash, stakingHash}: AddressDe
           <View style={styles.textRow}>
             <Text style={styles.textAddressDetails}>{stakingHash}</Text>
 
-            <CopyButton value={stakingHash} />
+            <CopyButton value={stakingHash} message={strings.addressCopiedMsg} />
           </View>
         </View>
       )}
@@ -68,7 +68,7 @@ export const ShareDetailsCard = ({address, spendingHash, stakingHash}: AddressDe
           <View style={styles.textRow}>
             <Text style={styles.textAddressDetails}>{spendingHash}</Text>
 
-            <CopyButton value={spendingHash} />
+            <CopyButton value={spendingHash} message={strings.addressCopiedMsg} />
           </View>
         </View>
       )}


### PR DESCRIPTION
Fixes [YOMO-1285](https://emurgo.atlassian.net/browse/YOMO-1285)

After  fix:


<img src="https://github.com/Emurgo/yoroi/assets/62512215/172dabe6-5f83-47cb-b11a-b80c611bcf11" alt="Image" width="300" height="700">



[YOMO-1285]: https://emurgo.atlassian.net/browse/YOMO-1285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ