### PR TITLE
fix(wallet-mobile): receive address visual derivation

### DIFF
--- a/apps/wallet-mobile/src/features/Receive/common/useReceiveAddressesStatus.tsx
+++ b/apps/wallet-mobile/src/features/Receive/common/useReceiveAddressesStatus.tsx
@@ -7,6 +7,7 @@ type ReceiveAddressesStatus = {
   used: string[]
   unused: string[]
   next: string
+  canIncrease: boolean
 }
 export const useReceiveAddressesStatus = (addressMode: Wallet.AddressMode): Readonly<ReceiveAddressesStatus> => {
   const {wallet} = useSelectedWallet()
@@ -24,14 +25,17 @@ export const useReceiveAddressesStatus = (addressMode: Wallet.AddressMode): Read
       }
       return addresses
     },
-    {used: [], unused: []} as Omit<ReceiveAddressesStatus, 'next'>,
+    {used: [], unused: []} as Omit<ReceiveAddressesStatus, 'next' | 'canIncrease'>,
   )
+  const info = wallet.receiveAddressInfo
+  const limitUnused = addressesStatus.unused.slice(0, info.lastUsedIndexVisual + 1)
   const multipleAddress = addressesStatus.unused[0] ?? addressesStatus.used[0]
   const nextAddress = isSingle ? singleAddress : multipleAddress
   const result: ReceiveAddressesStatus = {
     used: addressesStatus.used,
-    unused: addressesStatus.unused,
+    unused: limitUnused,
     next: nextAddress,
+    canIncrease: info.canIncrease,
   } as const
 
   return result

--- a/apps/wallet-mobile/src/features/WalletManager/network-manager/helpers/get-wallet-factory.ts
+++ b/apps/wallet-mobile/src/features/WalletManager/network-manager/helpers/get-wallet-factory.ts
@@ -13,6 +13,8 @@ const ShelleyWalletMainnet = makeCardanoWallet(networkManagers[Chain.Network.Mai
 const ShelleyWalletTestnet = makeCardanoWallet(networkManagers[Chain.Network.Preprod], 'cardano-cip1852', TESTNET)
 const ShelleySanchonetWallet = makeCardanoWallet(networkManagers[Chain.Network.Sancho], 'cardano-cip1852', SANCHONET)
 const ByronWallet = makeCardanoWallet(networkManagers[Chain.Network.Mainnet], 'cardano-bip44', MAINNET)
+const ByronWalletTestnet = makeCardanoWallet(networkManagers[Chain.Network.Preprod], 'cardano-bip44', TESTNET)
+const ByronSanchonetWallet = makeCardanoWallet(networkManagers[Chain.Network.Sancho], 'cardano-bip44', SANCHONET)
 
 /**
  * Retrieves the wallet factory based on the network and implementation ID
@@ -37,9 +39,11 @@ export function getWalletFactory({
     },
     [Chain.Network.Preprod]: /* cardano testnet */ {
       'cardano-cip1852': ShelleyWalletTestnet,
+      'cardano-bip44': ByronWalletTestnet,
     },
     [Chain.Network.Sancho]: /* cardano sanchonet */ {
       'cardano-cip1852': ShelleySanchonetWallet,
+      'cardano-bip44': ByronSanchonetWallet,
     },
   } as const)
 

--- a/apps/wallet-mobile/src/yoroi-wallets/cardano/constants/cardano-config.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/cardano/constants/cardano-config.ts
@@ -9,6 +9,7 @@ export const cardanoConfig = freeze(
       minUtxoValue: 1_000_000n,
     },
     derivation: {
+      gapLimit: 20,
       hardStart: 2_147_483_648,
       keyLevel: {
         root: 0,
@@ -31,7 +32,6 @@ export const cardanoConfig = freeze(
           },
         },
         derivations: {
-          gapLimit: 20,
           base: {
             roles: {
               external: 0,
@@ -57,7 +57,6 @@ export const cardanoConfig = freeze(
           staking: false,
         },
         derivations: {
-          gapLimit: 20,
           base: {
             roles: {
               external: 0,

--- a/apps/wallet-mobile/src/yoroi-wallets/cardano/types.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/cardano/types.ts
@@ -90,6 +90,12 @@ export interface YoroiWallet {
   sync(params: {isForced?: boolean}): Promise<void>
   // ---------------------------------------------------------------------------------------
 
+  get receiveAddressInfo(): Readonly<{
+    lastUsedIndexVisual: number
+    lastUsedIndex: number
+    canIncrease: boolean
+  }>
+
   // API
   api: App.Api
 
@@ -143,11 +149,8 @@ export interface YoroiWallet {
   get externalAddresses(): Addresses
   get internalAddresses(): Addresses
   get isUsedAddressIndex(): Record<string, boolean>
-  get numReceiveAddresses(): number
   get receiveAddresses(): Addresses
-  canGenerateNewReceiveAddress(): boolean
   generateNewReceiveAddress(): boolean
-  generateNewReceiveAddressIfNeeded(): boolean
   getChangeAddress(addressMode: Wallet.AddressMode): string
 
   // Balances, TxDetails
@@ -224,11 +227,8 @@ const yoroiWalletKeys: Array<keyof YoroiWallet> = [
   'externalAddresses',
   'internalAddresses',
   'isUsedAddressIndex',
-  'numReceiveAddresses',
   'receiveAddresses',
-  'canGenerateNewReceiveAddress',
   'generateNewReceiveAddress',
-  'generateNewReceiveAddressIfNeeded',
 
   // Sync, Save
   'resync',

--- a/apps/wallet-mobile/src/yoroi-wallets/mocks/wallet.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/mocks/wallet.ts
@@ -242,15 +242,11 @@ const wallet: YoroiWallet = {
   confirmationCounts: {},
   transactions: mockTransactionInfos,
   isUsedAddressIndex: {},
-  numReceiveAddresses: 0,
   receiveAddresses: [],
-  canGenerateNewReceiveAddress: (...args: unknown[]) => {
-    action('canGenerateNewReceiveAddress')(...args)
-    return true
-  },
-  generateNewReceiveAddressIfNeeded: (...args: unknown[]) => {
-    action('generateNewReceiveAddressIfNeeded')(...args)
-    return true
+  receiveAddressInfo: {
+    canIncrease: true,
+    lastUsedIndex: 0,
+    lastUsedIndexVisual: 0,
   },
   generateNewReceiveAddress: (...args: unknown[]) => {
     action('generateNewReceiveAddress')(...args)


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

- The address derivation for receive (external) has a visual index aka former (lastIndexGenerated), it doesn't generate (derive) a new address, only bumps the index, since the addresses are derived in blocks of 50.
