### PR TITLE
fix(navigation): Set height to 0 when tab bar is hidden

### DIFF
--- a/apps/wallet-mobile/src/kernel/navigation.tsx
+++ b/apps/wallet-mobile/src/kernel/navigation.tsx
@@ -627,7 +627,7 @@ export const hideTabBarForRoutes = (
   getFocusedRouteNameFromRoute(route)?.startsWith('exchange') ||
   getFocusedRouteNameFromRoute(route)?.startsWith('discover-browser') ||
   getFocusedRouteNameFromRoute(route)?.startsWith('portfolio')
-    ? {display: 'none'}
+    ? {display: 'none', height: 0}
     : undefined
 
 function useKeepRoutesInHistory(routesToKeep: string[]) {


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)
Setting tab bar height to 0 seems to resolve the weird navigation behaviour


##### Ticket

[YOMO-1487](https://emurgo.atlassian.net/jira/software/c/projects/YOMO/issues/YOMO-1487)



[YOMO-1487]: https://emurgo.atlassian.net/browse/YOMO-1487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ