### PR TITLE
fix(wallet-mobile): Non sticky max address message

### DIFF
--- a/apps/wallet-mobile/src/features/Receive/useCases/ListMultipleAddressesScreen.tsx
+++ b/apps/wallet-mobile/src/features/Receive/useCases/ListMultipleAddressesScreen.tsx
@@ -1,7 +1,7 @@
 import {useFocusEffect} from '@react-navigation/native'
 import {useTheme} from '@yoroi/theme'
 import * as React from 'react'
-import {StyleSheet, View, ViewToken} from 'react-native'
+import {NativeScrollEvent, NativeSyntheticEvent, ScrollView, StyleSheet, View, ViewToken} from 'react-native'
 import Animated, {Layout} from 'react-native-reanimated'
 import {SafeAreaView} from 'react-native-safe-area-context'
 
@@ -72,10 +72,26 @@ export const ListMultipleAddressesScreen = () => {
     }, [track]),
   )
 
+  const [showAddressLimitInfo, setShowAddressLimitInfo] = React.useState(true)
+  const scrollViewRef = React.useRef<ScrollView>(null)
+
+  const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    if (event.nativeEvent.contentOffset.y <= 0) {
+      setShowAddressLimitInfo(true)
+    } else if (showAddressLimitInfo && event.nativeEvent.contentOffset.y > 0) {
+      setShowAddressLimitInfo(false)
+    }
+  }
+  React.useEffect(() => {
+    if (hasReachedGapLimit) {
+      setShowAddressLimitInfo(true)
+    }
+  }, [hasReachedGapLimit])
+
   return (
     <SafeAreaView style={styles.root} edges={['left', 'right', 'bottom']}>
       <View style={styles.content}>
-        {hasReachedGapLimit && (
+        {showAddressLimitInfo && hasReachedGapLimit && (
           <>
             <ShowAddressLimitInfo />
 
@@ -83,14 +99,21 @@ export const ListMultipleAddressesScreen = () => {
           </>
         )}
 
-        <Animated.FlatList
-          data={addressInfos}
-          keyExtractor={(addressInfo) => addressInfo.address}
-          renderItem={renderAddressInfo}
-          layout={Layout}
+        <ScrollView
+          ref={scrollViewRef}
+          onScroll={handleScroll}
+          scrollEventThrottle={16}
           showsVerticalScrollIndicator={false}
-          onViewableItemsChanged={onViewableItemsChanged}
-        />
+        >
+          <Animated.FlatList
+            data={addressInfos}
+            keyExtractor={(addressInfo) => addressInfo.address}
+            renderItem={renderAddressInfo}
+            layout={Layout}
+            showsVerticalScrollIndicator={false}
+            onViewableItemsChanged={onViewableItemsChanged}
+          />
+        </ScrollView>
       </View>
 
       <Animated.View

--- a/apps/wallet-mobile/src/features/Receive/useCases/ListMultipleAddressesScreen.tsx
+++ b/apps/wallet-mobile/src/features/Receive/useCases/ListMultipleAddressesScreen.tsx
@@ -1,7 +1,15 @@
 import {useFocusEffect} from '@react-navigation/native'
 import {useTheme} from '@yoroi/theme'
 import * as React from 'react'
-import {NativeScrollEvent, NativeSyntheticEvent, ScrollView, StyleSheet, View, ViewToken} from 'react-native'
+import {
+  LayoutAnimation,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  ScrollView,
+  StyleSheet,
+  View,
+  ViewToken,
+} from 'react-native'
 import Animated, {Layout} from 'react-native-reanimated'
 import {SafeAreaView} from 'react-native-safe-area-context'
 
@@ -77,6 +85,7 @@ export const ListMultipleAddressesScreen = () => {
 
   const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
     if (event.nativeEvent.contentOffset.y <= 0) {
+      LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
       setShowAddressLimitInfo(true)
     } else if (showAddressLimitInfo && event.nativeEvent.contentOffset.y > 0) {
       setShowAddressLimitInfo(false)
@@ -84,6 +93,7 @@ export const ListMultipleAddressesScreen = () => {
   }
   React.useEffect(() => {
     if (hasReachedGapLimit) {
+      LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
       setShowAddressLimitInfo(true)
     }
   }, [hasReachedGapLimit])

--- a/apps/wallet-mobile/src/features/Receive/useCases/ListMultipleAddressesScreen.tsx
+++ b/apps/wallet-mobile/src/features/Receive/useCases/ListMultipleAddressesScreen.tsx
@@ -6,10 +6,8 @@ import {
   LayoutAnimation,
   NativeScrollEvent,
   NativeSyntheticEvent,
-  Platform,
   ScrollView,
   StyleSheet,
-  UIManager,
   View,
   ViewToken,
 } from 'react-native'
@@ -44,10 +42,6 @@ export const ListMultipleAddressesScreen = () => {
   const {addressMode} = useAddressModeManager()
   const addresses = useReceiveAddressesStatus(addressMode)
   const {selectedAddressChanged} = useReceive()
-
-  if (Platform.OS === 'android') {
-    UIManager.setLayoutAnimationEnabledExperimental(true)
-  }
 
   React.useEffect(() => {
     wallet.generateNewReceiveAddressIfNeeded()

--- a/apps/wallet-mobile/src/features/Receive/useCases/ListMultipleAddressesScreen.tsx
+++ b/apps/wallet-mobile/src/features/Receive/useCases/ListMultipleAddressesScreen.tsx
@@ -2,11 +2,14 @@ import {useFocusEffect} from '@react-navigation/native'
 import {useTheme} from '@yoroi/theme'
 import * as React from 'react'
 import {
+  InteractionManager,
   LayoutAnimation,
   NativeScrollEvent,
   NativeSyntheticEvent,
+  Platform,
   ScrollView,
   StyleSheet,
+  UIManager,
   View,
   ViewToken,
 } from 'react-native'
@@ -41,6 +44,10 @@ export const ListMultipleAddressesScreen = () => {
   const {addressMode} = useAddressModeManager()
   const addresses = useReceiveAddressesStatus(addressMode)
   const {selectedAddressChanged} = useReceive()
+
+  if (Platform.OS === 'android') {
+    UIManager.setLayoutAnimationEnabledExperimental(true)
+  }
 
   React.useEffect(() => {
     wallet.generateNewReceiveAddressIfNeeded()
@@ -85,16 +92,20 @@ export const ListMultipleAddressesScreen = () => {
 
   const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
     if (event.nativeEvent.contentOffset.y <= 0) {
-      LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
-      setShowAddressLimitInfo(true)
+      InteractionManager.runAfterInteractions(() => {
+        LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
+        setShowAddressLimitInfo(true)
+      })
     } else if (showAddressLimitInfo && event.nativeEvent.contentOffset.y > 0) {
       setShowAddressLimitInfo(false)
     }
   }
   React.useEffect(() => {
     if (hasReachedGapLimit) {
-      LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
-      setShowAddressLimitInfo(true)
+      InteractionManager.runAfterInteractions(() => {
+        LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
+        setShowAddressLimitInfo(true)
+      })
     }
   }, [hasReachedGapLimit])
 


### PR DESCRIPTION
Fixes [YOMO-1292](https://emurgo.atlassian.net/browse/YOMO-1292)

Below cases were handled

1. Limit was just reached - the message is displayed at the top of the current view regardless of the current scroll position. If user scrolls from this position, message disappears and can see it again if scrolls all the way up.
2. Limit already reached and user enters receive funnel - the message is displayed on the top and if user scrolls down it disappears and if user scrolls back all the way up, the message reappears

[YOMO-1292]: https://emurgo.atlassian.net/browse/YOMO-1292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ