### PR TITLE
chore(portfolio): added new token-info single endpoint

### DIFF
--- a/apps/wallet-mobile/src/features/Portfolio/common/TokenAmountItem/TokenInfoIcon.tsx
+++ b/apps/wallet-mobile/src/features/Portfolio/common/TokenAmountItem/TokenInfoIcon.tsx
@@ -6,7 +6,6 @@ import React from 'react'
 import {ImageStyle, StyleSheet, View} from 'react-native'
 
 import {Icon} from '../../../../components/Icon'
-import {isEmptyString} from '../../../../kernel/utils'
 import {useSelectedWallet} from '../../../WalletManager/common/hooks/useSelectedWallet'
 
 type TokenInfoIconProps = {
@@ -28,16 +27,6 @@ export const TokenInfoIcon = ({info, size = 'md', imageStyle}: TokenInfoIconProp
         placeholder={blurhash}
       />
     )
-
-  if (!isEmptyString(info.icon)) {
-    return (
-      <Image
-        source={{uri: `data:image/png;base64,${info.icon}`}}
-        style={[size === 'sm' ? styles.iconSmall : styles.iconMedium, imageStyle]}
-        placeholder={blurhash}
-      />
-    )
-  }
 
   const [policy, name] = info.id.split('.')
   const uri = `https://${wallet.networkManager.network}.processed-media.yoroiwallet.com/${policy}/${name}?width=64&height=64&kind=metadata&fit=cover`

--- a/apps/wallet-mobile/src/features/WalletManager/network-manager/network-manager.ts
+++ b/apps/wallet-mobile/src/features/WalletManager/network-manager/network-manager.ts
@@ -17,8 +17,6 @@ export const primaryTokenInfoMainnet = createPrimaryTokenInfo({
   website: 'https://www.cardano.org/',
   originalImage: '',
   description: 'Cardano',
-  icon: '',
-  mediaType: '',
 })
 
 export const primaryTokenInfoAnyTestnet = createPrimaryTokenInfo({
@@ -31,8 +29,6 @@ export const primaryTokenInfoAnyTestnet = createPrimaryTokenInfo({
   website: 'https://www.cardano.org/',
   originalImage: '',
   description: 'Cardano',
-  icon: '',
-  mediaType: '',
 })
 
 export const shelleyEraConfig: Readonly<Network.EraConfig> = freeze(

--- a/apps/wallet-mobile/src/yoroi-wallets/mocks/wallet.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/mocks/wallet.ts
@@ -46,8 +46,6 @@ const primaryTokenInfoMainnet = createPrimaryTokenInfo({
   website: 'https://www.cardano.org/',
   originalImage: '',
   description: 'Cardano',
-  icon: '',
-  mediaType: '',
 })
 
 const walletMeta: Wallet.Meta = {

--- a/packages/portfolio/src/adapters/dullahan-api/api-maker.mocks.ts
+++ b/packages/portfolio/src/adapters/dullahan-api/api-maker.mocks.ts
@@ -25,6 +25,16 @@ export const responseTokenInfosMocks = asyncBehavior.maker<
   emptyRepresentation: null,
 })
 
+export const responseTokenInfoMocks = asyncBehavior.maker<
+  Api.Response<Portfolio.Token.Info>
+>({
+  data: {
+    tag: 'right',
+    value: {status: 200, data: tokenMocks.nftCryptoKitty.info},
+  },
+  emptyRepresentation: null,
+})
+
 export const responseTokenTraits = asyncBehavior.maker<
   Api.Response<Portfolio.Api.TokenTraitsResponse>
 >({
@@ -37,24 +47,36 @@ export const responseTokenTraits = asyncBehavior.maker<
 
 const success: Portfolio.Api.Api = {
   tokenDiscovery: responseTokenDiscoveryMocks.success,
+  tokenInfo: responseTokenInfoMocks.success,
   tokenInfos: responseTokenInfosMocks.success,
   tokenTraits: responseTokenTraits.success,
 }
 
 const delayed: Portfolio.Api.Api = {
   tokenDiscovery: responseTokenDiscoveryMocks.delayed,
+  tokenInfo: responseTokenInfoMocks.delayed,
   tokenInfos: responseTokenInfosMocks.delayed,
   tokenTraits: responseTokenTraits.delayed,
 }
 
 const loading: Portfolio.Api.Api = {
   tokenDiscovery: responseTokenDiscoveryMocks.loading,
+  tokenInfo: responseTokenInfoMocks.loading,
   tokenInfos: responseTokenInfosMocks.loading,
   tokenTraits: responseTokenTraits.loading,
 }
 
 const error: Portfolio.Api.Api = {
   tokenDiscovery: () =>
+    Promise.resolve({
+      tag: 'left',
+      error: {
+        status: 400,
+        message: 'Bad Request',
+        responseData: {message: 'Bad Request'},
+      },
+    }),
+  tokenInfo: () =>
     Promise.resolve({
       tag: 'left',
       error: {
@@ -85,6 +107,7 @@ const error: Portfolio.Api.Api = {
 
 const empty: Portfolio.Api.Api = {
   tokenDiscovery: responseTokenDiscoveryMocks.empty,
+  tokenInfo: responseTokenInfoMocks.empty,
   tokenInfos: responseTokenInfosMocks.empty,
   tokenTraits: responseTokenTraits.empty,
 }

--- a/packages/portfolio/src/adapters/dullahan-api/api-maker.test.ts
+++ b/packages/portfolio/src/adapters/dullahan-api/api-maker.test.ts
@@ -65,8 +65,9 @@ describe('portfolioApiMaker', () => {
     await api.tokenDiscovery(tokenDiscoveryMocks.nftCryptoKitty.id)
     await api.tokenInfos(mockTokenIdsWithCache)
     await api.tokenTraits(tokenMocks.nftCryptoKitty.info.id)
+    await api.tokenInfo(tokenMocks.nftCryptoKitty.info.id)
 
-    expect(mockRequest).toHaveBeenCalledTimes(3)
+    expect(mockRequest).toHaveBeenCalledTimes(4)
 
     expect(mockRequest).toHaveBeenCalledWith({
       method: 'get',
@@ -92,6 +93,17 @@ describe('portfolioApiMaker', () => {
       method: 'get',
       url:
         apiConfig[Chain.Network.Mainnet].tokenTraits +
+        '/' +
+        tokenMocks.nftCryptoKitty.info.id,
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      },
+    })
+    expect(mockRequest).toHaveBeenCalledWith({
+      method: 'get',
+      url:
+        apiConfig[Chain.Network.Mainnet].tokenInfo +
         '/' +
         tokenMocks.nftCryptoKitty.info.id,
       headers: {
@@ -198,6 +210,30 @@ describe('portfolioApiMaker', () => {
         },
       },
     })
+
+    const resultInfo = await api.tokenInfo(tokenMocks.nftCryptoKitty.info.id)
+    expect(mockRequest).toHaveBeenCalledTimes(4)
+    expect(mockRequest).toHaveBeenCalledWith({
+      method: 'get',
+      url:
+        apiConfig[Chain.Network.Mainnet].tokenInfo +
+        '/' +
+        tokenMocks.nftCryptoKitty.info.id,
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      },
+    })
+    expect(resultInfo).toEqual({
+      tag: 'left',
+      error: {
+        status: -3,
+        message: 'Failed to transform token info response',
+        responseData: {
+          ['wrong']: 'data',
+        },
+      },
+    })
   })
 
   it('should return the error and not throw', async () => {
@@ -286,9 +322,32 @@ describe('portfolioApiMaker', () => {
         'Content-Type': 'application/json',
       },
     })
+
+    await expect(
+      api.tokenInfo(tokenMocks.nftCryptoKitty.info.id),
+    ).resolves.toEqual({
+      tag: 'left',
+      value: {
+        status: 500,
+        message: 'Internal Server Error',
+        responseData: {},
+      },
+    })
+    expect(mockRequest).toHaveBeenCalledTimes(4)
+    expect(mockRequest).toHaveBeenCalledWith({
+      method: 'get',
+      url:
+        apiConfig[Chain.Network.Mainnet].tokenInfo +
+        '/' +
+        tokenMocks.nftCryptoKitty.info.id,
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      },
+    })
   })
 
-  it('should return the data on success', async () => {
+  it('should return the data on success (traits)', async () => {
     mockRequest.mockResolvedValue({
       tag: 'right',
       value: {
@@ -321,6 +380,43 @@ describe('portfolioApiMaker', () => {
       value: {
         status: 200,
         data: tokenMocks.nftCryptoKitty.traits,
+      },
+    })
+  })
+
+  it('should return the data on success (tokenInfo)', async () => {
+    mockRequest.mockResolvedValue({
+      tag: 'right',
+      value: {
+        status: 200,
+        data: tokenMocks.nftCryptoKitty.info,
+      },
+    })
+    const api = portfolioApiMaker({
+      network: mockNetwork,
+      request: mockRequest,
+      maxIdsPerRequest: 10,
+      maxConcurrentRequests: 10,
+    })
+
+    const result = await api.tokenInfo(tokenMocks.nftCryptoKitty.info.id)
+    expect(mockRequest).toHaveBeenCalledTimes(1)
+    expect(mockRequest).toHaveBeenCalledWith({
+      method: 'get',
+      url:
+        apiConfig[Chain.Network.Mainnet].tokenInfo +
+        '/' +
+        tokenMocks.nftCryptoKitty.info.id,
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      },
+    })
+    expect(result).toEqual({
+      tag: 'right',
+      value: {
+        status: 200,
+        data: tokenMocks.nftCryptoKitty.info,
       },
     })
   })

--- a/packages/portfolio/src/adapters/dullahan-api/transformers.test.ts
+++ b/packages/portfolio/src/adapters/dullahan-api/transformers.test.ts
@@ -1,25 +1,9 @@
-import {
-  toDullahanRequest,
-  toSecondaryTokenInfo,
-  toSecondaryTokenInfos,
-} from './transformers'
+import {toDullahanRequest, toSecondaryTokenInfos} from './transformers'
 import {Portfolio, Api} from '@yoroi/types'
 
 import {tokenMocks} from '../token.mocks'
 
 describe('transformers', () => {
-  describe('toSecondaryTokenInfo', () => {
-    it('should set the nature to Secondary', () => {
-      const tokenInfo: Omit<Portfolio.Token.Info, 'nature'> = {
-        ...tokenMocks.primaryETH.info,
-      }
-
-      const result = toSecondaryTokenInfo(tokenInfo)
-
-      expect(result.nature).toBe(Portfolio.Token.Nature.Secondary)
-    })
-  })
-
   describe('toSecondaryTokenInfos', () => {
     it('should return an empty object if apiTokenInfosResponse is empty', () => {
       const apiTokenInfosResponse: Portfolio.Api.TokenInfosResponse = {}
@@ -80,7 +64,7 @@ describe('transformers', () => {
         ],
         [tokenMocks.nftCryptoKitty.info.id]: [
           200,
-          toSecondaryTokenInfo(tokenMocks.nftCryptoKitty.info),
+          tokenMocks.nftCryptoKitty.info,
           'etag',
           0,
         ],

--- a/packages/portfolio/src/adapters/dullahan-api/transformers.ts
+++ b/packages/portfolio/src/adapters/dullahan-api/transformers.ts
@@ -6,13 +6,6 @@ import {
   DullahanApiTokenInfosResponse,
 } from './types'
 
-export const toSecondaryTokenInfo = (
-  tokenInfo: Omit<Portfolio.Token.Info, 'nature'>,
-): Portfolio.Token.Info => ({
-  ...tokenInfo,
-  nature: Portfolio.Token.Nature.Secondary,
-})
-
 export const toSecondaryTokenInfos = (
   apiTokenInfosResponse: DullahanApiTokenInfosResponse,
 ) => {
@@ -25,9 +18,7 @@ export const toSecondaryTokenInfos = (
     (acc, [id, tokenInfoWithCache]) => {
       const castedId = id as Portfolio.Token.Id
       const castedTokenInfoWithCache =
-        tokenInfoWithCache as Api.ResponseWithCache<
-          Omit<Portfolio.Token.Info, 'nature'>
-        >
+        tokenInfoWithCache as Api.ResponseWithCache<Portfolio.Token.Info>
 
       if (!parseSecondaryTokenInfoWithCacheRecord(castedTokenInfoWithCache))
         throw new Api.Errors.ResponseMalformed(
@@ -41,9 +32,8 @@ export const toSecondaryTokenInfos = (
       }
 
       const [, tokenInfo, hash, maxAge] = castedTokenInfoWithCache
-      const updatedTokenInfo = toSecondaryTokenInfo(tokenInfo)
 
-      acc[castedId] = [statusCode, updatedTokenInfo, hash, maxAge]
+      acc[castedId] = [statusCode, tokenInfo, hash, maxAge]
 
       return acc
     },

--- a/packages/portfolio/src/adapters/dullahan-api/types.ts
+++ b/packages/portfolio/src/adapters/dullahan-api/types.ts
@@ -1,10 +1,12 @@
 import {Api, Portfolio} from '@yoroi/types'
 
 export type DullahanApiTokenInfosResponse = Readonly<{
-  [key: Portfolio.Token.Id]: Api.ResponseWithCache<
-    Omit<Portfolio.Token.Info, 'nature'>
-  >
+  [key: Portfolio.Token.Id]: Api.ResponseWithCache<Portfolio.Token.Info>
 }>
+
+export type DullahanApiTokenInfoResponse = Readonly<
+  Api.Response<Portfolio.Token.Info>
+>
 
 export type DullahanApiTokenTraitsResponse = Readonly<
   Portfolio.Token.Traits & {
@@ -13,14 +15,8 @@ export type DullahanApiTokenTraitsResponse = Readonly<
   }
 >
 
-export type DullahanTokenDiscovery = Omit<
-  Portfolio.Token.Discovery,
-  'supply'
-> & {
-  supply: string
-}
-
-export type DullahanApiTokenDiscoveryResponse = Readonly<DullahanTokenDiscovery>
+export type DullahanApiTokenDiscoveryResponse =
+  Readonly<Portfolio.Token.Discovery>
 
 export type DullahanIdWithCache = `${string}.${string}:${string}`
 

--- a/packages/portfolio/src/adapters/token-info.mocks.ts
+++ b/packages/portfolio/src/adapters/token-info.mocks.ts
@@ -18,8 +18,6 @@ const primaryETH: Portfolio.Token.Info = {
   nature: Portfolio.Token.Nature.Primary,
   type: Portfolio.Token.Type.FT,
   description: '',
-  icon: '',
-  mediaType: '',
 }
 
 const nftCryptoKitty: Portfolio.Token.Info = {
@@ -38,8 +36,6 @@ const nftCryptoKitty: Portfolio.Token.Info = {
   nature: Portfolio.Token.Nature.Secondary,
   type: Portfolio.Token.Type.NFT,
   description: '',
-  icon: '',
-  mediaType: '',
 }
 
 const rnftWhatever: Portfolio.Token.Info = {
@@ -58,8 +54,6 @@ const rnftWhatever: Portfolio.Token.Info = {
   nature: Portfolio.Token.Nature.Secondary,
   type: Portfolio.Token.Type.NFT,
   description: '',
-  icon: '',
-  mediaType: '',
 }
 
 const ftNoTicker: Portfolio.Token.Info = {
@@ -78,8 +72,6 @@ const ftNoTicker: Portfolio.Token.Info = {
   nature: Portfolio.Token.Nature.Secondary,
   type: Portfolio.Token.Type.FT,
   description: '',
-  icon: '',
-  mediaType: '',
 }
 
 const ftNameless: Portfolio.Token.Info = {
@@ -98,8 +90,6 @@ const ftNameless: Portfolio.Token.Info = {
   nature: Portfolio.Token.Nature.Secondary,
   type: Portfolio.Token.Type.FT,
   description: '',
-  icon: '',
-  mediaType: '',
 }
 
 // NOTE: If you marked a record as not modified 304, remember to add to the intiial state

--- a/packages/portfolio/src/balance-manager.test.ts
+++ b/packages/portfolio/src/balance-manager.test.ts
@@ -46,6 +46,7 @@ describe('portfolioBalanceManagerMaker', () => {
     sync: jest.fn().mockResolvedValue(new Map()),
     clear: jest.fn(),
     api: {
+      tokenInfo: jest.fn(),
       tokenInfos: jest.fn(),
       tokenDiscovery: jest.fn(),
       tokenTraits: jest.fn(),
@@ -91,6 +92,7 @@ describe('hydrate', () => {
     sync: jest.fn().mockResolvedValue(new Map()),
     clear: jest.fn(),
     api: {
+      tokenInfo: jest.fn(),
       tokenInfos: jest.fn(),
       tokenDiscovery: jest.fn(),
       tokenTraits: jest.fn(),
@@ -178,6 +180,7 @@ describe('destroy', () => {
     sync: jest.fn().mockResolvedValue(new Map()),
     clear: jest.fn(),
     api: {
+      tokenInfo: jest.fn(),
       tokenInfos: jest.fn(),
       tokenDiscovery: jest.fn(),
       tokenTraits: jest.fn(),
@@ -259,6 +262,7 @@ describe('primary updates', () => {
     sync: jest.fn().mockResolvedValue(new Map()),
     clear: jest.fn(),
     api: {
+      tokenInfo: jest.fn(),
       tokenInfos: jest.fn(),
       tokenDiscovery: jest.fn(),
       tokenTraits: jest.fn(),
@@ -415,6 +419,7 @@ describe('sync & refresh', () => {
     sync: jest.fn().mockResolvedValue(new Map()),
     clear: jest.fn(),
     api: {
+      tokenInfo: jest.fn(),
       tokenInfos: jest.fn(),
       tokenDiscovery: jest.fn(),
       tokenTraits: jest.fn(),
@@ -704,6 +709,7 @@ describe('clear', () => {
     sync: jest.fn().mockResolvedValue(new Map()),
     clear: jest.fn(),
     api: {
+      tokenInfo: jest.fn(),
       tokenInfos: jest.fn(),
       tokenDiscovery: jest.fn(),
       tokenTraits: jest.fn(),

--- a/packages/portfolio/src/helpers/create-primary-token-info.test.ts
+++ b/packages/portfolio/src/helpers/create-primary-token-info.test.ts
@@ -16,8 +16,6 @@ describe('createPrimaryTokenInfo', () => {
       ticker: 'ADA',
       website: 'https://cardano.org/',
       description: '',
-      icon: '',
-      mediaType: '',
     }
 
     const expectedTokenInfo: Readonly<Portfolio.Token.Info> = {

--- a/packages/portfolio/src/helpers/create-unknown-token-info.test.ts
+++ b/packages/portfolio/src/helpers/create-unknown-token-info.test.ts
@@ -23,8 +23,6 @@ describe('createPrimaryTokenInfo', () => {
       website: '',
       originalImage: '',
       description: '',
-      icon: '',
-      mediaType: '',
       ...cardanoUnknownToken,
     }
 

--- a/packages/portfolio/src/helpers/create-unknown-token-info.ts
+++ b/packages/portfolio/src/helpers/create-unknown-token-info.ts
@@ -15,8 +15,6 @@ export function createUnknownTokenInfo(
       fingerprint: '',
       originalImage: '',
       description: '',
-      mediaType: '',
-      icon: '',
       nature: Portfolio.Token.Nature.Secondary,
       type: Portfolio.Token.Type.FT,
       application: Portfolio.Token.Application.General,

--- a/packages/portfolio/src/validators/token-info.ts
+++ b/packages/portfolio/src/validators/token-info.ts
@@ -76,16 +76,14 @@ export const parseTokenInfo = (
 export const SecondaryTokenInfoApiResponseWithCacheRecordSchema =
   responseRecordWithCacheSchemaMaker(SecondaryTokenInfoApiResponseSchema)
 
-// NOTE: the difference is the 'nature' field, that is added on fly by the manager
-// everything that comes from the API is secondary, primary is offline and is injected in the manager
 export const isSecondaryTokenInfoWithCacheRecord = (
   data: unknown,
-): data is Api.ResponseWithCache<Omit<Portfolio.Token.Info, 'nature'>> =>
+): data is Api.ResponseWithCache<Portfolio.Token.Info> =>
   SecondaryTokenInfoApiResponseWithCacheRecordSchema.safeParse(data).success
 
 export const parseSecondaryTokenInfoWithCacheRecord = (
   data: unknown,
-): Api.ResponseWithCache<Omit<Portfolio.Token.Info, 'nature'>> | undefined => {
+): Api.ResponseWithCache<Portfolio.Token.Info> | undefined => {
   return isSecondaryTokenInfoWithCacheRecord(data) ? data : undefined
 }
 

--- a/packages/types/src/portfolio/api.ts
+++ b/packages/types/src/portfolio/api.ts
@@ -17,6 +17,9 @@ export type PortfolioApiTokenInfosResponse = {
 export type PortfolioApiTokenTraitsResponse = PortfolioTokenTraits
 
 export type PortfolioApi = Readonly<{
+  tokenInfo(
+    id: PortfolioTokenId,
+  ): Promise<Readonly<ApiResponse<PortfolioTokenInfo>>>
   tokenInfos(
     idsWithETag: ReadonlyArray<ApiRequestRecordWithCache<PortfolioTokenId>>,
   ): Promise<Readonly<ApiResponse<PortfolioApiTokenInfosResponse>>>

--- a/packages/types/src/portfolio/info.ts
+++ b/packages/types/src/portfolio/info.ts
@@ -24,8 +24,6 @@ type CommonTokenInfo = {
   website: string // Full link with protocol
 
   originalImage: string // Base link
-  icon: string // base64 - 32x32
-  mediaType: string
 }
 
 type PrimaryTokenInfo = {


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

- [x] Updated the token-info type (dropped media-type & icon) 
- [x] Added getTokenInfo to API interface (single endpoint - swap + other features)
- [x] Updated `nature` is coming from API
- [x] Supply needs checking (sometimes is returning as `number` sometimes as `string`) from endpoint) 
