### PR TITLE
(pool-transition) Fix modal reopening

### DIFF
--- a/apps/wallet-mobile/package.json
+++ b/apps/wallet-mobile/package.json
@@ -99,7 +99,7 @@
     "@emurgo/csl-mobile-bridge": "6.0.0-alpha.9",
     "@emurgo/react-native-blockies-svg": "^0.0.2",
     "@emurgo/react-native-hid": "^5.15.6",
-    "@emurgo/yoroi-lib": "0.15.5-alpha.8",
+    "@emurgo/yoroi-lib": "0.15.5",
     "@formatjs/intl-datetimeformat": "^6.7.0",
     "@formatjs/intl-getcanonicallocales": "^2.1.0",
     "@formatjs/intl-locale": "^3.2.1",

--- a/apps/wallet-mobile/src/Staking/PoolTransition/PoolTransitionModal.tsx
+++ b/apps/wallet-mobile/src/Staking/PoolTransition/PoolTransitionModal.tsx
@@ -6,9 +6,7 @@ import LinearGradient from 'react-native-linear-gradient'
 
 import {Button, Icon, useModal} from '../../components'
 import {Space} from '../../components/Space/Space'
-import {useSelectedWallet} from '../../features/WalletManager/Context/SelectedWalletContext'
 import {formatTimeSpan} from '../../yoroi-wallets/utils'
-import {usePoolTransitionContext} from './PoolTransitionProvider'
 import {useStrings} from './usePoolTransition'
 
 export const PoolTransitionModal = ({
@@ -23,11 +21,8 @@ export const PoolTransitionModal = ({
   const strings = useStrings()
 
   const {closeModal} = useModal()
-  const wallet = useSelectedWallet()
-  const [, setClosedWallets] = usePoolTransitionContext()
 
-  const handleClose = () => {
-    setClosedWallets((closedWallets) => [wallet.id, ...closedWallets])
+  const handleOnSkip = () => {
     closeModal()
   }
 
@@ -37,7 +32,7 @@ export const PoolTransitionModal = ({
       await onContinue()
     } finally {
       setIsLoading(false)
-      handleClose()
+      closeModal()
     }
   }
 
@@ -138,7 +133,7 @@ export const PoolTransitionModal = ({
       <Space height="xl" />
 
       <Actions>
-        <Button outline title={strings.skipNoRewards} textStyles={styles.outlineButton} onPress={handleClose} />
+        <Button outline title={strings.skipNoRewards} textStyles={styles.outlineButton} onPress={handleOnSkip} />
 
         <Button
           shelleyTheme

--- a/apps/wallet-mobile/src/Staking/PoolTransition/PoolTransitionModal.tsx
+++ b/apps/wallet-mobile/src/Staking/PoolTransition/PoolTransitionModal.tsx
@@ -6,7 +6,9 @@ import LinearGradient from 'react-native-linear-gradient'
 
 import {Button, Icon, useModal} from '../../components'
 import {Space} from '../../components/Space/Space'
+import {useSelectedWallet} from '../../features/WalletManager/Context/SelectedWalletContext'
 import {formatTimeSpan} from '../../yoroi-wallets/utils'
+import {usePoolTransitionContext} from './PoolTransitionProvider'
 import {useStrings} from './usePoolTransition'
 
 export const PoolTransitionModal = ({
@@ -21,8 +23,11 @@ export const PoolTransitionModal = ({
   const strings = useStrings()
 
   const {closeModal} = useModal()
+  const wallet = useSelectedWallet()
+  const [, setClosedWallets] = usePoolTransitionContext()
 
-  const handleOnSkip = () => {
+  const handleClose = () => {
+    setClosedWallets((closedWallets) => [wallet.id, ...closedWallets])
     closeModal()
   }
 
@@ -32,7 +37,7 @@ export const PoolTransitionModal = ({
       await onContinue()
     } finally {
       setIsLoading(false)
-      closeModal()
+      handleClose()
     }
   }
 
@@ -133,7 +138,7 @@ export const PoolTransitionModal = ({
       <Space height="xl" />
 
       <Actions>
-        <Button outline title={strings.skipNoRewards} textStyles={styles.outlineButton} onPress={handleOnSkip} />
+        <Button outline title={strings.skipNoRewards} textStyles={styles.outlineButton} onPress={handleClose} />
 
         <Button
           shelleyTheme

--- a/apps/wallet-mobile/src/Staking/PoolTransition/PoolTransitionProvider.tsx
+++ b/apps/wallet-mobile/src/Staking/PoolTransition/PoolTransitionProvider.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+const PoolTransitionContext = React.createContext<
+  [string[], React.Dispatch<React.SetStateAction<string[]>>] | undefined
+>(undefined)
+
+export const PoolTransitionProvider = ({children}: {children: React.ReactNode}) => {
+  const value = React.useState<Array<string>>([])
+
+  return <PoolTransitionContext.Provider value={value}>{children}</PoolTransitionContext.Provider>
+}
+
+export const usePoolTransitionContext = () => React.useContext(PoolTransitionContext) || missingProvider()
+
+const missingProvider = () => {
+  throw new Error('PoolTransitionProvider is missing')
+}

--- a/apps/wallet-mobile/src/Staking/PoolTransition/usePoolTransitionModal.tsx
+++ b/apps/wallet-mobile/src/Staking/PoolTransition/usePoolTransitionModal.tsx
@@ -1,24 +1,37 @@
 import * as React from 'react'
 
 import {useModal} from '../../components'
+import {useSelectedWallet} from '../../features/WalletManager/Context/SelectedWalletContext'
 import {PoolTransitionModal} from './PoolTransitionModal'
+import {usePoolTransitionContext} from './PoolTransitionProvider'
 import {usePoolTransition, useStrings} from './usePoolTransition'
 
 export const usePoolTransitionModal = () => {
   const {poolTransition, isPoolRetiring, isLoading, navigateToUpdate} = usePoolTransition()
+  const wallet = useSelectedWallet()
+  const [closedWallets] = usePoolTransitionContext()
   const {openModal} = useModal()
   const strings = useStrings()
   const modalHeight = 700
 
   React.useEffect(() => {
-    if (isPoolRetiring && poolTransition !== null) {
+    if (!closedWallets.includes(wallet.id) && isPoolRetiring && poolTransition !== null) {
       openModal(
         strings.title,
         <PoolTransitionModal poolTransition={poolTransition} onContinue={navigateToUpdate} />,
         modalHeight,
       )
     }
-  }, [isPoolRetiring, modalHeight, navigateToUpdate, openModal, poolTransition, strings.title])
+  }, [
+    closedWallets,
+    isPoolRetiring,
+    modalHeight,
+    navigateToUpdate,
+    openModal,
+    poolTransition,
+    strings.title,
+    wallet.id,
+  ])
 
   return {isLoading}
 }

--- a/apps/wallet-mobile/src/Staking/PoolTransition/usePoolTransitionModal.tsx
+++ b/apps/wallet-mobile/src/Staking/PoolTransition/usePoolTransitionModal.tsx
@@ -9,21 +9,22 @@ import {usePoolTransition, useStrings} from './usePoolTransition'
 export const usePoolTransitionModal = () => {
   const {poolTransition, isPoolRetiring, isLoading, navigateToUpdate} = usePoolTransition()
   const wallet = useSelectedWallet()
-  const [closedWallets] = usePoolTransitionContext()
+  const [shownWallets, setShownWallets] = usePoolTransitionContext()
   const {openModal} = useModal()
   const strings = useStrings()
   const modalHeight = 700
 
   React.useEffect(() => {
-    if (!closedWallets.includes(wallet.id) && isPoolRetiring && poolTransition !== null) {
+    if (!shownWallets.includes(wallet.id) && isPoolRetiring && poolTransition !== null) {
       openModal(
         strings.title,
         <PoolTransitionModal poolTransition={poolTransition} onContinue={navigateToUpdate} />,
         modalHeight,
       )
+      setShownWallets(() => [wallet.id, ...shownWallets])
     }
   }, [
-    closedWallets,
+    shownWallets,
     isPoolRetiring,
     modalHeight,
     navigateToUpdate,
@@ -31,6 +32,7 @@ export const usePoolTransitionModal = () => {
     poolTransition,
     strings.title,
     wallet.id,
+    setShownWallets,
   ])
 
   return {isLoading}

--- a/apps/wallet-mobile/src/YoroiApp.tsx
+++ b/apps/wallet-mobile/src/YoroiApp.tsx
@@ -22,6 +22,7 @@ import {CONFIG} from './legacy/config'
 import {setLogLevel} from './legacy/logging'
 import {makeMetricsManager, MetricsProvider} from './metrics/metricsManager'
 import {useMigrations} from './migrations/useMigrations'
+import {PoolTransitionProvider} from './Staking/PoolTransition/PoolTransitionProvider'
 import {walletManager} from './wallet-manager/walletManager'
 import {WalletManagerProvider} from './wallet-manager/WalletManagerContext'
 import {rootStorage} from './yoroi-wallets/storage/rootStorage'
@@ -66,7 +67,9 @@ export const YoroiApp = () => {
                               <SelectedWalletProvider>
                                 <LinksProvider>
                                   <SetupWalletProvider>
-                                    <InitApp />
+                                    <PoolTransitionProvider>
+                                      <InitApp />
+                                    </PoolTransitionProvider>
                                   </SetupWalletProvider>
                                 </LinksProvider>
                               </SelectedWalletProvider>

--- a/apps/wallet-mobile/translations/messages/src/Staking/PoolTransition/usePoolTransition.json
+++ b/apps/wallet-mobile/translations/messages/src/Staking/PoolTransition/usePoolTransition.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 114,
       "column": 9,
-      "index": 4044
+      "index": 4001
     },
     "end": {
       "line": 117,
       "column": 3,
-      "index": 4142
+      "index": 4099
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 118,
       "column": 11,
-      "index": 4155
+      "index": 4112
     },
     "end": {
       "line": 122,
       "column": 3,
-      "index": 4351
+      "index": 4308
     }
   },
   {
@@ -36,12 +36,12 @@
     "start": {
       "line": 123,
       "column": 16,
-      "index": 4369
+      "index": 4326
     },
     "end": {
       "line": 127,
       "column": 3,
-      "index": 4575
+      "index": 4532
     }
   },
   {
@@ -51,12 +51,12 @@
     "start": {
       "line": 128,
       "column": 15,
-      "index": 4592
+      "index": 4549
     },
     "end": {
       "line": 131,
       "column": 3,
-      "index": 4685
+      "index": 4642
     }
   },
   {
@@ -66,12 +66,12 @@
     "start": {
       "line": 132,
       "column": 11,
-      "index": 4698
+      "index": 4655
     },
     "end": {
       "line": 135,
       "column": 3,
-      "index": 4783
+      "index": 4740
     }
   },
   {
@@ -81,12 +81,12 @@
     "start": {
       "line": 136,
       "column": 16,
-      "index": 4801
+      "index": 4758
     },
     "end": {
       "line": 139,
       "column": 3,
-      "index": 4896
+      "index": 4853
     }
   },
   {
@@ -96,12 +96,12 @@
     "start": {
       "line": 140,
       "column": 7,
-      "index": 4905
+      "index": 4862
     },
     "end": {
       "line": 143,
       "column": 3,
-      "index": 4981
+      "index": 4938
     }
   },
   {
@@ -111,12 +111,12 @@
     "start": {
       "line": 144,
       "column": 24,
-      "index": 5007
+      "index": 4964
     },
     "end": {
       "line": 147,
       "column": 3,
-      "index": 5144
+      "index": 5101
     }
   },
   {
@@ -126,12 +126,12 @@
     "start": {
       "line": 148,
       "column": 17,
-      "index": 5163
+      "index": 5120
     },
     "end": {
       "line": 151,
       "column": 3,
-      "index": 5297
+      "index": 5254
     }
   },
   {
@@ -141,12 +141,12 @@
     "start": {
       "line": 152,
       "column": 23,
-      "index": 5322
+      "index": 5279
     },
     "end": {
       "line": 155,
       "column": 3,
-      "index": 5452
+      "index": 5409
     }
   },
   {
@@ -156,12 +156,12 @@
     "start": {
       "line": 156,
       "column": 17,
-      "index": 5471
+      "index": 5428
     },
     "end": {
       "line": 159,
       "column": 3,
-      "index": 5585
+      "index": 5542
     }
   },
   {
@@ -171,12 +171,12 @@
     "start": {
       "line": 160,
       "column": 21,
-      "index": 5608
+      "index": 5565
     },
     "end": {
       "line": 163,
       "column": 3,
-      "index": 5722
+      "index": 5679
     }
   },
   {
@@ -186,12 +186,12 @@
     "start": {
       "line": 164,
       "column": 10,
-      "index": 5734
+      "index": 5691
     },
     "end": {
       "line": 167,
       "column": 3,
-      "index": 5821
+      "index": 5778
     }
   }
 ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2780,10 +2780,10 @@
     bignumber.js "^9.0.1"
     easy-crc "1.1.0"
 
-"@emurgo/yoroi-lib@0.15.5-alpha.8":
-  version "0.15.5-alpha.8"
-  resolved "https://registry.yarnpkg.com/@emurgo/yoroi-lib/-/yoroi-lib-0.15.5-alpha.8.tgz#71791392419f718d19256c4aaedd1ac8d3a37bbe"
-  integrity sha512-avc0cwttCgEgBMflxKK2Kaxw4IbErLa+ezlWWgJ4iGN0fgHYcpY335xXd2g+cQmsRKpPyhNWWqPXafo6e8lT8Q==
+"@emurgo/yoroi-lib@0.15.5":
+  version "0.15.5"
+  resolved "https://registry.yarnpkg.com/@emurgo/yoroi-lib/-/yoroi-lib-0.15.5.tgz#534cf4b81376f2b185b73e05a2103d9712be4a8d"
+  integrity sha512-Fq6MN/l5Na14d3LOsnT7xzKDky1ugbKxQ6+zzxchZkcF+w0OXGtK4sFGXccR47E7JhRLhjLqOzKSKhKGkTVt+A==
   dependencies:
     "@cardano-foundation/ledgerjs-hw-app-cardano" "^6.0.0"
     "@emurgo/cross-csl-core" "4.4.0"


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

##### Ticket

[YOMO-1477
](https://emurgo.atlassian.net/browse/YOMO-1477)


So the idea is that every wallet (per app restart) gets the modal to transition a pool at most once.
Had to have a global state just to remember if a modal has been closed already, using an array of wallet ids.