### PR TITLE
fix(wallet-mobile): avatar svg requires img size on android

### DIFF
--- a/apps/wallet-mobile/src/WalletNavigator.tsx
+++ b/apps/wallet-mobile/src/WalletNavigator.tsx
@@ -289,6 +289,7 @@ const useStyles = () => {
       ...atoms.body_1_lg_medium,
       width: width - 75,
       textAlign: 'center',
+      color: color.text_gray_normal,
     },
     headerTitleContainerStyle: {
       flex: 1,

--- a/apps/wallet-mobile/src/components/Icon/WalletAvatar.tsx
+++ b/apps/wallet-mobile/src/components/Icon/WalletAvatar.tsx
@@ -6,14 +6,15 @@ import {StyleSheet, View, ViewStyle} from 'react-native'
 type Props = {
   image: string
   style?: ViewStyle
+  size?: number
 }
 
-export const WalletAvatar = ({image = '', style}: Props) => {
+export const WalletAvatar = ({image = '', size = 40, style}: Props) => {
   const styles = useStyles()
 
   return (
     <View style={[styles.defaultStyle, style]}>
-      <Image source={{uri: image}} style={{width: 40, height: 40}} />
+      <Image source={{uri: image, width: 64, height: 64}} style={{width: size, height: size}} />
     </View>
   )
 }

--- a/apps/wallet-mobile/src/features/SetupWallet/common/CardAboutPhrase/CardAboutPhrase.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/common/CardAboutPhrase/CardAboutPhrase.tsx
@@ -64,6 +64,7 @@ export const CardAboutPhrase = ({
                     <Icon.WalletAvatar
                       image={new Blockies().asBase64({seed: checksumImage})}
                       style={styles.walletChecksum}
+                      size={24}
                     />
 
                     <Space width="sm" />

--- a/apps/wallet-mobile/src/features/SetupWallet/useCases/CreateWallet/WalletDetailsScreen.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/useCases/CreateWallet/WalletDetailsScreen.tsx
@@ -333,7 +333,7 @@ export const WalletDetailsScreen = () => {
           <Space height="xl" />
 
           <View style={styles.checksum}>
-            <Icon.WalletAvatar image={new Blockies().asBase64({seed: plate.ImagePart})} style={styles.walletChecksum} />
+            <Icon.WalletAvatar image={new Blockies().asBase64({seed: plate.ImagePart})} style={styles.walletChecksum} size={24} />
 
             <Space width="sm" />
 

--- a/apps/wallet-mobile/src/features/SetupWallet/useCases/RestoreWallet/RestoreWalletDetailsScreen.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/useCases/RestoreWallet/RestoreWalletDetailsScreen.tsx
@@ -284,7 +284,7 @@ export const RestoreWalletDetailsScreen = () => {
           <Space height="xl" />
 
           <View style={styles.checksum}>
-            <Icon.WalletAvatar image={new Blockies().asBase64({seed: plate.ImagePart})} style={styles.walletChecksum} />
+            <Icon.WalletAvatar image={new Blockies().asBase64({seed: plate.ImagePart})} style={styles.walletChecksum} size={24} />
 
             <Space width="sm" />
 

--- a/apps/wallet-mobile/src/features/SetupWallet/useCases/RestoreWallet/RestoreWalletScreen.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/useCases/RestoreWallet/RestoreWalletScreen.tsx
@@ -237,7 +237,7 @@ const Modal = ({
       <Space height="lg" />
 
       <View style={styles.checksum}>
-        <Icon.WalletAvatar image={new Blockies().asBase64({seed: plate.ImagePart})} style={styles.walletChecksum} />
+        <Icon.WalletAvatar image={new Blockies().asBase64({seed: plate.ImagePart})} style={styles.walletChecksum} size={38} />
 
         <Space width="sm" />
 

--- a/apps/wallet-mobile/src/legacy/TxHistory/BalanceBanner.tsx
+++ b/apps/wallet-mobile/src/legacy/TxHistory/BalanceBanner.tsx
@@ -22,7 +22,7 @@ export const BalanceBanner = React.forwardRef<ResetErrorRef>((_, ref) => {
       <Spacer height={14} />
 
       <CenteredRow>
-        <Icon.WalletAvatar style={styles.walletIcon} image={meta.avatar} />
+        <Icon.WalletAvatar style={styles.walletIcon} image={meta.avatar} size={40} />
       </CenteredRow>
 
       <Spacer height={10} />

--- a/apps/wallet-mobile/translations/messages/src/WalletNavigator.json
+++ b/apps/wallet-mobile/translations/messages/src/WalletNavigator.json
@@ -4,14 +4,14 @@
     "defaultMessage": "!!!Transactions",
     "file": "src/WalletNavigator.tsx",
     "start": {
-      "line": 316,
+      "line": 317,
       "column": 22,
-      "index": 10791
+      "index": 10828
     },
     "end": {
-      "line": 319,
+      "line": 320,
       "column": 3,
-      "index": 10894
+      "index": 10931
     }
   },
   {
@@ -19,14 +19,14 @@
     "defaultMessage": "!!!Send",
     "file": "src/WalletNavigator.tsx",
     "start": {
-      "line": 320,
+      "line": 321,
       "column": 14,
-      "index": 10910
+      "index": 10947
     },
     "end": {
-      "line": 323,
+      "line": 324,
       "column": 3,
-      "index": 11009
+      "index": 11046
     }
   },
   {
@@ -34,14 +34,14 @@
     "defaultMessage": "!!!Receive",
     "file": "src/WalletNavigator.tsx",
     "start": {
-      "line": 324,
+      "line": 325,
       "column": 17,
-      "index": 11028
+      "index": 11065
     },
     "end": {
-      "line": 327,
+      "line": 328,
       "column": 3,
-      "index": 11133
+      "index": 11170
     }
   },
   {
@@ -49,14 +49,14 @@
     "defaultMessage": "!!!Dashboard",
     "file": "src/WalletNavigator.tsx",
     "start": {
-      "line": 328,
+      "line": 329,
       "column": 19,
-      "index": 11154
+      "index": 11191
     },
     "end": {
-      "line": 331,
+      "line": 332,
       "column": 3,
-      "index": 11251
+      "index": 11288
     }
   },
   {
@@ -64,14 +64,14 @@
     "defaultMessage": "!!!Delegate",
     "file": "src/WalletNavigator.tsx",
     "start": {
-      "line": 332,
+      "line": 333,
       "column": 18,
-      "index": 11271
+      "index": 11308
     },
     "end": {
-      "line": 335,
+      "line": 336,
       "column": 3,
-      "index": 11366
+      "index": 11403
     }
   },
   {
@@ -79,14 +79,14 @@
     "defaultMessage": "!!!Wallet",
     "file": "src/WalletNavigator.tsx",
     "start": {
-      "line": 336,
+      "line": 337,
       "column": 16,
-      "index": 11384
+      "index": 11421
     },
     "end": {
-      "line": 339,
+      "line": 340,
       "column": 3,
-      "index": 11482
+      "index": 11519
     }
   },
   {
@@ -94,14 +94,14 @@
     "defaultMessage": "!!!Staking",
     "file": "src/WalletNavigator.tsx",
     "start": {
-      "line": 340,
+      "line": 341,
       "column": 17,
-      "index": 11501
+      "index": 11538
     },
     "end": {
-      "line": 343,
+      "line": 344,
       "column": 3,
-      "index": 11566
+      "index": 11603
     }
   },
   {
@@ -109,14 +109,14 @@
     "defaultMessage": "!!!NFT Gallery",
     "file": "src/WalletNavigator.tsx",
     "start": {
-      "line": 344,
+      "line": 345,
       "column": 14,
-      "index": 11582
+      "index": 11619
     },
     "end": {
-      "line": 347,
+      "line": 348,
       "column": 3,
-      "index": 11676
+      "index": 11713
     }
   },
   {
@@ -124,14 +124,14 @@
     "defaultMessage": "!!!Menu",
     "file": "src/WalletNavigator.tsx",
     "start": {
-      "line": 348,
+      "line": 349,
       "column": 14,
-      "index": 11692
+      "index": 11729
     },
     "end": {
-      "line": 351,
+      "line": 352,
       "column": 3,
-      "index": 11744
+      "index": 11781
     }
   },
   {
@@ -139,14 +139,14 @@
     "defaultMessage": "!!!Discover",
     "file": "src/WalletNavigator.tsx",
     "start": {
-      "line": 352,
+      "line": 353,
       "column": 18,
-      "index": 11764
+      "index": 11801
     },
     "end": {
-      "line": 355,
+      "line": 356,
       "column": 3,
-      "index": 11853
+      "index": 11890
     }
   },
   {
@@ -154,14 +154,14 @@
     "defaultMessage": "!!!My wallets",
     "file": "src/WalletNavigator.tsx",
     "start": {
-      "line": 356,
+      "line": 357,
       "column": 31,
-      "index": 11886
+      "index": 11923
     },
     "end": {
-      "line": 359,
+      "line": 360,
       "column": 3,
-      "index": 11995
+      "index": 12032
     }
   },
   {
@@ -169,14 +169,14 @@
     "defaultMessage": "!!!Portfolio",
     "file": "src/WalletNavigator.tsx",
     "start": {
-      "line": 360,
+      "line": 361,
       "column": 19,
-      "index": 12016
+      "index": 12053
     },
     "end": {
-      "line": 363,
+      "line": 364,
       "column": 3,
-      "index": 12085
+      "index": 12122
     }
   }
 ]


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

On Android, `expo-image` requires `width` + `height` for base64