### PR TITLE
fix(setup-wallet): mnemonic input local/selected word inequality on blur

### DIFF
--- a/apps/wallet-mobile/src/features/SetupWallet/useCases/RestoreWallet/MnemonicInput/MnemonicInput.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/useCases/RestoreWallet/MnemonicInput/MnemonicInput.tsx
@@ -232,18 +232,18 @@ const MnemonicWordInput = React.forwardRef<MnemonicWordInputRef, MnemonicWordInp
       [],
     )
 
-    const onSubmitEditing = React.useCallback(() => {
+    const handleOnSubmitEditing = React.useCallback(() => {
       if (!isEmptyString(suggestedWords[0])) {
         onSelect(normalizeText(suggestedWords[0]))
       }
     }, [suggestedWords, onSelect])
 
-    const onChangeText = React.useCallback(
+    const handleOnChangeText = React.useCallback(
       (text: string) => {
         if (text.endsWith(' ')) {
           text = text.trimEnd()
           setWord(normalizeText(text))
-          onSubmitEditing()
+          handleOnSubmitEditing()
         } else {
           setWord(normalizeText(text))
         }
@@ -262,15 +262,15 @@ const MnemonicWordInput = React.forwardRef<MnemonicWordInputRef, MnemonicWordInp
           onClearError()
         }
       },
-      [onClearError, onError, onSubmitEditing, setSuggestedWords],
+      [onClearError, onError, handleOnSubmitEditing, setSuggestedWords],
     )
 
     const handleOnBlur = React.useCallback(() => {
       if (word !== selectedWord) {
-        onSubmitEditing()
+        handleOnSubmitEditing()
       }
       setSuggestedWords([])
-    }, [onSubmitEditing, selectedWord, setSuggestedWords, word])
+    }, [handleOnSubmitEditing, selectedWord, setSuggestedWords, word])
 
     return (
       <TextInput
@@ -286,10 +286,10 @@ const MnemonicWordInput = React.forwardRef<MnemonicWordInputRef, MnemonicWordInp
 
           onFocus()
         }}
-        onChangeText={onChangeText}
+        onChangeText={handleOnChangeText}
         enablesReturnKeyAutomatically
         blurOnSubmit={false}
-        onSubmitEditing={onSubmitEditing}
+        onSubmitEditing={handleOnSubmitEditing}
         dense
         selectTextOnFocus
         noHelper

--- a/apps/wallet-mobile/src/features/SetupWallet/useCases/RestoreWallet/MnemonicInput/MnemonicInput.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/useCases/RestoreWallet/MnemonicInput/MnemonicInput.tsx
@@ -265,7 +265,7 @@ const MnemonicWordInput = React.forwardRef<MnemonicWordInputRef, MnemonicWordInp
       [onClearError, onError, onSubmitEditing, setSuggestedWords],
     )
 
-    const onBlur = React.useCallback(() => {
+    const handleOnBlur = React.useCallback(() => {
       if (word !== selectedWord) {
         onSubmitEditing()
       }
@@ -306,7 +306,7 @@ const MnemonicWordInput = React.forwardRef<MnemonicWordInputRef, MnemonicWordInp
             onKeyPress(word)
           }
         }}
-        onBlur={onBlur}
+        onBlur={handleOnBlur}
         keyboardType={Platform.OS === 'android' ? 'visible-password' : undefined} // to hide keyboard suggestions on android
       />
     )

--- a/apps/wallet-mobile/src/features/SetupWallet/useCases/RestoreWallet/MnemonicInput/MnemonicInput.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/useCases/RestoreWallet/MnemonicInput/MnemonicInput.tsx
@@ -265,6 +265,13 @@ const MnemonicWordInput = React.forwardRef<MnemonicWordInputRef, MnemonicWordInp
       [onClearError, onError, onSubmitEditing, setSuggestedWords],
     )
 
+    const onBlur = React.useCallback(() => {
+      if (word !== selectedWord) {
+        onSubmitEditing()
+      }
+      setSuggestedWords([])
+    }, [onSubmitEditing, selectedWord, setSuggestedWords, word])
+
     return (
       <TextInput
         ref={inputRef}
@@ -299,7 +306,7 @@ const MnemonicWordInput = React.forwardRef<MnemonicWordInputRef, MnemonicWordInp
             onKeyPress(word)
           }
         }}
-        onBlur={() => setSuggestedWords([])}
+        onBlur={onBlur}
         keyboardType={Platform.OS === 'android' ? 'visible-password' : undefined} // to hide keyboard suggestions on android
       />
     )


### PR DESCRIPTION
This situation occurs when the user moves the focus to another input without completing the selection in the input that was blurred.

Related to [YOMO-1424](https://emurgo.atlassian.net/browse/YOMO-1424)

[YOMO-1424]: https://emurgo.atlassian.net/browse/YOMO-1424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ