### PR TITLE
chore(portfolio): added single token-info hook

### DIFF
--- a/packages/portfolio/src/adapters/token-info.mocks.ts
+++ b/packages/portfolio/src/adapters/token-info.mocks.ts
@@ -171,6 +171,29 @@ const storage: {
   ],
 }
 
+const apiResponseTokenInfo: Readonly<
+  Record<'success' | 'error', Api.Response<Portfolio.Token.Info>>
+> = freeze(
+  {
+    success: {
+      tag: 'right',
+      value: {
+        status: 200,
+        data: nftCryptoKitty,
+      },
+    },
+    error: {
+      tag: 'left',
+      error: {
+        status: 404,
+        responseData: null,
+        message: 'Not found',
+      },
+    },
+  },
+  true,
+)
+
 export const tokenInfoMocks = freeze({
   primaryETH,
   nftCryptoKitty,
@@ -182,4 +205,7 @@ export const tokenInfoMocks = freeze({
 
   apiResponseResult: apiResponseTokenInfos,
   apiRequestArgs: apiRequestTokenInfos,
+  apiReponse: {
+    nftCryptoKitty: apiResponseTokenInfo,
+  },
 })

--- a/packages/portfolio/src/translators/reactjs/usePortfolioTokenInfo.test.tsx
+++ b/packages/portfolio/src/translators/reactjs/usePortfolioTokenInfo.test.tsx
@@ -1,0 +1,101 @@
+import * as React from 'react'
+import {QueryClient} from 'react-query'
+import {Text, View} from 'react-native'
+import {render, waitFor} from '@testing-library/react-native'
+import {queryClientFixture} from '@yoroi/common'
+import {Chain} from '@yoroi/types'
+
+import {wrapperMaker} from '../../fixtures/wrapperMaker'
+import {tokenMocks} from '../../adapters/token.mocks'
+import {tokenInfoMocks} from '../../adapters/token-info.mocks'
+import {usePorfolioTokenInfo} from './usePortfolioTokenInfo'
+import {createUnknownTokenInfo} from '../../helpers/create-unknown-token-info'
+
+describe('usePortfolioTokenInfo', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    queryClient = queryClientFixture()
+  })
+
+  afterEach(() => {
+    queryClient.clear()
+  })
+
+  it('success', async () => {
+    const mockedGetTokenInfo = jest
+      .fn()
+      .mockResolvedValue(tokenInfoMocks.apiReponse.nftCryptoKitty.success)
+
+    const TestComponent = () => {
+      const {data} = usePorfolioTokenInfo(
+        {
+          id: tokenMocks.nftCryptoKitty.info.id,
+          network: Chain.Network.Mainnet,
+          getTokenInfo: mockedGetTokenInfo,
+        },
+        {
+          suspense: true,
+        },
+      )
+      return (
+        <View>
+          <Text testID="data">{JSON.stringify(data)}</Text>
+        </View>
+      )
+    }
+    const wrapper = wrapperMaker({
+      queryClient,
+    })
+    const {getByTestId} = render(<TestComponent />, {wrapper})
+
+    await waitFor(() => {
+      expect(getByTestId('data')).toBeDefined()
+    })
+
+    expect(getByTestId('data').props.children).toEqual(
+      JSON.stringify(tokenInfoMocks.nftCryptoKitty),
+    )
+    expect(mockedGetTokenInfo).toHaveBeenCalledWith(
+      tokenMocks.nftCryptoKitty.info.id,
+    )
+  })
+
+  it('error should return unknonw token', async () => {
+    const unknownTokenInfo = createUnknownTokenInfo({
+      id: tokenMocks.nftCryptoKitty.info.id,
+      name: tokenInfoMocks.nftCryptoKitty.id.split('.')[1] ?? '',
+    })
+    const mockedGetTokenInfo = jest.fn().mockResolvedValue(unknownTokenInfo)
+
+    const TestComponent = () => {
+      const {data} = usePorfolioTokenInfo(
+        {
+          id: tokenMocks.nftCryptoKitty.info.id,
+          network: Chain.Network.Mainnet,
+          getTokenInfo: mockedGetTokenInfo,
+        },
+        {
+          suspense: true,
+        },
+      )
+      return (
+        <View>
+          <Text testID="data">{JSON.stringify(data)}</Text>
+        </View>
+      )
+    }
+    const wrapper = wrapperMaker({
+      queryClient,
+    })
+    const {getByTestId} = render(<TestComponent />, {wrapper})
+
+    await waitFor(() => {
+      expect(getByTestId('data')).toBeDefined()
+    })
+    expect(getByTestId('data').props.children).toEqual(
+      JSON.stringify(unknownTokenInfo),
+    )
+  })
+})

--- a/packages/portfolio/src/translators/reactjs/usePortfolioTokenInfo.tsx
+++ b/packages/portfolio/src/translators/reactjs/usePortfolioTokenInfo.tsx
@@ -1,0 +1,38 @@
+import {isRight} from '@yoroi/common'
+import {Chain, Portfolio} from '@yoroi/types'
+import {UseQueryOptions, useQuery} from 'react-query'
+import {createUnknownTokenInfo} from '../../helpers/create-unknown-token-info'
+
+export function usePorfolioTokenInfo(
+  {
+    id,
+    getTokenInfo,
+    network,
+  }: {
+    id: Portfolio.Token.Id
+    getTokenInfo: Portfolio.Api.Api['tokenInfo']
+    network: Chain.SupportedNetworks
+  },
+  options?: UseQueryOptions<
+    Portfolio.Token.Info,
+    Error,
+    Portfolio.Token.Info,
+    [Chain.SupportedNetworks, 'usePorfolioTokenInfo', Portfolio.Token.Id]
+  >,
+) {
+  const query = useQuery({
+    queryKey: [network, 'usePorfolioTokenInfo', id],
+    ...options,
+    queryFn: async () => {
+      const response = await getTokenInfo(id)
+      if (isRight(response)) return response.value.data
+      const [, assetName] = id.split('.')
+      return createUnknownTokenInfo({id, name: assetName!})
+    },
+  })
+
+  return {
+    ...query,
+    tokenTraits: query.data,
+  }
+}


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

- [x] Added single token info endpoint with same behaviour of multi (returning unknown token in case of any API error off-line first)
