### PR TITLE
chore(wallet-mobile): Rename Layout to LinearTransition

### DIFF
--- a/apps/wallet-mobile/ios/Podfile.lock
+++ b/apps/wallet-mobile/ios/Podfile.lock
@@ -482,7 +482,7 @@ PODS:
     - React-Core
   - RNPermissions (3.8.4):
     - React-Core
-  - RNReanimated (3.3.0):
+  - RNReanimated (3.5.0):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -911,7 +911,7 @@ SPEC CHECKSUMS:
   RNKeychain: f75b8c8b2f17d3b2aa1f25b4a0ac5b83d947ff8f
   RNLocalize: dbea38dcb344bf80ff18a1757b1becf11f70cae4
   RNPermissions: f1b49dd05fa9b83993cd05a9ee115247944d8f1a
-  RNReanimated: d6b4b867b6d1ee0798f5fb372708fa4bb8d66029
+  RNReanimated: 69c7b6b965b4dd71f63c3c6162f8bc0b5c614a02
   RNScreens: 50ffe2fa2342eabb2d0afbe19f7c1af286bc7fb3
   RNSentry: f9e637773502a61c7b455c4ce65bc7008ce22a6e
   RNShare: 859ff710211285676b0bcedd156c12437ea1d564

--- a/apps/wallet-mobile/package.json
+++ b/apps/wallet-mobile/package.json
@@ -183,7 +183,7 @@
     "react-native-qrcode-svg": "6.0.6",
     "react-native-quick-base64": "^2.0.6",
     "react-native-randombytes": "3.6.0",
-    "react-native-reanimated": "^3.1.0",
+    "react-native-reanimated": "3.4.0",
     "react-native-safe-area-context": "^4.5.1",
     "react-native-screens": "^3.20.0",
     "react-native-share": "^10.0.2",

--- a/apps/wallet-mobile/package.json
+++ b/apps/wallet-mobile/package.json
@@ -183,7 +183,7 @@
     "react-native-qrcode-svg": "6.0.6",
     "react-native-quick-base64": "^2.0.6",
     "react-native-randombytes": "3.6.0",
-    "react-native-reanimated": "3.4.0",
+    "react-native-reanimated": "3.5.0",
     "react-native-safe-area-context": "^4.5.1",
     "react-native-screens": "^3.20.0",
     "react-native-share": "^10.0.2",

--- a/apps/wallet-mobile/src/components/Button/Button.tsx
+++ b/apps/wallet-mobile/src/components/Button/Button.tsx
@@ -1,7 +1,7 @@
 import {useTheme} from '@yoroi/theme'
 import React, {type ReactNode} from 'react'
 import {Image, StyleSheet, TextStyle, TouchableOpacity, TouchableOpacityProps, View, ViewStyle} from 'react-native'
-import Animated, {FadeInDown, FadeOutDown, Layout} from 'react-native-reanimated'
+import Animated, {FadeInDown, FadeOutDown, LinearTransition} from 'react-native-reanimated'
 
 import {Text} from '../Text'
 
@@ -58,7 +58,7 @@ export const Button = (props: ButtonProps) => {
       {...rest}
     >
       {isCopying && (
-        <Animated.View layout={Layout} entering={FadeInDown} exiting={FadeOutDown} style={styles.isCopying}>
+        <Animated.View layout={LinearTransition} entering={FadeInDown} exiting={FadeOutDown} style={styles.isCopying}>
           <Text style={styles.copiedText}>{copiedText}</Text>
         </Animated.View>
       )}

--- a/apps/wallet-mobile/src/components/CopyButton.tsx
+++ b/apps/wallet-mobile/src/components/CopyButton.tsx
@@ -1,7 +1,7 @@
 import {useTheme} from '@yoroi/theme'
 import React from 'react'
 import {StyleProp, StyleSheet, TouchableOpacity, View, ViewStyle} from 'react-native'
-import Animated, {FadeInDown, FadeOutDown, Layout} from 'react-native-reanimated'
+import Animated, {FadeInDown, FadeOutDown, LinearTransition} from 'react-native-reanimated'
 
 import {Text} from '../../../wallet-mobile/src/components/Text'
 import {Icon} from '../components/Icon'
@@ -48,7 +48,12 @@ const AnimatedCopyButton = ({
       {isCopying ? (
         <View style={styles.rowContainer}>
           {!isEmptyString(message) ? (
-            <Animated.View layout={Layout} entering={FadeInDown} exiting={FadeOutDown} style={styles.isCopying}>
+            <Animated.View
+              layout={LinearTransition}
+              entering={FadeInDown}
+              exiting={FadeOutDown}
+              style={styles.isCopying}
+            >
               <Text style={styles.copiedText}>{message}</Text>
             </Animated.View>
           ) : (

--- a/apps/wallet-mobile/src/features/Receive/common/AddressDetailCard/AddressDetailCard.tsx
+++ b/apps/wallet-mobile/src/features/Receive/common/AddressDetailCard/AddressDetailCard.tsx
@@ -1,7 +1,7 @@
 import {useTheme} from '@yoroi/theme'
 import * as React from 'react'
 import {StyleSheet, useWindowDimensions, View} from 'react-native'
-import Animated, {Layout} from 'react-native-reanimated'
+import Animated, {LinearTransition} from 'react-native-reanimated'
 
 import {Spacer} from '../../../../components'
 import {useCopy} from '../../../../hooks/useCopy'
@@ -89,7 +89,7 @@ export const AddressDetailCard = ({title}: AddressDetailCardProps) => {
     <>
       <View style={styles.container}>
         <Animated.FlatList
-          layout={Layout}
+          layout={LinearTransition}
           horizontal={true}
           showsHorizontalScrollIndicator={false}
           data={cards}

--- a/apps/wallet-mobile/src/features/Receive/common/ShareQRCodeCard/ShareQRCodeCard.tsx
+++ b/apps/wallet-mobile/src/features/Receive/common/ShareQRCodeCard/ShareQRCodeCard.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import {StyleSheet, TouchableOpacity, TouchableWithoutFeedback, useWindowDimensions, View} from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 import QRCode from 'react-native-qrcode-svg'
-import Animated, {FadeInDown, FadeOutDown, Layout} from 'react-native-reanimated'
+import Animated, {FadeInDown, FadeOutDown, LinearTransition} from 'react-native-reanimated'
 import Share from 'react-native-share'
 import ViewShot, {captureRef} from 'react-native-view-shot'
 
@@ -91,7 +91,7 @@ export const ShareQRCodeCard = ({content, title, isCopying, onLongPress, testId}
         </View>
 
         {isCopying && (
-          <Animated.View layout={Layout} entering={FadeInDown} exiting={FadeOutDown} style={styles.isCopying}>
+          <Animated.View layout={LinearTransition} entering={FadeInDown} exiting={FadeOutDown} style={styles.isCopying}>
             <Text style={styles.copiedText}>{strings.addressCopiedMsg}</Text>
           </Animated.View>
         )}

--- a/apps/wallet-mobile/src/features/Receive/common/ShowAddressLimitInfo/ShowAddressLimitInfo.tsx
+++ b/apps/wallet-mobile/src/features/Receive/common/ShowAddressLimitInfo/ShowAddressLimitInfo.tsx
@@ -1,7 +1,7 @@
 import {useTheme} from '@yoroi/theme'
 import React from 'react'
 import {Linking, StyleSheet, Text, TouchableWithoutFeedback} from 'react-native'
-import Animated, {FadeInUp, FadeOut, Layout} from 'react-native-reanimated'
+import Animated, {FadeInUp, FadeOut, LinearTransition} from 'react-native-reanimated'
 
 import {Icon} from '../../../../components'
 import {YoroiZendeskLink} from '../contants'
@@ -12,7 +12,7 @@ export const ShowAddressLimitInfo = () => {
   const {styles, colors, color} = useStyles()
 
   return (
-    <Animated.View layout={Layout} entering={FadeInUp} exiting={FadeOut} style={styles.smallAddressCard}>
+    <Animated.View layout={LinearTransition} entering={FadeInUp} exiting={FadeOut} style={styles.smallAddressCard}>
       <Icon.Info size={24} color={colors.icon} />
 
       <Text style={styles.text}>

--- a/apps/wallet-mobile/src/features/Receive/common/SmallAddressCard/SmallAddressCard.tsx
+++ b/apps/wallet-mobile/src/features/Receive/common/SmallAddressCard/SmallAddressCard.tsx
@@ -2,7 +2,7 @@ import {useTheme} from '@yoroi/theme'
 import React from 'react'
 import {StyleSheet, Text, TouchableOpacity, View} from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
-import Animated, {FadeInDown, FadeInUp, FadeOut, FadeOutDown, Layout} from 'react-native-reanimated'
+import Animated, {FadeInDown, FadeInUp, FadeOut, FadeOutDown, LinearTransition} from 'react-native-reanimated'
 
 import {Spacer} from '../../../../components'
 import {useCopy} from '../../../../hooks/useCopy'
@@ -35,7 +35,7 @@ export const SmallAddressCard = ({address, isUsed, date, onPress, loading, testI
 
   return (
     <>
-      <Animated.View layout={Layout} entering={FadeInUp} exiting={FadeOut}>
+      <Animated.View layout={LinearTransition} entering={FadeInUp} exiting={FadeOut}>
         <TouchableOpacity
           style={styles.smallAddressCard}
           activeOpacity={0.6}
@@ -69,7 +69,7 @@ export const SmallAddressCard = ({address, isUsed, date, onPress, loading, testI
       <Spacer height={16} />
 
       {isCopying && (
-        <Animated.View layout={Layout} entering={FadeInDown} exiting={FadeOutDown} style={styles.isCopying}>
+        <Animated.View layout={LinearTransition} entering={FadeInDown} exiting={FadeOutDown} style={styles.isCopying}>
           <Text style={styles.copiedText}>{strings.addressCopiedMsg}</Text>
         </Animated.View>
       )}

--- a/apps/wallet-mobile/src/features/Receive/useCases/ListMultipleAddressesScreen.tsx
+++ b/apps/wallet-mobile/src/features/Receive/useCases/ListMultipleAddressesScreen.tsx
@@ -10,7 +10,7 @@ import {
   View,
   ViewToken,
 } from 'react-native'
-import Animated, {Layout} from 'react-native-reanimated'
+import Animated, {LinearTransition} from 'react-native-reanimated'
 import {SafeAreaView} from 'react-native-safe-area-context'
 
 import {Button, Spacer} from '../../../components'
@@ -113,7 +113,7 @@ export const ListMultipleAddressesScreen = () => {
           data={addressInfos}
           keyExtractor={(addressInfo) => addressInfo.address}
           renderItem={renderAddressInfo}
-          layout={Layout}
+          layout={LinearTransition}
           showsVerticalScrollIndicator={false}
           onViewableItemsChanged={onViewableItemsChanged}
         />
@@ -124,7 +124,7 @@ export const ListMultipleAddressesScreen = () => {
           styles.footer,
           {display: hasReachedGapLimit ? 'none' : 'flex', borderTopWidth: inView.current < addressInfos.length ? 1 : 0},
         ]}
-        layout={Layout}
+        layout={LinearTransition}
       >
         <Button
           shelleyTheme

--- a/apps/wallet-mobile/src/features/SetupWallet/common/StepperProgress/StepperProgress.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/common/StepperProgress/StepperProgress.tsx
@@ -1,7 +1,7 @@
 import {useTheme} from '@yoroi/theme'
 import * as React from 'react'
 import {StyleSheet, ViewStyle} from 'react-native'
-import Animated, {Layout} from 'react-native-reanimated'
+import Animated, {LinearTransition} from 'react-native-reanimated'
 
 import {CheckIllustration} from '../../illustrations/Check'
 import {Number1} from '../../illustrations/Number1'
@@ -33,7 +33,7 @@ export const StepperProgress = ({currentStep, currentStepTitle, totalSteps, styl
       <Animated.View key={index} style={styles.root}>
         {getStepperLogo(currentStep, false)}
 
-        <Animated.Text layout={Layout} style={styles.currentStepTitle}>
+        <Animated.Text layout={LinearTransition} style={styles.currentStepTitle}>
           {currentStepTitle}
         </Animated.Text>
       </Animated.View>
@@ -47,7 +47,7 @@ export const StepperProgress = ({currentStep, currentStepTitle, totalSteps, styl
   const stepIndicator = [...stepIndicatorFirstPart, ...stepIndicatorSecondPart]
 
   return (
-    <Animated.View layout={Layout} style={[styles.bar, style]}>
+    <Animated.View layout={LinearTransition} style={[styles.bar, style]}>
       {stepIndicator}
     </Animated.View>
   )

--- a/apps/wallet-mobile/src/features/SetupWallet/useCases/CreateWallet/VerifyRecoveryPhraseScreen.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/useCases/CreateWallet/VerifyRecoveryPhraseScreen.tsx
@@ -4,7 +4,7 @@ import {useTheme} from '@yoroi/theme'
 import * as React from 'react'
 import {StyleProp, StyleSheet, Text, TextStyle, TouchableOpacity, View} from 'react-native'
 import {ScrollView} from 'react-native-gesture-handler'
-import Animated, {FadeIn, FadeOut, Layout} from 'react-native-reanimated'
+import Animated, {FadeIn, FadeOut, LinearTransition} from 'react-native-reanimated'
 import {SafeAreaView} from 'react-native-safe-area-context'
 
 import {Button} from '../../../../components'
@@ -186,7 +186,7 @@ const MnemonicInput = ({defaultMnemonic, userEntries, onPress}: MnemonicInputPro
   }
 
   return (
-    <Animated.View layout={Layout} entering={FadeIn} exiting={FadeOut} style={styles.recoveryPhrase}>
+    <Animated.View layout={LinearTransition} entering={FadeIn} exiting={FadeOut} style={styles.recoveryPhrase}>
       <View style={[StyleSheet.absoluteFill, {backgroundColor: colors.gradientBlueGreen}]} />
 
       <View style={styles.recoveryPhraseBackground}>
@@ -203,7 +203,12 @@ const MnemonicInput = ({defaultMnemonic, userEntries, onPress}: MnemonicInputPro
                 disabled={!isLast || !recoveryWordError}
                 style={styles.wordBadge}
               >
-                <Animated.View style={styles.wordBadgeView} layout={Layout} entering={FadeIn} exiting={FadeOut}>
+                <Animated.View
+                  style={styles.wordBadgeView}
+                  layout={LinearTransition}
+                  entering={FadeIn}
+                  exiting={FadeOut}
+                >
                   <WordBadge
                     word={`${(index + 1).toString()}.`}
                     used
@@ -213,7 +218,7 @@ const MnemonicInput = ({defaultMnemonic, userEntries, onPress}: MnemonicInputPro
                   />
 
                   <Animated.View
-                    layout={Layout}
+                    layout={LinearTransition}
                     entering={FadeIn}
                     exiting={FadeOut}
                     style={[styles.wordBadgeContainerOutline, recoveryWordError && styles.errorBadgeBackground]}
@@ -290,7 +295,7 @@ const WordBadges = ({
   const {styles, colors} = useStyles()
 
   return (
-    <Animated.View layout={Layout} style={styles.words}>
+    <Animated.View layout={LinearTransition} style={styles.words}>
       {mnemonicEntries.map((entry) => {
         const isUsed = isWordUsed(entry.id)
 
@@ -304,7 +309,12 @@ const WordBadges = ({
             disabled={isUsed}
             onPress={() => selectWord(entry)}
           >
-            <Animated.View layout={Layout} entering={FadeIn} exiting={FadeOut} style={styles.wordBadgeContainer}>
+            <Animated.View
+              layout={LinearTransition}
+              entering={FadeIn}
+              exiting={FadeOut}
+              style={styles.wordBadgeContainer}
+            >
               <View
                 style={[
                   StyleSheet.absoluteFill,
@@ -340,9 +350,9 @@ type WordBadgeProps = {
 const WordBadge = ({word, used, usedError, recoveryWordError, style}: WordBadgeProps) => {
   const {styles} = useStyles()
   return (
-    <Animated.View layout={Layout} entering={FadeIn} exiting={FadeOut} style={styles.wordBadge}>
+    <Animated.View layout={LinearTransition} entering={FadeIn} exiting={FadeOut} style={styles.wordBadge}>
       <Animated.Text
-        layout={Layout}
+        layout={LinearTransition}
         entering={FadeIn}
         exiting={FadeOut}
         style={[

--- a/apps/wallet-mobile/src/legacy/TxHistory/ActionsBanner.tsx
+++ b/apps/wallet-mobile/src/legacy/TxHistory/ActionsBanner.tsx
@@ -5,7 +5,7 @@ import {useTransfer} from '@yoroi/transfer'
 import React, {ReactNode} from 'react'
 import {useIntl} from 'react-intl'
 import {StyleSheet, TouchableOpacity, View} from 'react-native'
-import Animated, {FadeInDown, FadeOutDown, Layout} from 'react-native-reanimated'
+import Animated, {FadeInDown, FadeOutDown, LinearTransition} from 'react-native-reanimated'
 
 import {Icon, Spacer, Text} from '../../components'
 import {useReceive} from '../../features/Receive/common/ReceiveProvider'
@@ -109,7 +109,12 @@ export const ActionsBanner = ({disabled = false}: {disabled: boolean}) => {
       <View style={styles.centralized}>
         <View style={[styles.row, disabled && styles.disabled]}>
           {isCopying && (
-            <Animated.View layout={Layout} entering={FadeInDown} exiting={FadeOutDown} style={styles.isCopying}>
+            <Animated.View
+              layout={LinearTransition}
+              entering={FadeInDown}
+              exiting={FadeOutDown}
+              style={styles.isCopying}
+            >
               <Text style={styles.textCopy}>{strings.addressCopiedMsg}</Text>
             </Animated.View>
           )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -19387,10 +19387,10 @@ react-native-randombytes@3.6.0:
     buffer "^4.9.1"
     sjcl "^1.0.3"
 
-react-native-reanimated@3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.4.0.tgz#93b4d0b4b48e712fdc93f6828654b93083c6531d"
-  integrity sha512-B5cZJseoIkYlZTRBRN0xuU1NBxUza/6GSHhiEBQfbOufWVlUMMcWUecIRVglW49l8d2wXbfCdQlNyVoFqmHkaQ==
+react-native-reanimated@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.5.0.tgz#f6ecac80f6263de397e2e105ce5d9caf0397621e"
+  integrity sha512-om2AfxCD0YyBvGADJ5Ql38CKIJ8MXZTTpve1jt94TcRjLHXui24wYomoumSnnBQEfeRDzjwpmFdqcLtJ5mU5Pg==
   dependencies:
     "@babel/plugin-transform-object-assign" "^7.16.7"
     "@babel/preset-typescript" "^7.16.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19387,10 +19387,10 @@ react-native-randombytes@3.6.0:
     buffer "^4.9.1"
     sjcl "^1.0.3"
 
-react-native-reanimated@^3.1.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.3.0.tgz#80f9d58e28fddf62fe4c1bc792337b8ab57936ab"
-  integrity sha512-LzfpPZ1qXBGy5BcUHqw3pBC0qSd22qXS3t8hWSbozXNrBkzMhhOrcILE/nEg/PHpNNp1xvGOW8NwpAMF006roQ==
+react-native-reanimated@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.4.0.tgz#93b4d0b4b48e712fdc93f6828654b93083c6531d"
+  integrity sha512-B5cZJseoIkYlZTRBRN0xuU1NBxUza/6GSHhiEBQfbOufWVlUMMcWUecIRVglW49l8d2wXbfCdQlNyVoFqmHkaQ==
   dependencies:
     "@babel/plugin-transform-object-assign" "^7.16.7"
     "@babel/preset-typescript" "^7.16.7"


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

This causes some noise in the react-native bump, because it conflicts all the time with other changes in develop.

`Layout` is an alias for `LinearTransition` that react-native-reanimated is deprecating.
https://github.com/software-mansion/react-native-reanimated/blob/3.1.0/src/reanimated2/layoutReanimation/defaultTransitions/LinearTransition.ts#L48

![image](https://github.com/Emurgo/yoroi/assets/1725956/80372d03-c34f-45d9-a632-edffb36b0870)

By having it already changed in develop, it'll make life easier when upgrading the dependency. 
