### PR TITLE
fix(wallet-mobile): balances - protocolparams

### DIFF
--- a/apps/wallet-mobile/src/features/WalletManager/network-manager/useProtocolParams.tsx
+++ b/apps/wallet-mobile/src/features/WalletManager/network-manager/useProtocolParams.tsx
@@ -1,0 +1,33 @@
+import {Api} from '@yoroi/types'
+import {useQuery, UseQueryOptions} from 'react-query'
+
+import {time} from '../../../kernel/constants'
+import {queryInfo} from '../../../kernel/query-client'
+import {useSelectedNetwork} from '../common/hooks/useSelectedNetwork'
+import {protocolParamsPlaceholder} from './network-manager'
+
+export const useProtocolParams = (
+  options?: UseQueryOptions<
+    Api.Cardano.ProtocolParams,
+    Error,
+    Api.Cardano.ProtocolParams,
+    [string, string, 'useProtocolParams']
+  >,
+) => {
+  const {network, networkManager} = useSelectedNetwork()
+  const query = useQuery({
+    suspense: true,
+    // TODO: it should be infinity until it is invalided when epoch changes after conway
+    staleTime: time.oneHour,
+    cacheTime: time.oneHour,
+    keepPreviousData: true,
+    queryKey: [queryInfo.keyToPersist, network, 'useProtocolParams'],
+    ...options,
+    queryFn: () => networkManager.api.protocolParams(),
+  })
+
+  return {
+    ...query,
+    protocolParams: query.data ?? protocolParamsPlaceholder,
+  }
+}

--- a/apps/wallet-mobile/src/yoroi-wallets/cardano/types.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/cardano/types.ts
@@ -10,7 +10,7 @@ import {
   TxMetadata as TxMetadataType,
   UnsignedTx as UnsignedTxType,
 } from '@emurgo/yoroi-lib'
-import {Api, App, Balance, HW, Network, Portfolio, Wallet} from '@yoroi/types'
+import {App, Balance, HW, Network, Portfolio, Wallet} from '@yoroi/types'
 import {BigNumber} from 'bignumber.js'
 
 import {WalletEncryptedStorage} from '../../kernel/storage/EncryptedStorage'
@@ -180,8 +180,6 @@ export interface YoroiWallet {
 
   // CIP36 Payment Address
   getFirstPaymentAddress(): Promise<CoreTypes.BaseAddress>
-
-  getProtocolParams(): Promise<Api.Cardano.ProtocolParamsResult>
 }
 
 export const isYoroiWallet = (wallet: unknown): wallet is YoroiWallet => {

--- a/apps/wallet-mobile/src/yoroi-wallets/hooks/index.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/hooks/index.ts
@@ -4,7 +4,7 @@ import {Certificate} from '@emurgo/cross-csl-core'
 import AsyncStorage, {AsyncStorageStatic} from '@react-native-async-storage/async-storage'
 import {mountMMKVStorage, observableStorageMaker, parseBoolean, useMutationWithInvalidations} from '@yoroi/common'
 import {themeStorageMaker} from '@yoroi/theme'
-import {Api, App, Balance, HW, Wallet} from '@yoroi/types'
+import {App, Balance, HW, Wallet} from '@yoroi/types'
 import {Buffer} from 'buffer'
 import * as React from 'react'
 import {useCallback, useMemo} from 'react'
@@ -502,28 +502,6 @@ export const useFrontendFees = (
   return {
     ...query,
     frontendFees: query.data,
-  }
-}
-
-export const useProtocolParams = (
-  wallet: YoroiWallet,
-  options?: UseQueryOptions<
-    Api.Cardano.ProtocolParamsResult,
-    Error,
-    Api.Cardano.ProtocolParamsResult,
-    [string, 'protocol-params']
-  >,
-) => {
-  const query = useQuery({
-    suspense: true,
-    queryKey: [wallet.id, 'protocol-params'],
-    ...options,
-    queryFn: () => wallet.getProtocolParams(),
-  })
-
-  return {
-    ...query,
-    protocolParams: query.data,
   }
 }
 

--- a/apps/wallet-mobile/src/yoroi-wallets/mocks/wallet.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/mocks/wallet.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import {action} from '@storybook/addon-actions'
-import {AppApi, CardanoApi} from '@yoroi/api'
+import {AppApi} from '@yoroi/api'
 import {createPrimaryTokenInfo} from '@yoroi/portfolio'
 import {Balance, Portfolio, Wallet} from '@yoroi/types'
 import BigNumber from 'bignumber.js'
@@ -264,12 +264,9 @@ const wallet: YoroiWallet = {
   resync: async (...args: unknown[]) => {
     action('resync')(...args)
   },
-  getProtocolParams: CardanoApi.mockCardanoApi.getProtocolParams,
-
   fetchFundInfo: () => {
     throw new Error('not implemented: fetchFundInfo')
   },
-
   createUnsignedGovernanceTx: () => {
     throw new Error('not implemented: createUnsignedGovernanceTx')
   },

--- a/packages/api/src/cardano/api/protocol-params.mocks.ts
+++ b/packages/api/src/cardano/api/protocol-params.mocks.ts
@@ -1,6 +1,6 @@
 import {Api} from '@yoroi/types'
 
-export const paramsMockResponse: Api.Cardano.ProtocolParamsResult = {
+export const paramsMockResponse: Api.Cardano.ProtocolParams = {
   coinsPerUtxoByte: '4310',
   keyDeposit: '2000000',
   linearFee: {coefficient: '44', constant: '155381'},

--- a/packages/api/src/cardano/api/protocol-params.ts
+++ b/packages/api/src/cardano/api/protocol-params.ts
@@ -4,13 +4,13 @@ import {Api} from '@yoroi/types'
 
 export const getProtocolParams =
   (baseUrl: string, request: Fetcher = fetcher) =>
-  async (): Promise<Api.Cardano.ProtocolParamsResult> => {
-    return request<Api.Cardano.ProtocolParamsResult>({
+  async (): Promise<Api.Cardano.ProtocolParams> => {
+    return request<Api.Cardano.ProtocolParams>({
       url: `${baseUrl}/protocolparameters`,
       data: undefined,
       method: 'GET',
       headers: {'Content-Type': 'application/json'},
-    }).then((response: Api.Cardano.ProtocolParamsResult) => {
+    }).then((response: Api.Cardano.ProtocolParams) => {
       const parsedResponse = parseProtocolParamsResponse(response)
 
       if (!parsedResponse)
@@ -20,8 +20,8 @@ export const getProtocolParams =
   }
 
 export const parseProtocolParamsResponse = (
-  data: Api.Cardano.ProtocolParamsResult,
-): Api.Cardano.ProtocolParamsResult | undefined => {
+  data: Api.Cardano.ProtocolParams,
+): Api.Cardano.ProtocolParams | undefined => {
   return isProtocolParamsResponse(data) ? data : undefined
 }
 

--- a/packages/types/src/api/cardano.ts
+++ b/packages/types/src/api/cardano.ts
@@ -147,7 +147,7 @@ export type ApiTokenIdentity = {
   nameHex: string
 }
 
-export type ApiProtocolParamsResult = Readonly<{
+export type ApiProtocolParams = Readonly<{
   coinsPerUtxoByte: string
   keyDeposit: string
   linearFee: {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -93,7 +93,7 @@ import {
   ApiOnChainMetadataRecord,
   ApiOnChainMetadataRequest,
   ApiOnChainMetadataResponse,
-  ApiProtocolParamsResult,
+  ApiProtocolParams,
   ApiTokenId,
   ApiTokenIdentity,
   ApiTokenRegistryEntry,
@@ -208,6 +208,7 @@ import {HWDeviceInfo, HWDeviceObj, HWFeatures} from './hw/hw'
 import {WalletAddressMode, WalletImplementation} from './wallet/wallet'
 import {WalletMeta} from './wallet/meta'
 import {
+  NetworkApi,
   NetworkConfig,
   NetworkEpochInfo,
   NetworkEpochProgress,
@@ -395,10 +396,10 @@ export namespace Api {
     export type MetadataFile = ApiMetadataFile
     export type TokenId = ApiTokenId
 
-    export type ProtocolParamsResult = ApiProtocolParamsResult
+    export type ProtocolParams = ApiProtocolParams
 
     export interface Actions {
-      getProtocolParams: () => Promise<ProtocolParamsResult>
+      getProtocolParams: () => Promise<ProtocolParams>
     }
   }
 }
@@ -566,6 +567,7 @@ export namespace Exchange {
 }
 
 export namespace Network {
+  export type Api = NetworkApi
   export type Manager = NetworkManager
   export type Config = NetworkConfig
   export type EraConfig = NetworkEraConfig

--- a/packages/types/src/network/manager.ts
+++ b/packages/types/src/network/manager.ts
@@ -1,3 +1,4 @@
+import {ApiProtocolParams} from '../api/cardano'
 import {AppObservableStorage} from '../app/observable-storage'
 import {ChainSupportedNetworks} from '../chain/network'
 import {PortfolioTokenInfo} from '../portfolio/info'
@@ -16,10 +17,14 @@ export type NetworkConfig = {
 }
 
 // NOTE: NetworkConfig will be a generic type in the future
+export type NetworkApi = {
+  protocolParams: () => Promise<Readonly<ApiProtocolParams>>
+}
 export type NetworkManager = {
   tokenManager: PortfolioManagerToken
   rootStorage: AppObservableStorage<false>
   legacyRootStorage: AppObservableStorage
+  api: NetworkApi
 } & NetworkConfig
 
 export type NetworkEraConfig = {


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

- Protocol params can change per epoch after Conway, added persistence to it
- Ignoring API errors, falling back to hardcoded values 
- Considering consuming it straight from network-manager since is too tight to flavour