### PR TITLE
fix(wallet-mobile): Remove duplicate variable to fix staking navigation check

### DIFF
--- a/apps/wallet-mobile/src/kernel/env.ts
+++ b/apps/wallet-mobile/src/kernel/env.ts
@@ -16,7 +16,6 @@ export const frontendFeeAddressPreprod = getString('FRONTEND_FEE_ADDRESS_PREPROD
 
 export const banxaTestWallet = getString('BANXA_TEST_WALLET')
 
-export const dappExplorerEnabled = Boolean(BuildConfig['DAPP_EXPLORER_ENABLED'])
 export const disableLogbox = Boolean(BuildConfig['DISABLE_LOGBOX'])
 
 const possibleLoggerFilter = getString('LOGGER_FILTER')

--- a/apps/wallet-mobile/src/kernel/navigation.tsx
+++ b/apps/wallet-mobile/src/kernel/navigation.tsx
@@ -20,7 +20,7 @@ import {ScanFeature} from '../features/Scan/common/types'
 import {Routes as StakingGovernanceRoutes} from '../features/Staking/Governance/common/navigation'
 import {YoroiUnsignedTx} from '../yoroi-wallets/types'
 import {compareArrays} from '../yoroi-wallets/utils/utils'
-import {dappExplorerEnabled} from './env'
+import {dappExplorerEnabled} from './config'
 
 // prettier-ignore
 export const useUnsafeParams = <Params, >() => {


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

Remove duplicate `dappExplorerEnabled` variable to fix feature check in staking navigation

##### Ticket

[YOMO-1471](https://emurgo.atlassian.net/browse/YOMO-1471)


[YOMO-1471]: https://emurgo.atlassian.net/browse/YOMO-1471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ