### PR TITLE
fix(wallet-mobile): Quick changes from dark theme meeting

### DIFF
--- a/apps/wallet-mobile/src/components/Accordion/Accordion.tsx
+++ b/apps/wallet-mobile/src/components/Accordion/Accordion.tsx
@@ -71,7 +71,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       ...atoms.flex_1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     header: {
       ...atoms.flex_row,

--- a/apps/wallet-mobile/src/components/Analytics/Analytics.tsx
+++ b/apps/wallet-mobile/src/components/Analytics/Analytics.tsx
@@ -190,7 +190,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     container: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     content: {
       alignItems: 'center',
@@ -242,7 +242,7 @@ const useStyles = () => {
       width: '100%',
       position: 'absolute',
       bottom: 0,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       height: BOTTOM_BUTTON_ROW_HEIGHT,
       padding: 16,
     },

--- a/apps/wallet-mobile/src/components/Banner/Banner.tsx
+++ b/apps/wallet-mobile/src/components/Banner/Banner.tsx
@@ -60,7 +60,7 @@ const useStyles = () => {
       color: color.sys_magenta_c500,
     },
     bannerError: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       ...atoms.py_sm,
     },
     label: {

--- a/apps/wallet-mobile/src/components/ConfirmTx/ConfirmTx.tsx
+++ b/apps/wallet-mobile/src/components/ConfirmTx/ConfirmTx.tsx
@@ -317,7 +317,7 @@ const useStyles = () => {
   const {color} = useTheme()
   const styles = StyleSheet.create({
     root: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     actionContainer: {
       justifyContent: 'space-between',

--- a/apps/wallet-mobile/src/components/ErrorModal/ErrorModal.tsx
+++ b/apps/wallet-mobile/src/components/ErrorModal/ErrorModal.tsx
@@ -132,7 +132,7 @@ const useStyles = () => {
       shadowRadius: 12,
       shadowOpacity: 0.06,
       shadowColor: color.black_static,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       borderRadius: 8,
     },
     errorSectionContent: {

--- a/apps/wallet-mobile/src/components/ExpandableInfoCard/ExpandableInfoCard.tsx
+++ b/apps/wallet-mobile/src/components/ExpandableInfoCard/ExpandableInfoCard.tsx
@@ -195,10 +195,10 @@ const useStyles = () => {
       padding: 16,
       width: '100%',
       height: 'auto',
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     shadowProp: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       shadowColor: color.gray_cmax,
       shadowOffset: {
         width: 0,

--- a/apps/wallet-mobile/src/components/Modal/ModalScreen.tsx
+++ b/apps/wallet-mobile/src/components/Modal/ModalScreen.tsx
@@ -97,7 +97,7 @@ const useStyles = () => {
     },
     backdrop: {
       ...StyleSheet.absoluteFillObject,
-      backgroundColor: 'rgba(0, 0, 0, 0.64)',
+      backgroundColor: color.mobile_overlay,
     },
     animatedView: {
       alignSelf: 'stretch',

--- a/apps/wallet-mobile/src/components/ProgressStep.tsx
+++ b/apps/wallet-mobile/src/components/ProgressStep.tsx
@@ -42,7 +42,7 @@ const useStyles = () => {
   const {color} = useTheme()
   const styles = StyleSheet.create({
     bar: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       height: 10,
       flexDirection: 'row',
     },

--- a/apps/wallet-mobile/src/components/SafeArea.tsx
+++ b/apps/wallet-mobile/src/components/SafeArea.tsx
@@ -18,7 +18,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
   })
   return styles

--- a/apps/wallet-mobile/src/components/Tabs/Tabs.tsx
+++ b/apps/wallet-mobile/src/components/Tabs/Tabs.tsx
@@ -75,7 +75,7 @@ const useStyles = () => {
     tabNavigatorRoot: {
       flex: 1,
       paddingTop: 8,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       borderTopLeftRadius: 8,
       borderTopRightRadius: 8,
     },

--- a/apps/wallet-mobile/src/components/TitledCard.tsx
+++ b/apps/wallet-mobile/src/components/TitledCard.tsx
@@ -39,7 +39,7 @@ const useStyles = () => {
       shadowRadius: 12,
       shadowOffset: {width: 0, height: 2},
       shadowColor: 'rgba(0, 0, 0, 0.06)',
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     poolInfoContent: {
       ...atoms.p_0,

--- a/apps/wallet-mobile/src/components/legacy/Modal/Modal.tsx
+++ b/apps/wallet-mobile/src/components/legacy/Modal/Modal.tsx
@@ -94,14 +94,14 @@ const useStyles = () => {
       alignItems: 'stretch',
       justifyContent: 'center',
       ...atoms.px_xl,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.mobile_overlay,
     },
     noPadding: {
       padding: 0,
       marginTop: 0,
     },
     container: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       borderRadius: 4,
       ...atoms.px_xl,
     },

--- a/apps/wallet-mobile/src/features/Auth/PinInput/PinInput.tsx
+++ b/apps/wallet-mobile/src/features/Auth/PinInput/PinInput.tsx
@@ -95,7 +95,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     pinInput: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     info: {
       flex: 1,

--- a/apps/wallet-mobile/src/features/Auth/PinLoginScreen/PinLoginScreen.tsx
+++ b/apps/wallet-mobile/src/features/Auth/PinLoginScreen/PinLoginScreen.tsx
@@ -59,7 +59,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     container: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
   })
   return styles

--- a/apps/wallet-mobile/src/features/Dev/DeveloperScreen.tsx
+++ b/apps/wallet-mobile/src/features/Dev/DeveloperScreen.tsx
@@ -242,7 +242,7 @@ const useStyles = () => {
     safeAreaView: {
       flex: 1,
       paddingTop: 50,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     container: {
       flex: 1,

--- a/apps/wallet-mobile/src/features/Discover/BrowserNavigator.tsx
+++ b/apps/wallet-mobile/src/features/Discover/BrowserNavigator.tsx
@@ -30,7 +30,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
   })
 

--- a/apps/wallet-mobile/src/features/Discover/common/LabelCategoryDApp.tsx
+++ b/apps/wallet-mobile/src/features/Discover/common/LabelCategoryDApp.tsx
@@ -21,7 +21,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     labelContainer: {
       borderRadius: 20,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       paddingVertical: 1,
       paddingHorizontal: 6,
       height: 24,

--- a/apps/wallet-mobile/src/features/Discover/useCases/BrowseDapp/BrowseDappScreen.tsx
+++ b/apps/wallet-mobile/src/features/Discover/useCases/BrowseDapp/BrowseDappScreen.tsx
@@ -52,7 +52,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       ...atoms.flex_1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     listContainer: {
       ...atoms.flex_grow,

--- a/apps/wallet-mobile/src/features/Discover/useCases/BrowseDapp/BrowserTabBar.tsx
+++ b/apps/wallet-mobile/src/features/Discover/useCases/BrowseDapp/BrowserTabBar.tsx
@@ -119,7 +119,7 @@ const useStyles = () => {
       gap: 16,
       ...atoms.px_lg,
       ...atoms.pt_md,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     shadow: {
       shadowColor: '#054037',

--- a/apps/wallet-mobile/src/features/Discover/useCases/BrowseDapp/BrowserTabsBar.tsx
+++ b/apps/wallet-mobile/src/features/Discover/useCases/BrowseDapp/BrowserTabsBar.tsx
@@ -61,7 +61,7 @@ const useStyles = () => {
       flex: 1,
     },
     root: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       paddingVertical: 12,
       paddingHorizontal: 16,
       flexDirection: 'row',

--- a/apps/wallet-mobile/src/features/Discover/useCases/BrowseDapp/BrowserToolbar.tsx
+++ b/apps/wallet-mobile/src/features/Discover/useCases/BrowseDapp/BrowserToolbar.tsx
@@ -48,7 +48,7 @@ const useStyles = () => {
 
   const styles = StyleSheet.create({
     root: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       paddingVertical: 10,
       paddingHorizontal: 16,
       flexDirection: 'row',

--- a/apps/wallet-mobile/src/features/Discover/useCases/SearchDappInBrowser/SearchDappInBrowserScreen.tsx
+++ b/apps/wallet-mobile/src/features/Discover/useCases/SearchDappInBrowser/SearchDappInBrowserScreen.tsx
@@ -81,7 +81,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     dAppContainer: {
       ...atoms.p_lg,

--- a/apps/wallet-mobile/src/features/Discover/useCases/SelectDappFromList/DAppTypes/DAppTypes.tsx
+++ b/apps/wallet-mobile/src/features/Discover/useCases/SelectDappFromList/DAppTypes/DAppTypes.tsx
@@ -99,7 +99,7 @@ const useStyles = () => {
       ...atoms.p_2xs,
       height: 40,
       paddingHorizontal: 14,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       flexDirection: 'row',
       alignItems: 'center',
       gap: 8,

--- a/apps/wallet-mobile/src/features/Discover/useCases/SelectDappFromList/ListSkeleton.tsx
+++ b/apps/wallet-mobile/src/features/Discover/useCases/SelectDappFromList/ListSkeleton.tsx
@@ -31,7 +31,7 @@ const useStyles = () => {
   const {color, atoms} = useTheme()
   const styles = StyleSheet.create({
     root: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       ...atoms.p_lg,
       ...atoms.flex_1,
     },

--- a/apps/wallet-mobile/src/features/Discover/useCases/SelectDappFromList/SelectDappFromListScreen.tsx
+++ b/apps/wallet-mobile/src/features/Discover/useCases/SelectDappFromList/SelectDappFromListScreen.tsx
@@ -104,7 +104,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     boxHeader: {},
     containerHeader: {},

--- a/apps/wallet-mobile/src/features/Exchange/common/AmountCard/AmountCard.tsx
+++ b/apps/wallet-mobile/src/features/Exchange/common/AmountCard/AmountCard.tsx
@@ -139,7 +139,7 @@ const useStyles = () => {
       position: 'absolute',
       top: -7,
       left: 10,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       paddingHorizontal: 5,
       fontSize: 12,
       color: color.gray_c900,

--- a/apps/wallet-mobile/src/features/Exchange/common/ShowBuyBanner/BuyBannerBig.tsx
+++ b/apps/wallet-mobile/src/features/Exchange/common/ShowBuyBanner/BuyBannerBig.tsx
@@ -60,7 +60,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       ...atoms.pb_md,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       flex: 1,
     },
     gradient: {

--- a/apps/wallet-mobile/src/features/Exchange/common/ShowBuyBanner/BuyBannerSmall.tsx
+++ b/apps/wallet-mobile/src/features/Exchange/common/ShowBuyBanner/BuyBannerSmall.tsx
@@ -59,7 +59,7 @@ const useStyles = () => {
   const {color, atoms} = useTheme()
   const styles = StyleSheet.create({
     root: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     gradient: {
       flex: 1,

--- a/apps/wallet-mobile/src/features/Exchange/useCases/CreateExchangeOrderScreen/CreateExchangeOrderScreen.tsx
+++ b/apps/wallet-mobile/src/features/Exchange/useCases/CreateExchangeOrderScreen/CreateExchangeOrderScreen.tsx
@@ -181,7 +181,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     flex: {
       flex: 1,

--- a/apps/wallet-mobile/src/features/Exchange/useCases/ShowExchangeResultOrderScreen/ShowExchangeResultOrderScreen.tsx
+++ b/apps/wallet-mobile/src/features/Exchange/useCases/ShowExchangeResultOrderScreen/ShowExchangeResultOrderScreen.tsx
@@ -137,7 +137,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     flex: {
       flex: 1,

--- a/apps/wallet-mobile/src/features/Initialization/AnalyticsChangedScreen/AnalyticsChangedScreen.tsx
+++ b/apps/wallet-mobile/src/features/Initialization/AnalyticsChangedScreen/AnalyticsChangedScreen.tsx
@@ -31,7 +31,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     container: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
   })
 

--- a/apps/wallet-mobile/src/features/Initialization/AnalyticsNoticeScreen/AnalyticsNoticeScreen.tsx
+++ b/apps/wallet-mobile/src/features/Initialization/AnalyticsNoticeScreen/AnalyticsNoticeScreen.tsx
@@ -33,7 +33,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     container: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
   })
 

--- a/apps/wallet-mobile/src/features/Initialization/ChooseBiometricLogin/ChooseBiometricLoginScreen.tsx
+++ b/apps/wallet-mobile/src/features/Initialization/ChooseBiometricLogin/ChooseBiometricLoginScreen.tsx
@@ -83,7 +83,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       ...atoms.px_lg,
     },
     content: {

--- a/apps/wallet-mobile/src/features/Initialization/DarkThemeAnnouncement/DarkThemeAnnouncement.stories.tsx
+++ b/apps/wallet-mobile/src/features/Initialization/DarkThemeAnnouncement/DarkThemeAnnouncement.stories.tsx
@@ -18,7 +18,7 @@ const useStyles = () => {
     container: {
       flex: 1,
       padding: 16,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
   })
 

--- a/apps/wallet-mobile/src/features/Initialization/DarkThemeAnnouncement/DarkThemeAnnouncement.tsx
+++ b/apps/wallet-mobile/src/features/Initialization/DarkThemeAnnouncement/DarkThemeAnnouncement.tsx
@@ -109,7 +109,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       ...atoms.px_lg,
     },
     content: {

--- a/apps/wallet-mobile/src/features/Initialization/InitialScreen/InitialScreen.tsx
+++ b/apps/wallet-mobile/src/features/Initialization/InitialScreen/InitialScreen.tsx
@@ -115,7 +115,7 @@ const useStyles = () => {
     container: {
       flex: 1,
       ...atoms.p_lg,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     title: {
       ...atoms.heading_3_medium,

--- a/apps/wallet-mobile/src/features/Initialization/LanguagePickerScreen/LanguagePickerScreen.tsx
+++ b/apps/wallet-mobile/src/features/Initialization/LanguagePickerScreen/LanguagePickerScreen.tsx
@@ -20,7 +20,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     safeAreaView: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
   })
 

--- a/apps/wallet-mobile/src/features/Initialization/ReadPrivacyPolicyScreen/ReadPrivacyPolicyScreen.tsx
+++ b/apps/wallet-mobile/src/features/Initialization/ReadPrivacyPolicyScreen/ReadPrivacyPolicyScreen.tsx
@@ -24,7 +24,7 @@ const useStyles = () => {
 
   const styles = StyleSheet.create({
     safeAreaView: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       flex: 1,
     },
     contentContainer: {

--- a/apps/wallet-mobile/src/features/Initialization/ReadTermsOfServiceScreen/ReadTermsOfServiceScreen.tsx
+++ b/apps/wallet-mobile/src/features/Initialization/ReadTermsOfServiceScreen/ReadTermsOfServiceScreen.tsx
@@ -24,7 +24,7 @@ const useStyles = () => {
 
   const styles = StyleSheet.create({
     safeAreaView: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       flex: 1,
     },
     contentContainer: {

--- a/apps/wallet-mobile/src/features/Initialization/TermsOfServiceChangedScreen/TermsOfServiceChangedScreen.tsx
+++ b/apps/wallet-mobile/src/features/Initialization/TermsOfServiceChangedScreen/TermsOfServiceChangedScreen.tsx
@@ -89,7 +89,7 @@ const useStyles = () => {
     container: {
       flex: 1,
       ...atoms.p_lg,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     title: {
       ...atoms.heading_3_medium,

--- a/apps/wallet-mobile/src/features/Links/useCases/AskToOpenAWalletScreen/AskToOpenAWalletScreen.tsx
+++ b/apps/wallet-mobile/src/features/Links/useCases/AskToOpenAWalletScreen/AskToOpenAWalletScreen.tsx
@@ -45,7 +45,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       ...atoms.px_lg,
     },
     actions: {

--- a/apps/wallet-mobile/src/features/Links/useCases/AskToRedirect/AskToRedirectScreen.tsx
+++ b/apps/wallet-mobile/src/features/Links/useCases/AskToRedirect/AskToRedirectScreen.tsx
@@ -43,7 +43,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       ...atoms.px_lg,
     },
     actions: {

--- a/apps/wallet-mobile/src/features/Links/useCases/RequestedAdaPaymentWithLinkScreen/RequestedAdaPaymentWithLinkScreen.tsx
+++ b/apps/wallet-mobile/src/features/Links/useCases/RequestedAdaPaymentWithLinkScreen/RequestedAdaPaymentWithLinkScreen.tsx
@@ -80,7 +80,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       ...atoms.px_lg,
     },
     actions: {

--- a/apps/wallet-mobile/src/features/ListTxHistory/TxHistoryNavigator.tsx
+++ b/apps/wallet-mobile/src/features/ListTxHistory/TxHistoryNavigator.tsx
@@ -595,6 +595,6 @@ const sendOptions = (navigationOptions: StackNavigationOptions, color: ThemedPal
   headerStyle: {
     elevation: 0,
     shadowOpacity: 0,
-    backgroundColor: color.gray_cmin,
+    backgroundColor: color.bg_color_high,
   },
 })

--- a/apps/wallet-mobile/src/features/ListTxHistory/useCases/ListTxHistory/TxHistory.tsx
+++ b/apps/wallet-mobile/src/features/ListTxHistory/useCases/ListTxHistory/TxHistory.tsx
@@ -103,7 +103,7 @@ const useStyles = () => {
     panel: {
       flex: 1,
       paddingTop: 8,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       borderTopLeftRadius: 24,
       borderTopRightRadius: 24,
     },

--- a/apps/wallet-mobile/src/features/ListTxHistory/useCases/ShowTxDetails/AssetListSend.style.ts
+++ b/apps/wallet-mobile/src/features/ListTxHistory/useCases/ShowTxDetails/AssetListSend.style.ts
@@ -26,7 +26,7 @@ export const useSendStyles = () => {
       marginBottom: 10,
       ...atoms.px_lg,
       ...atoms.py_md,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       borderTopWidth: 1,
       borderBottomWidth: 2,
       borderColor: 'rgba(173, 174, 182, 0.3)',

--- a/apps/wallet-mobile/src/features/ListTxHistory/useCases/ShowTxDetails/TxDetails.tsx
+++ b/apps/wallet-mobile/src/features/ListTxHistory/useCases/ShowTxDetails/TxDetails.tsx
@@ -339,7 +339,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     container: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     contentContainer: {
       ...atoms.px_lg,

--- a/apps/wallet-mobile/src/features/Menu/Menu.tsx
+++ b/apps/wallet-mobile/src/features/Menu/Menu.tsx
@@ -276,7 +276,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     item: {
       ...atoms.py_lg,

--- a/apps/wallet-mobile/src/features/Nfts/useCases/Nfts.tsx
+++ b/apps/wallet-mobile/src/features/Nfts/useCases/Nfts.tsx
@@ -127,7 +127,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     safeAreaView: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     container: {
       flexDirection: 'column',

--- a/apps/wallet-mobile/src/features/Portfolio/common/MediaDetails/MediaDetails.tsx
+++ b/apps/wallet-mobile/src/features/Portfolio/common/MediaDetails/MediaDetails.tsx
@@ -298,7 +298,7 @@ const useStyles = () => {
     },
     container: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     image: {
       flexGrow: 1,

--- a/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioDashboard/DashboardTokensList/BuyADABanner/BuyADABanner.tsx
+++ b/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioDashboard/DashboardTokensList/BuyADABanner/BuyADABanner.tsx
@@ -54,7 +54,7 @@ const useStyles = () => {
       ...atoms.relative,
       ...atoms.rounded_sm,
       ...atoms.overflow_hidden,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     spaceButtonText: {
       ...atoms.p_0,

--- a/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioDashboard/DashboardTokensList/TradeTokensBanner.tsx
+++ b/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioDashboard/DashboardTokensList/TradeTokensBanner.tsx
@@ -54,7 +54,7 @@ const useStyles = () => {
       ...atoms.justify_between,
       ...atoms.relative,
       ...atoms.overflow_hidden,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     spaceButtonText: {
       ...atoms.p_0,

--- a/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioDashboard/PortfolioDashboardScreen.tsx
+++ b/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioDashboard/PortfolioDashboardScreen.tsx
@@ -42,7 +42,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       ...atoms.flex_1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
   })
 

--- a/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokenDetails/PortfolioTokenAction.tsx
+++ b/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokenDetails/PortfolioTokenAction.tsx
@@ -39,7 +39,7 @@ const useStyles = () => {
   const {atoms, color} = useTheme()
   const styles = StyleSheet.create({
     root: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       borderTopWidth: 1,
       borderTopColor: color.gray_c200,
     },

--- a/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokenDetails/PortfolioTokenDetailLayout.tsx
+++ b/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokenDetails/PortfolioTokenDetailLayout.tsx
@@ -30,7 +30,7 @@ const useStyles = () => {
     root: {
       ...atoms.flex_1,
       ...atoms.flex_col,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     scrollView: {
       ...atoms.flex_1,

--- a/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokenDetails/PortfolioTokenDetailsScreen.tsx
+++ b/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokenDetails/PortfolioTokenDetailsScreen.tsx
@@ -133,7 +133,7 @@ const useStyles = () => {
     tabs: {
       ...atoms.justify_between,
       ...atoms.px_lg,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     tab: {
       flex: 0,

--- a/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokenDetails/PortfolioTokenInfo/PortfolioTokenInfo.tsx
+++ b/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokenDetails/PortfolioTokenInfo/PortfolioTokenInfo.tsx
@@ -35,7 +35,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       ...atoms.flex_1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
   })
 

--- a/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokenDetails/PortfolioTokenInfo/Transactions/TransactionItem.tsx
+++ b/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokenDetails/PortfolioTokenInfo/Transactions/TransactionItem.tsx
@@ -112,7 +112,7 @@ const useStyles = () => {
       ...atoms.flex_row,
       ...atoms.justify_between,
       ...atoms.align_center,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     leftContainer: {
       ...atoms.flex_1,

--- a/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokenDetails/PortfolioTokenInfo/Transactions/index.tsx
+++ b/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokenDetails/PortfolioTokenInfo/Transactions/index.tsx
@@ -161,7 +161,7 @@ const useStyles = () => {
     root: {
       ...atoms.flex_1,
       ...atoms.flex_col,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     scrollView: {
       ...atoms.flex_1,

--- a/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokensList/PortfolioDAppsTokenList/PortfolioDAppsTokenList.tsx
+++ b/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokensList/PortfolioDAppsTokenList/PortfolioDAppsTokenList.tsx
@@ -121,7 +121,7 @@ const useStyles = () => {
     root: {
       ...atoms.flex_1,
       ...atoms.px_lg,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     container: {
       ...atoms.flex_grow,

--- a/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokensList/PortfolioTokenListScreen.tsx
+++ b/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokensList/PortfolioTokenListScreen.tsx
@@ -68,7 +68,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       ...atoms.flex_1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
   })
 

--- a/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokensList/PortfolioWalletTokenList/PortfolioWalletTokenList.tsx
+++ b/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokensList/PortfolioWalletTokenList/PortfolioWalletTokenList.tsx
@@ -159,7 +159,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       ...atoms.flex_1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     textAvailable: {
       color: color.gray_c700,

--- a/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokensList/PortfolioWalletTokenList/TokenBalanceItem.tsx
+++ b/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokensList/PortfolioWalletTokenList/TokenBalanceItem.tsx
@@ -69,7 +69,7 @@ const useStyles = () => {
   const {color, atoms} = useTheme()
   const styles = StyleSheet.create({
     root: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       ...atoms.flex_row,
       ...atoms.align_center,
       ...atoms.justify_between,

--- a/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokensList/PortfolioWalletTokenList/TradeTokensBannerBig.tsx
+++ b/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokensList/PortfolioWalletTokenList/TradeTokensBannerBig.tsx
@@ -60,7 +60,7 @@ const useStyles = () => {
       ...atoms.justify_between,
       ...atoms.relative,
       ...atoms.overflow_hidden,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     spaceButtonText: {
       ...atoms.p_0,

--- a/apps/wallet-mobile/src/features/Receive/common/CaptureShareQRCodeCard/CaptureShareQRCodeCard.tsx
+++ b/apps/wallet-mobile/src/features/Receive/common/CaptureShareQRCodeCard/CaptureShareQRCodeCard.tsx
@@ -46,7 +46,7 @@ const useStyles = () => {
 
   const styles = StyleSheet.create({
     qrCode: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       padding: 10,
       borderRadius: 8,
     },

--- a/apps/wallet-mobile/src/features/Receive/common/ShareQRCodeCard/ShareQRCodeCard.tsx
+++ b/apps/wallet-mobile/src/features/Receive/common/ShareQRCodeCard/ShareQRCodeCard.tsx
@@ -111,7 +111,7 @@ const useStyles = () => {
 
   const styles = StyleSheet.create({
     qrCode: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       padding: 10,
       borderRadius: 8,
     },

--- a/apps/wallet-mobile/src/features/Receive/common/SmallAddressCard/SmallAddressCard.tsx
+++ b/apps/wallet-mobile/src/features/Receive/common/SmallAddressCard/SmallAddressCard.tsx
@@ -115,7 +115,7 @@ const useStyles = () => {
     },
     statusUsed: {
       borderRadius: 20,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       paddingVertical: 4,
       paddingHorizontal: 8,
       alignItems: 'center',

--- a/apps/wallet-mobile/src/features/Receive/useCases/DescribeSelectedAddressScreen.tsx
+++ b/apps/wallet-mobile/src/features/Receive/useCases/DescribeSelectedAddressScreen.tsx
@@ -118,7 +118,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       ...atoms.p_lg,
     },
     address: {

--- a/apps/wallet-mobile/src/features/Receive/useCases/ListMultipleAddressesScreen.tsx
+++ b/apps/wallet-mobile/src/features/Receive/useCases/ListMultipleAddressesScreen.tsx
@@ -157,7 +157,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       ...atoms.pt_lg,
     },
     content: {
@@ -165,7 +165,7 @@ const useStyles = () => {
       ...atoms.px_lg,
     },
     footer: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       borderColor: color.gray_c200,
       ...atoms.p_lg,
     },

--- a/apps/wallet-mobile/src/features/Receive/useCases/RequestSpecificAmountScreen.tsx
+++ b/apps/wallet-mobile/src/features/Receive/useCases/RequestSpecificAmountScreen.tsx
@@ -163,7 +163,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       ...atoms.px_lg,
     },
     content: {

--- a/apps/wallet-mobile/src/features/Scan/useCases/ShowCameraPermissionDeniedScreen/ShowCameraPermissionDeniedScreen.tsx
+++ b/apps/wallet-mobile/src/features/Scan/useCases/ShowCameraPermissionDeniedScreen/ShowCameraPermissionDeniedScreen.tsx
@@ -47,7 +47,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     container: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       ...atoms.px_lg,
     },
     scroll: {

--- a/apps/wallet-mobile/src/features/Send/common/ButtonGroup/ButtonGroup.tsx
+++ b/apps/wallet-mobile/src/features/Send/common/ButtonGroup/ButtonGroup.tsx
@@ -55,7 +55,7 @@ const useStyles = () => {
       borderRadius: 6,
     },
     selected: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     label: {
       color: color.primary_c600,

--- a/apps/wallet-mobile/src/features/Send/useCases/ConfirmTx/ConfirmTxScreen.tsx
+++ b/apps/wallet-mobile/src/features/Send/useCases/ConfirmTx/ConfirmTxScreen.tsx
@@ -139,11 +139,11 @@ const useStyles = () => {
 
   const styles = StyleSheet.create({
     root: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       flex: 1,
     },
     container: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       flex: 1,
       ...atoms.px_lg,
     },

--- a/apps/wallet-mobile/src/features/Send/useCases/ConfirmTx/FailedTx/FailedTxScreen.tsx
+++ b/apps/wallet-mobile/src/features/Send/useCases/ConfirmTx/FailedTx/FailedTxScreen.tsx
@@ -39,7 +39,7 @@ const useStyles = () => {
   const {color, atoms} = useTheme()
   const styles = StyleSheet.create({
     container: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       flex: 1,
       alignItems: 'center',
       justifyContent: 'center',

--- a/apps/wallet-mobile/src/features/Send/useCases/ConfirmTx/SubmittedTx/SubmittedTxScreen.tsx
+++ b/apps/wallet-mobile/src/features/Send/useCases/ConfirmTx/SubmittedTx/SubmittedTxScreen.tsx
@@ -37,7 +37,7 @@ const useStyles = () => {
   const {atoms, color} = useTheme()
   const styles = StyleSheet.create({
     container: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       ...atoms.p_lg,
       flex: 1,
       alignItems: 'center',

--- a/apps/wallet-mobile/src/features/Send/useCases/ConfirmTx/Summary/CurrentBalance.tsx
+++ b/apps/wallet-mobile/src/features/Send/useCases/ConfirmTx/Summary/CurrentBalance.tsx
@@ -35,7 +35,7 @@ const useStyles = () => {
   const {color, atoms} = useTheme()
   const styles = StyleSheet.create({
     banner: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       ...atoms.py_lg,
       alignItems: 'center',
       justifyContent: 'center',

--- a/apps/wallet-mobile/src/features/Send/useCases/ListAmountsToSend/AddToken/SelectTokenFromListScreen.tsx
+++ b/apps/wallet-mobile/src/features/Send/useCases/ListAmountsToSend/AddToken/SelectTokenFromListScreen.tsx
@@ -384,7 +384,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     subheader: {
       ...atoms.px_lg,

--- a/apps/wallet-mobile/src/features/Send/useCases/ListAmountsToSend/EditAmount/EditAmountScreen.tsx
+++ b/apps/wallet-mobile/src/features/Send/useCases/ListAmountsToSend/EditAmount/EditAmountScreen.tsx
@@ -221,7 +221,7 @@ const useStyles = () => {
     },
     container: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     scrollView: {
       flex: 1,
@@ -240,7 +240,7 @@ const useStyles = () => {
     },
     amount: {
       ...atoms.heading_2_regular,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       borderWidth: 0,
       textAlign: 'right',
     },

--- a/apps/wallet-mobile/src/features/Send/useCases/ListAmountsToSend/ListAmountsToSendScreen.tsx
+++ b/apps/wallet-mobile/src/features/Send/useCases/ListAmountsToSend/ListAmountsToSendScreen.tsx
@@ -218,7 +218,7 @@ const useStyles = () => {
     },
     container: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       ...atoms.px_lg,
     },
     amountItem: {

--- a/apps/wallet-mobile/src/features/Send/useCases/StartMultiTokenTx/StartMultiTokenTxScreen.tsx
+++ b/apps/wallet-mobile/src/features/Send/useCases/StartMultiTokenTx/StartMultiTokenTxScreen.tsx
@@ -161,7 +161,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     container: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       ...atoms.pt_lg,
     },
     flex: {

--- a/apps/wallet-mobile/src/features/Settings/About/About.tsx
+++ b/apps/wallet-mobile/src/features/Settings/About/About.tsx
@@ -62,7 +62,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     about: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       ...atoms.p_lg,
     },
     row: {

--- a/apps/wallet-mobile/src/features/Settings/ApplicationSettings/ApplicationSettingsScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/ApplicationSettings/ApplicationSettingsScreen.tsx
@@ -329,7 +329,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     settings: {
       flex: 1,

--- a/apps/wallet-mobile/src/features/Settings/ChangeLanguage/ChangeLanguageScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/ChangeLanguage/ChangeLanguageScreen.tsx
@@ -19,7 +19,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     safeAreaView: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
   })
   return styles

--- a/apps/wallet-mobile/src/features/Settings/ChangePassword/ChangePasswordScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/ChangePassword/ChangePasswordScreen.tsx
@@ -163,14 +163,14 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     safeAreaView: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     contentContainer: {
       padding: 16,
     },
     actions: {
       padding: 16,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
   })
   return styles

--- a/apps/wallet-mobile/src/features/Settings/ChangeTheme/ChangeThemeScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/ChangeTheme/ChangeThemeScreen.tsx
@@ -23,7 +23,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     safeAreaView: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
   })
 

--- a/apps/wallet-mobile/src/features/Settings/Currency/ChangeCurrencyScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/Currency/ChangeCurrencyScreen.tsx
@@ -23,7 +23,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     safeAreaView: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
   })
 

--- a/apps/wallet-mobile/src/features/Settings/EasyConfirmation/DisableEasyConfirmationScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/EasyConfirmation/DisableEasyConfirmationScreen.tsx
@@ -60,7 +60,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     container: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     heading: {
       ...atoms.body_1_lg_regular,

--- a/apps/wallet-mobile/src/features/Settings/EasyConfirmation/EnableEasyConfirmationScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/EasyConfirmation/EnableEasyConfirmationScreen.tsx
@@ -117,7 +117,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     container: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     contentContainer: {
       padding: 16,

--- a/apps/wallet-mobile/src/features/Settings/ManageCollateral/ConfirmTx/ConfirmTxScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/ManageCollateral/ConfirmTx/ConfirmTxScreen.tsx
@@ -116,7 +116,7 @@ const useStyles = () => {
   const {color} = useTheme()
   const styles = StyleSheet.create({
     root: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       flex: 1,
     },
     container: {

--- a/apps/wallet-mobile/src/features/Settings/ManageCollateral/ConfirmTx/FailedTx/FailedTxScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/ManageCollateral/ConfirmTx/FailedTx/FailedTxScreen.tsx
@@ -32,7 +32,7 @@ const useStyles = () => {
   const {color, atoms} = useTheme()
   const styles = StyleSheet.create({
     container: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       flex: 1,
       alignItems: 'center',
       justifyContent: 'center',

--- a/apps/wallet-mobile/src/features/Settings/ManageCollateral/ConfirmTx/SubmittedTx/SubmittedTxScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/ManageCollateral/ConfirmTx/SubmittedTx/SubmittedTxScreen.tsx
@@ -33,7 +33,7 @@ const useStyles = () => {
   const {color, atoms} = useTheme()
   const styles = StyleSheet.create({
     container: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       flex: 1,
       alignItems: 'center',
       justifyContent: 'center',

--- a/apps/wallet-mobile/src/features/Settings/ManageCollateral/ConfirmTx/Summary/CurrentBalance.tsx
+++ b/apps/wallet-mobile/src/features/Settings/ManageCollateral/ConfirmTx/Summary/CurrentBalance.tsx
@@ -35,7 +35,7 @@ const useStyles = () => {
   const {color} = useTheme()
   const styles = StyleSheet.create({
     banner: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       paddingVertical: 16,
       alignItems: 'center',
       justifyContent: 'center',

--- a/apps/wallet-mobile/src/features/Settings/ManageCollateral/ManageCollateralScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/ManageCollateral/ManageCollateralScreen.tsx
@@ -232,7 +232,7 @@ const useStyles = () => {
   const {color} = useTheme()
   const styles = StyleSheet.create({
     safeAreaView: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       flex: 1,
       paddingHorizontal: 16,
     },

--- a/apps/wallet-mobile/src/features/Settings/PrivacyPolicy/PrivacyPolicyScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/PrivacyPolicy/PrivacyPolicyScreen.tsx
@@ -23,7 +23,7 @@ const useStyles = () => {
   const {color} = useTheme()
   const styles = StyleSheet.create({
     safeAreaView: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       flex: 1,
     },
     contentContainer: {

--- a/apps/wallet-mobile/src/features/Settings/RemoveWallet/RemoveWalletScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/RemoveWallet/RemoveWalletScreen.tsx
@@ -162,13 +162,13 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     container: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     contentContainer: {
       ...atoms.px_lg,
     },
     descriptionContainer: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     description: {
       ...atoms.body_1_lg_regular,

--- a/apps/wallet-mobile/src/features/Settings/RenameWallet/RenameWallet.tsx
+++ b/apps/wallet-mobile/src/features/Settings/RenameWallet/RenameWallet.tsx
@@ -82,7 +82,7 @@ const useStyles = () => {
   const {color, atoms} = useTheme()
   const styles = StyleSheet.create({
     safeAreaView: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       flex: 1,
     },
     scrollContentContainer: {
@@ -90,7 +90,7 @@ const useStyles = () => {
     },
     action: {
       ...atoms.p_lg,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
   })
   return styles

--- a/apps/wallet-mobile/src/features/Settings/SettingsScreenNavigator.tsx
+++ b/apps/wallet-mobile/src/features/Settings/SettingsScreenNavigator.tsx
@@ -205,7 +205,7 @@ const SettingsTabNavigator = () => {
 
   return (
     <Tab.Navigator
-      style={{backgroundColor: color.gray_cmin}}
+      style={{backgroundColor: color.bg_color_high}}
       screenOptions={({route}) => ({
         ...defaultMaterialTopTabNavigationOptions(atoms, color),
         tabBarLabel: route.name === 'wallet-settings' ? strings.walletTabTitle : strings.appTabTitle,

--- a/apps/wallet-mobile/src/features/Settings/SystemLogScreen/SystemLogScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/SystemLogScreen/SystemLogScreen.tsx
@@ -71,7 +71,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       ...atoms.px_lg,
     },
     labelText: {

--- a/apps/wallet-mobile/src/features/Settings/TermsOfService/TermsOfServiceScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/TermsOfService/TermsOfServiceScreen.tsx
@@ -23,7 +23,7 @@ const useStyles = () => {
   const {color} = useTheme()
   const styles = StyleSheet.create({
     safeAreaView: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       flex: 1,
     },
     contentContainer: {

--- a/apps/wallet-mobile/src/features/Settings/WalletSettings/WalletSettingsScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/WalletSettings/WalletSettingsScreen.tsx
@@ -330,7 +330,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     settings: {
       flex: 1,

--- a/apps/wallet-mobile/src/features/SetupWallet/common/LogoBanner/LogoBanner.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/common/LogoBanner/LogoBanner.tsx
@@ -28,7 +28,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       alignItems: 'center',
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     title: {
       color: color.primary_c500,

--- a/apps/wallet-mobile/src/features/SetupWallet/common/PreparingWalletScreen/PreparingWalletScreen.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/common/PreparingWalletScreen/PreparingWalletScreen.tsx
@@ -41,7 +41,7 @@ const useStyles = () => {
       ...atoms.flex_1,
       ...atoms.align_center,
       ...atoms.justify_center,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     title: {
       color: color.primary_c500,

--- a/apps/wallet-mobile/src/features/SetupWallet/legacy/CheckNanoX/CheckNanoXScreen.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/legacy/CheckNanoX/CheckNanoXScreen.tsx
@@ -90,7 +90,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     safeAreaView: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     image: {
       alignSelf: 'center',

--- a/apps/wallet-mobile/src/features/SetupWallet/legacy/ConnectNanoX/ConnectNanoXScreen.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/legacy/ConnectNanoX/ConnectNanoXScreen.tsx
@@ -94,7 +94,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     safeAreaView: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
   })
   return styles

--- a/apps/wallet-mobile/src/features/SetupWallet/legacy/WalletForm.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/legacy/WalletForm.tsx
@@ -197,7 +197,7 @@ const useStyles = () => {
     },
     actions: {
       ...atoms.p_lg,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
   })
   return styles

--- a/apps/wallet-mobile/src/features/SetupWallet/legacy/WalletNameForm/WalletNameForm.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/legacy/WalletNameForm/WalletNameForm.tsx
@@ -109,7 +109,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     container: {
       paddingVertical: 24,

--- a/apps/wallet-mobile/src/features/SetupWallet/useCases/ChooseMnemonicType/ChooseMnemonicTypeScreen.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/useCases/ChooseMnemonicType/ChooseMnemonicTypeScreen.tsx
@@ -75,7 +75,7 @@ const useStyles = () => {
     container: {
       flex: 1,
       ...atoms.px_lg,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     icon: {
       position: 'absolute',

--- a/apps/wallet-mobile/src/features/SetupWallet/useCases/ChooseNetwork/ChooseNetworkScreen.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/useCases/ChooseNetwork/ChooseNetworkScreen.tsx
@@ -109,7 +109,7 @@ const useStyles = () => {
     container: {
       flex: 1,
       ...atoms.px_lg,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
   })
 

--- a/apps/wallet-mobile/src/features/SetupWallet/useCases/ChooseSetupType/ChooseSetupTypeScreen.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/useCases/ChooseSetupType/ChooseSetupTypeScreen.tsx
@@ -137,7 +137,7 @@ const useStyles = () => {
     container: {
       flex: 1,
       ...atoms.px_lg,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     icon: {
       position: 'absolute',

--- a/apps/wallet-mobile/src/features/SetupWallet/useCases/CreateWallet/AboutRecoveryPhraseScreen.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/useCases/CreateWallet/AboutRecoveryPhraseScreen.tsx
@@ -92,7 +92,7 @@ const useStyles = () => {
       flex: 1,
       ...atoms.px_lg,
       justifyContent: 'space-between',
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     aboutRecoveryPhraseTitle: {
       ...atoms.body_1_lg_regular,

--- a/apps/wallet-mobile/src/features/SetupWallet/useCases/CreateWallet/RecoveryPhraseScreen.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/useCases/CreateWallet/RecoveryPhraseScreen.tsx
@@ -188,7 +188,7 @@ const useStyles = () => {
       flex: 1,
       ...atoms.px_lg,
       justifyContent: 'space-between',
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     modal: {
       flex: 1,

--- a/apps/wallet-mobile/src/features/SetupWallet/useCases/CreateWallet/VerifyRecoveryPhraseScreen.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/useCases/CreateWallet/VerifyRecoveryPhraseScreen.tsx
@@ -373,7 +373,7 @@ const useStyles = () => {
       flex: 1,
       ...atoms.px_lg,
       justifyContent: 'space-between',
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     title: {
       ...atoms.body_1_lg_regular,
@@ -389,7 +389,7 @@ const useStyles = () => {
     recoveryPhraseBackground: {
       borderRadius: 6,
       overflow: 'hidden',
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       minHeight: 182,
     },
     recoveryPhraseOutline: {
@@ -455,7 +455,7 @@ const useStyles = () => {
     },
     usedWordBackground: {
       position: 'absolute',
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       borderRadius: 6,
       left: 2,
       right: 2,

--- a/apps/wallet-mobile/src/features/SetupWallet/useCases/CreateWallet/WalletDetailsScreen.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/useCases/CreateWallet/WalletDetailsScreen.tsx
@@ -392,7 +392,7 @@ const useStyles = () => {
     root: {
       flex: 1,
       justifyContent: 'space-between',
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     container: {
       flex: 1,

--- a/apps/wallet-mobile/src/features/SetupWallet/useCases/RestoreWallet/RestoreWalletDetailsScreen.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/useCases/RestoreWallet/RestoreWalletDetailsScreen.tsx
@@ -355,7 +355,7 @@ const useStyles = () => {
     root: {
       flex: 1,
       justifyContent: 'space-between',
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     modal: {
       flex: 1,

--- a/apps/wallet-mobile/src/features/SetupWallet/useCases/RestoreWallet/RestoreWalletScreen.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/useCases/RestoreWallet/RestoreWalletScreen.tsx
@@ -317,7 +317,7 @@ const useStyles = () => {
     root: {
       flex: 1,
       justifyContent: 'space-between',
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     title: {
       ...atoms.body_1_lg_regular,
@@ -365,7 +365,7 @@ const useStyles = () => {
       ...atoms.px_lg,
     },
     suggestions: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       borderColor: color.gray_c200,
       borderTopWidth: 1,
       flexDirection: 'row',
@@ -385,7 +385,7 @@ const useStyles = () => {
       color: color.primary_c500,
     },
     suggestionArea: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       borderColor: color.gray_c200,
       borderTopWidth: 1,
       alignItems: 'center',

--- a/apps/wallet-mobile/src/features/Staking/Governance/common/Action/Action.tsx
+++ b/apps/wallet-mobile/src/features/Staking/Governance/common/Action/Action.tsx
@@ -16,10 +16,10 @@ type Props = {
 }
 
 export const Action = ({title, description, onPress, pending, children, showRightArrow}: Props) => {
-  const styles = useStyles()
+  const {styles, color} = useStyles()
   return (
     <TouchableOpacity onPress={onPress} disabled={pending}>
-      <LinearGradient start={{x: 0, y: 0}} end={{x: 0, y: 1}} colors={['#E4E8F7', '#C6F7F7']} style={styles.gradient}>
+      <LinearGradient start={{x: 0, y: 0}} end={{x: 0, y: 1}} colors={color.bg_gradient_1} style={styles.gradient}>
         {pending && (
           <View style={styles.icon}>
             <ActivityIndicator color="black" size="small" />
@@ -82,5 +82,5 @@ const useStyles = () => {
     },
   })
 
-  return styles
+  return {styles, color}
 }

--- a/apps/wallet-mobile/src/features/Staking/Governance/common/SafeArea.tsx
+++ b/apps/wallet-mobile/src/features/Staking/Governance/common/SafeArea.tsx
@@ -22,7 +22,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
   })
   return styles

--- a/apps/wallet-mobile/src/features/Staking/Governance/useCases/FailedTx/FailedTxScreen.tsx
+++ b/apps/wallet-mobile/src/features/Staking/Governance/useCases/FailedTx/FailedTxScreen.tsx
@@ -42,7 +42,7 @@ const useStyles = () => {
 
   const styles = StyleSheet.create({
     root: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       flex: 1,
       padding: 16,
     },

--- a/apps/wallet-mobile/src/features/Swap/SwapNavigator.tsx
+++ b/apps/wallet-mobile/src/features/Swap/SwapNavigator.tsx
@@ -83,10 +83,10 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     tab: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
   })
   return styles

--- a/apps/wallet-mobile/src/features/Swap/common/AmountCard/AmountCard.tsx
+++ b/apps/wallet-mobile/src/features/Swap/common/AmountCard/AmountCard.tsx
@@ -181,7 +181,7 @@ const useStyles = () => {
       position: 'absolute',
       top: -7,
       left: 10,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       paddingHorizontal: 5,
       fontSize: 12,
       color: color.gray_c900,

--- a/apps/wallet-mobile/src/features/Swap/common/Counter/Counter.tsx
+++ b/apps/wallet-mobile/src/features/Swap/common/Counter/Counter.tsx
@@ -42,7 +42,7 @@ const useStyles = () => {
       paddingTop: 16,
       justifyContent: 'center',
       flexDirection: 'row',
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     counterText: {
       ...atoms.body_2_md_medium,

--- a/apps/wallet-mobile/src/features/Swap/useCases/ConfirmTxScreen/ConfirmTxScreen.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/ConfirmTxScreen/ConfirmTxScreen.tsx
@@ -168,19 +168,19 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       paddingTop: 16,
     },
     container: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       display: 'flex',
       flexDirection: 'column',
       justifyContent: 'space-between',
     },
     actions: {
       padding: 16,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     modalContent: {
       flex: 1,

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/CreateOrder.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/CreateOrder.tsx
@@ -324,7 +324,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     scroll: {
       paddingHorizontal: 16,

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditBuyAmount/SelectBuyTokenFromListScreen/SelectBuyTokenFromListScreen.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditBuyAmount/SelectBuyTokenFromListScreen/SelectBuyTokenFromListScreen.tsx
@@ -229,7 +229,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     container: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     ph: {
       paddingHorizontal: 16,

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditPool/SelectPoolFromListScreen/SelectPoolFromListScreen.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditPool/SelectPoolFromListScreen/SelectPoolFromListScreen.tsx
@@ -34,7 +34,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
   })
 

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditPrice/EditPrice.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditPrice/EditPrice.tsx
@@ -108,7 +108,7 @@ const useStyles = () => {
       position: 'absolute',
       top: -7,
       left: 10,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       paddingHorizontal: 5,
       fontSize: 12,
       color: color.gray_c900,

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditSellAmount/SelectSellTokenFromListScreen/SelectSellTokenFromListScreen.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditSellAmount/SelectSellTokenFromListScreen/SelectSellTokenFromListScreen.tsx
@@ -175,7 +175,7 @@ const useStyles = () => {
     },
     container: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       display: 'flex',
       justifyContent: 'flex-start',
     },

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditSlippage/EditSlippageScreen/EditSlippageScreen.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/CreateOrder/EditSlippage/EditSlippageScreen/EditSlippageScreen.tsx
@@ -143,7 +143,7 @@ const useStyles = () => {
     },
     container: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       ...atoms.p_lg,
     },
     textInfo: {
@@ -206,7 +206,7 @@ const useStyles = () => {
       paddingHorizontal: 3,
       ...atoms.body_3_sm_regular,
       color: color.gray_cmax,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
   })
 

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/ListOrders/CompletedOrders.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/ListOrders/CompletedOrders.tsx
@@ -198,7 +198,6 @@ export const ExpandableOrder = ({order, tokenInfos}: {order: MappedRawOrder; tok
         />
       }
       expanded={expanded}
-      withBoxShadow
     >
       <MainInfo
         tokenPrice={marketPrice}
@@ -384,7 +383,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     container: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     flex: {
       flex: 1,

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/ListOrders/ListOrders.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/ListOrders/ListOrders.tsx
@@ -69,7 +69,7 @@ const useStyles = () => {
     root: {
       flex: 1,
       justifyContent: 'space-between',
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
   })
   return styles

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/ListOrders/OpenOrders.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/ListOrders/OpenOrders.tsx
@@ -350,7 +350,6 @@ export const OpenOrders = () => {
                     {strings.listOrdersSheetButtonText.toLocaleUpperCase()}
                   </Footer>
                 }
-                withBoxShadow
               >
                 <MainInfo
                   tokenAmount={`${order.tokenAmount} ${order.assetToLabel}`}
@@ -740,7 +739,7 @@ const useStyles = () => {
     },
     container: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       paddingTop: 10,
     },
     content: {

--- a/apps/wallet-mobile/src/features/ToggleAnalyticsSettings/ToggleAnalyticsSettingsScreen.tsx
+++ b/apps/wallet-mobile/src/features/ToggleAnalyticsSettings/ToggleAnalyticsSettingsScreen.tsx
@@ -23,7 +23,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     container: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
   })
 

--- a/apps/wallet-mobile/src/features/WalletManager/useCases/SelectWalletFromListScreen/SelectWalletFromListScreen.tsx
+++ b/apps/wallet-mobile/src/features/WalletManager/useCases/SelectWalletFromListScreen/SelectWalletFromListScreen.tsx
@@ -153,7 +153,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     safeAreaView: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     topButton: {
       backgroundColor: color.primary_c500,

--- a/apps/wallet-mobile/src/kernel/navigation.tsx
+++ b/apps/wallet-mobile/src/kernel/navigation.tsx
@@ -65,7 +65,7 @@ export const defaultStackNavigationOptions = (atoms: Atoms, color: ThemedPalette
       <View
         style={{
           flex: 1,
-          backgroundColor: color.gray_cmin,
+          backgroundColor: color.bg_color_high,
         }}
       />
     ),
@@ -73,7 +73,7 @@ export const defaultStackNavigationOptions = (atoms: Atoms, color: ThemedPalette
     headerStyle: {
       elevation: 0,
       shadowOpacity: 0,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     headerTitleStyle: {
       ...atoms.body_1_lg_medium,
@@ -102,7 +102,7 @@ export const defaultMaterialTopTabNavigationOptions = (
   color: ThemedPalette,
 ): MaterialTopTabNavigationOptions => {
   return {
-    tabBarStyle: {backgroundColor: color.gray_cmin, elevation: 0, shadowOpacity: 0, marginHorizontal: 16},
+    tabBarStyle: {backgroundColor: color.bg_color_high, elevation: 0, shadowOpacity: 0, marginHorizontal: 16},
     tabBarIndicatorStyle: {backgroundColor: color.primary_c600, height: 2},
     tabBarLabelStyle: {
       textTransform: 'none',

--- a/apps/wallet-mobile/src/legacy/Catalyst/ConfirmPin.tsx
+++ b/apps/wallet-mobile/src/legacy/Catalyst/ConfirmPin.tsx
@@ -91,7 +91,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     safeAreaView: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     contentContainer: {
       ...atoms.px_lg,

--- a/apps/wallet-mobile/src/legacy/Catalyst/ConfirmVotingTx.tsx
+++ b/apps/wallet-mobile/src/legacy/Catalyst/ConfirmVotingTx.tsx
@@ -129,7 +129,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     safeAreaView: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     contentContainer: {
       ...atoms.px_lg,

--- a/apps/wallet-mobile/src/legacy/Catalyst/DisplayPin.tsx
+++ b/apps/wallet-mobile/src/legacy/Catalyst/DisplayPin.tsx
@@ -81,7 +81,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     safeAreaView: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     contentContainer: {
       ...atoms.px_lg,

--- a/apps/wallet-mobile/src/legacy/Catalyst/DownloadCatalyst.tsx
+++ b/apps/wallet-mobile/src/legacy/Catalyst/DownloadCatalyst.tsx
@@ -211,7 +211,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     safeAreaView: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     container: {
       ...atoms.px_lg,

--- a/apps/wallet-mobile/src/legacy/Catalyst/QrCode.tsx
+++ b/apps/wallet-mobile/src/legacy/Catalyst/QrCode.tsx
@@ -133,7 +133,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     safeAreaView: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     alertBox: {
       ...atoms.p_lg,

--- a/apps/wallet-mobile/src/legacy/Dashboard/Dashboard.tsx
+++ b/apps/wallet-mobile/src/legacy/Dashboard/Dashboard.tsx
@@ -253,7 +253,7 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     root: {
       flex: 1,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
     },
     container: {
       flexDirection: 'column',

--- a/apps/wallet-mobile/src/legacy/Dashboard/EpochProgress.tsx
+++ b/apps/wallet-mobile/src/legacy/Dashboard/EpochProgress.tsx
@@ -101,7 +101,7 @@ const useStyles = () => {
     timeBlock: {
       ...atoms.body_1_lg_regular,
       ...atoms.py_xs,
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       color: color.gray_c900,
       marginHorizontal: 4,
       borderRadius: 2,

--- a/apps/wallet-mobile/src/legacy/Staking/FailedTx/FailedTxScreen.tsx
+++ b/apps/wallet-mobile/src/legacy/Staking/FailedTx/FailedTxScreen.tsx
@@ -66,7 +66,7 @@ const useStyles = () => {
   const {atoms, color} = useTheme()
   const styles = StyleSheet.create({
     container: {
-      backgroundColor: color.gray_cmin,
+      backgroundColor: color.bg_color_high,
       flex: 1,
       alignItems: 'center',
       justifyContent: 'center',

--- a/apps/wallet-mobile/translations/messages/src/components/Analytics/Analytics.json
+++ b/apps/wallet-mobile/translations/messages/src/components/Analytics/Analytics.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 293,
       "column": 10,
-      "index": 7370
+      "index": 7378
     },
     "end": {
       "line": 296,
       "column": 3,
-      "index": 7463
+      "index": 7471
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 297,
       "column": 15,
-      "index": 7480
+      "index": 7488
     },
     "end": {
       "line": 300,
       "column": 3,
-      "index": 7619
+      "index": 7627
     }
   },
   {
@@ -36,12 +36,12 @@
     "start": {
       "line": 301,
       "column": 13,
-      "index": 7634
+      "index": 7642
     },
     "end": {
       "line": 304,
       "column": 3,
-      "index": 7721
+      "index": 7729
     }
   },
   {
@@ -51,12 +51,12 @@
     "start": {
       "line": 305,
       "column": 10,
-      "index": 7733
+      "index": 7741
     },
     "end": {
       "line": 308,
       "column": 3,
-      "index": 7828
+      "index": 7836
     }
   },
   {
@@ -66,12 +66,12 @@
     "start": {
       "line": 309,
       "column": 11,
-      "index": 7841
+      "index": 7849
     },
     "end": {
       "line": 312,
       "column": 3,
-      "index": 7938
+      "index": 7946
     }
   },
   {
@@ -81,12 +81,12 @@
     "start": {
       "line": 313,
       "column": 8,
-      "index": 7948
+      "index": 7956
     },
     "end": {
       "line": 316,
       "column": 3,
-      "index": 8046
+      "index": 8054
     }
   },
   {
@@ -96,12 +96,12 @@
     "start": {
       "line": 317,
       "column": 10,
-      "index": 8058
+      "index": 8066
     },
     "end": {
       "line": 320,
       "column": 3,
-      "index": 8144
+      "index": 8152
     }
   },
   {
@@ -111,12 +111,12 @@
     "start": {
       "line": 321,
       "column": 8,
-      "index": 8154
+      "index": 8162
     },
     "end": {
       "line": 324,
       "column": 3,
-      "index": 8242
+      "index": 8250
     }
   },
   {
@@ -126,12 +126,12 @@
     "start": {
       "line": 325,
       "column": 8,
-      "index": 8252
+      "index": 8260
     },
     "end": {
       "line": 328,
       "column": 3,
-      "index": 8314
+      "index": 8322
     }
   },
   {
@@ -141,12 +141,12 @@
     "start": {
       "line": 329,
       "column": 10,
-      "index": 8326
+      "index": 8334
     },
     "end": {
       "line": 332,
       "column": 3,
-      "index": 8392
+      "index": 8400
     }
   },
   {
@@ -156,12 +156,12 @@
     "start": {
       "line": 333,
       "column": 10,
-      "index": 8404
+      "index": 8412
     },
     "end": {
       "line": 336,
       "column": 3,
-      "index": 8485
+      "index": 8493
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/components/ErrorModal/ErrorModal.json
+++ b/apps/wallet-mobile/translations/messages/src/components/ErrorModal/ErrorModal.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 152,
       "column": 13,
-      "index": 4218
+      "index": 4222
     },
     "end": {
       "line": 155,
       "column": 3,
-      "index": 4318
+      "index": 4322
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 156,
       "column": 13,
-      "index": 4333
+      "index": 4337
     },
     "end": {
       "line": 159,
       "column": 3,
-      "index": 4433
+      "index": 4437
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/features/Auth/PinLoginScreen/PinLoginScreen.json
+++ b/apps/wallet-mobile/translations/messages/src/features/Auth/PinLoginScreen/PinLoginScreen.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 69,
       "column": 9,
-      "index": 1759
+      "index": 1763
     },
     "end": {
       "line": 72,
       "column": 3,
-      "index": 1849
+      "index": 1853
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/features/Initialization/DarkThemeAnnouncement/DarkThemeAnnouncement.json
+++ b/apps/wallet-mobile/translations/messages/src/features/Initialization/DarkThemeAnnouncement/DarkThemeAnnouncement.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 157,
       "column": 10,
-      "index": 4635
+      "index": 4639
     },
     "end": {
       "line": 160,
       "column": 3,
-      "index": 4728
+      "index": 4732
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 161,
       "column": 15,
-      "index": 4745
+      "index": 4749
     },
     "end": {
       "line": 165,
       "column": 3,
-      "index": 4933
+      "index": 4937
     }
   },
   {
@@ -36,12 +36,12 @@
     "start": {
       "line": 166,
       "column": 15,
-      "index": 4950
+      "index": 4954
     },
     "end": {
       "line": 169,
       "column": 3,
-      "index": 5047
+      "index": 5051
     }
   },
   {
@@ -51,12 +51,12 @@
     "start": {
       "line": 170,
       "column": 12,
-      "index": 5061
+      "index": 5065
     },
     "end": {
       "line": 173,
       "column": 3,
-      "index": 5160
+      "index": 5164
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/features/Nfts/useCases/Nfts.json
+++ b/apps/wallet-mobile/translations/messages/src/features/Nfts/useCases/Nfts.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 162,
       "column": 12,
-      "index": 4313
+      "index": 4317
     },
     "end": {
       "line": 165,
       "column": 3,
-      "index": 4386
+      "index": 4390
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 166,
       "column": 14,
-      "index": 4402
+      "index": 4406
     },
     "end": {
       "line": 169,
       "column": 3,
-      "index": 4473
+      "index": 4477
     }
   },
   {
@@ -36,12 +36,12 @@
     "start": {
       "line": 170,
       "column": 20,
-      "index": 4495
+      "index": 4499
     },
     "end": {
       "line": 173,
       "column": 3,
-      "index": 4588
+      "index": 4592
     }
   },
   {
@@ -51,12 +51,12 @@
     "start": {
       "line": 174,
       "column": 13,
-      "index": 4603
+      "index": 4607
     },
     "end": {
       "line": 177,
       "column": 3,
-      "index": 4691
+      "index": 4695
     }
   },
   {
@@ -66,12 +66,12 @@
     "start": {
       "line": 178,
       "column": 15,
-      "index": 4708
+      "index": 4712
     },
     "end": {
       "line": 181,
       "column": 3,
-      "index": 4788
+      "index": 4792
     }
   },
   {
@@ -81,12 +81,12 @@
     "start": {
       "line": 182,
       "column": 18,
-      "index": 4808
+      "index": 4812
     },
     "end": {
       "line": 185,
       "column": 3,
-      "index": 4910
+      "index": 4914
     }
   },
   {
@@ -96,12 +96,12 @@
     "start": {
       "line": 186,
       "column": 9,
-      "index": 4921
+      "index": 4925
     },
     "end": {
       "line": 189,
       "column": 3,
-      "index": 4996
+      "index": 5000
     }
   },
   {
@@ -111,12 +111,12 @@
     "start": {
       "line": 190,
       "column": 10,
-      "index": 5008
+      "index": 5012
     },
     "end": {
       "line": 193,
       "column": 3,
-      "index": 5083
+      "index": 5087
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/features/Portfolio/common/MediaDetails/MediaDetails.json
+++ b/apps/wallet-mobile/translations/messages/src/features/Portfolio/common/MediaDetails/MediaDetails.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 342,
       "column": 9,
-      "index": 9657
+      "index": 9661
     },
     "end": {
       "line": 345,
       "column": 3,
-      "index": 9728
+      "index": 9732
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 346,
       "column": 12,
-      "index": 9742
+      "index": 9746
     },
     "end": {
       "line": 349,
       "column": 3,
-      "index": 9813
+      "index": 9817
     }
   },
   {
@@ -36,12 +36,12 @@
     "start": {
       "line": 350,
       "column": 12,
-      "index": 9827
+      "index": 9831
     },
     "end": {
       "line": 353,
       "column": 3,
-      "index": 9898
+      "index": 9902
     }
   },
   {
@@ -51,12 +51,12 @@
     "start": {
       "line": 354,
       "column": 11,
-      "index": 9911
+      "index": 9915
     },
     "end": {
       "line": 357,
       "column": 3,
-      "index": 9981
+      "index": 9985
     }
   },
   {
@@ -66,12 +66,12 @@
     "start": {
       "line": 358,
       "column": 13,
-      "index": 9996
+      "index": 10000
     },
     "end": {
       "line": 361,
       "column": 3,
-      "index": 10067
+      "index": 10071
     }
   },
   {
@@ -81,12 +81,12 @@
     "start": {
       "line": 362,
       "column": 15,
-      "index": 10084
+      "index": 10088
     },
     "end": {
       "line": 365,
       "column": 3,
-      "index": 10161
+      "index": 10165
     }
   },
   {
@@ -96,12 +96,12 @@
     "start": {
       "line": 366,
       "column": 10,
-      "index": 10173
+      "index": 10177
     },
     "end": {
       "line": 369,
       "column": 3,
-      "index": 10240
+      "index": 10244
     }
   },
   {
@@ -111,12 +111,12 @@
     "start": {
       "line": 370,
       "column": 15,
-      "index": 10257
+      "index": 10261
     },
     "end": {
       "line": 373,
       "column": 3,
-      "index": 10334
+      "index": 10338
     }
   },
   {
@@ -126,12 +126,12 @@
     "start": {
       "line": 374,
       "column": 12,
-      "index": 10348
+      "index": 10352
     },
     "end": {
       "line": 377,
       "column": 3,
-      "index": 10420
+      "index": 10424
     }
   },
   {
@@ -141,12 +141,12 @@
     "start": {
       "line": 378,
       "column": 16,
-      "index": 10438
+      "index": 10442
     },
     "end": {
       "line": 381,
       "column": 3,
-      "index": 10515
+      "index": 10519
     }
   },
   {
@@ -156,12 +156,12 @@
     "start": {
       "line": 382,
       "column": 16,
-      "index": 10533
+      "index": 10537
     },
     "end": {
       "line": 385,
       "column": 3,
-      "index": 10613
+      "index": 10617
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/features/Settings/About/About.json
+++ b/apps/wallet-mobile/translations/messages/src/features/Settings/About/About.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 101,
       "column": 18,
-      "index": 2586
+      "index": 2590
     },
     "end": {
       "line": 104,
       "column": 3,
-      "index": 2666
+      "index": 2670
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 105,
       "column": 10,
-      "index": 2678
+      "index": 2682
     },
     "end": {
       "line": 108,
       "column": 3,
-      "index": 2741
+      "index": 2745
     }
   },
   {
@@ -36,12 +36,12 @@
     "start": {
       "line": 109,
       "column": 11,
-      "index": 2754
+      "index": 2758
     },
     "end": {
       "line": 112,
       "column": 3,
-      "index": 2819
+      "index": 2823
     }
   },
   {
@@ -51,12 +51,12 @@
     "start": {
       "line": 113,
       "column": 14,
-      "index": 2835
+      "index": 2839
     },
     "end": {
       "line": 116,
       "column": 3,
-      "index": 2946
+      "index": 2950
     }
   },
   {
@@ -66,12 +66,12 @@
     "start": {
       "line": 117,
       "column": 15,
-      "index": 2963
+      "index": 2967
     },
     "end": {
       "line": 120,
       "column": 3,
-      "index": 3074
+      "index": 3078
     }
   },
   {
@@ -81,12 +81,12 @@
     "start": {
       "line": 121,
       "column": 17,
-      "index": 3093
+      "index": 3097
     },
     "end": {
       "line": 124,
       "column": 3,
-      "index": 3208
+      "index": 3212
     }
   },
   {
@@ -96,12 +96,12 @@
     "start": {
       "line": 125,
       "column": 21,
-      "index": 3231
+      "index": 3235
     },
     "end": {
       "line": 128,
       "column": 3,
-      "index": 3351
+      "index": 3355
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/features/Settings/RenameWallet/RenameWallet.json
+++ b/apps/wallet-mobile/translations/messages/src/features/Settings/RenameWallet/RenameWallet.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 102,
       "column": 16,
-      "index": 3223
+      "index": 3231
     },
     "end": {
       "line": 105,
       "column": 3,
-      "index": 3327
+      "index": 3335
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 106,
       "column": 24,
-      "index": 3353
+      "index": 3361
     },
     "end": {
       "line": 109,
       "column": 3,
-      "index": 3465
+      "index": 3473
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/features/Settings/SettingsScreenNavigator.json
+++ b/apps/wallet-mobile/translations/messages/src/features/Settings/SettingsScreenNavigator.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 242,
       "column": 18,
-      "index": 7354
+      "index": 7358
     },
     "end": {
       "line": 245,
       "column": 3,
-      "index": 7452
+      "index": 7456
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 246,
       "column": 15,
-      "index": 7469
+      "index": 7473
     },
     "end": {
       "line": 249,
       "column": 3,
-      "index": 7578
+      "index": 7582
     }
   },
   {
@@ -36,12 +36,12 @@
     "start": {
       "line": 250,
       "column": 24,
-      "index": 7604
+      "index": 7608
     },
     "end": {
       "line": 253,
       "column": 3,
-      "index": 7713
+      "index": 7717
     }
   },
   {
@@ -51,12 +51,12 @@
     "start": {
       "line": 254,
       "column": 23,
-      "index": 7738
+      "index": 7742
     },
     "end": {
       "line": 257,
       "column": 3,
-      "index": 7852
+      "index": 7856
     }
   },
   {
@@ -66,12 +66,12 @@
     "start": {
       "line": 258,
       "column": 21,
-      "index": 7875
+      "index": 7879
     },
     "end": {
       "line": 261,
       "column": 3,
-      "index": 7976
+      "index": 7980
     }
   },
   {
@@ -81,12 +81,12 @@
     "start": {
       "line": 262,
       "column": 23,
-      "index": 8001
+      "index": 8005
     },
     "end": {
       "line": 265,
       "column": 3,
-      "index": 8117
+      "index": 8121
     }
   },
   {
@@ -96,12 +96,12 @@
     "start": {
       "line": 266,
       "column": 25,
-      "index": 8144
+      "index": 8148
     },
     "end": {
       "line": 269,
       "column": 3,
-      "index": 8248
+      "index": 8252
     }
   },
   {
@@ -111,12 +111,12 @@
     "start": {
       "line": 270,
       "column": 16,
-      "index": 8266
+      "index": 8270
     },
     "end": {
       "line": 273,
       "column": 3,
-      "index": 8357
+      "index": 8361
     }
   },
   {
@@ -126,12 +126,12 @@
     "start": {
       "line": 274,
       "column": 31,
-      "index": 8390
+      "index": 8394
     },
     "end": {
       "line": 277,
       "column": 3,
-      "index": 8505
+      "index": 8509
     }
   },
   {
@@ -141,12 +141,12 @@
     "start": {
       "line": 278,
       "column": 32,
-      "index": 8539
+      "index": 8543
     },
     "end": {
       "line": 281,
       "column": 3,
-      "index": 8655
+      "index": 8659
     }
   },
   {
@@ -156,12 +156,12 @@
     "start": {
       "line": 282,
       "column": 18,
-      "index": 8675
+      "index": 8679
     },
     "end": {
       "line": 285,
       "column": 3,
-      "index": 8773
+      "index": 8777
     }
   },
   {
@@ -171,12 +171,12 @@
     "start": {
       "line": 286,
       "column": 17,
-      "index": 8792
+      "index": 8796
     },
     "end": {
       "line": 289,
       "column": 3,
-      "index": 8895
+      "index": 8899
     }
   },
   {
@@ -186,12 +186,12 @@
     "start": {
       "line": 290,
       "column": 17,
-      "index": 8914
+      "index": 8918
     },
     "end": {
       "line": 293,
       "column": 3,
-      "index": 9012
+      "index": 9016
     }
   },
   {
@@ -201,12 +201,12 @@
     "start": {
       "line": 294,
       "column": 14,
-      "index": 9028
+      "index": 9032
     },
     "end": {
       "line": 297,
       "column": 3,
-      "index": 9122
+      "index": 9126
     }
   },
   {
@@ -216,12 +216,12 @@
     "start": {
       "line": 298,
       "column": 20,
-      "index": 9144
+      "index": 9148
     },
     "end": {
       "line": 301,
       "column": 3,
-      "index": 9262
+      "index": 9266
     }
   },
   {
@@ -231,12 +231,12 @@
     "start": {
       "line": 302,
       "column": 14,
-      "index": 9278
+      "index": 9282
     },
     "end": {
       "line": 305,
       "column": 3,
-      "index": 9378
+      "index": 9382
     }
   },
   {
@@ -246,12 +246,12 @@
     "start": {
       "line": 306,
       "column": 22,
-      "index": 9402
+      "index": 9406
     },
     "end": {
       "line": 309,
       "column": 3,
-      "index": 9505
+      "index": 9509
     }
   },
   {
@@ -261,12 +261,12 @@
     "start": {
       "line": 310,
       "column": 14,
-      "index": 9521
+      "index": 9525
     },
     "end": {
       "line": 313,
       "column": 3,
-      "index": 9592
+      "index": 9596
     }
   },
   {
@@ -276,12 +276,12 @@
     "start": {
       "line": 314,
       "column": 18,
-      "index": 9612
+      "index": 9616
     },
     "end": {
       "line": 317,
       "column": 3,
-      "index": 9669
+      "index": 9673
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/features/SetupWallet/legacy/WalletNameForm/WalletNameForm.json
+++ b/apps/wallet-mobile/translations/messages/src/features/SetupWallet/legacy/WalletNameForm/WalletNameForm.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 138,
       "column": 24,
-      "index": 4096
+      "index": 4100
     },
     "end": {
       "line": 141,
       "column": 3,
-      "index": 4204
+      "index": 4208
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 142,
       "column": 8,
-      "index": 4214
+      "index": 4218
     },
     "end": {
       "line": 145,
       "column": 3,
-      "index": 4317
+      "index": 4321
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/legacy/Staking/FailedTx/FailedTxScreen.json
+++ b/apps/wallet-mobile/translations/messages/src/legacy/Staking/FailedTx/FailedTxScreen.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 106,
       "column": 18,
-      "index": 2604
+      "index": 2608
     },
     "end": {
       "line": 109,
       "column": 3,
-      "index": 2720
+      "index": 2724
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 110,
       "column": 20,
-      "index": 2742
+      "index": 2746
     },
     "end": {
       "line": 113,
       "column": 3,
-      "index": 2924
+      "index": 2928
     }
   },
   {
@@ -36,12 +36,12 @@
     "start": {
       "line": 114,
       "column": 10,
-      "index": 2936
+      "index": 2940
     },
     "end": {
       "line": 117,
       "column": 3,
-      "index": 3035
+      "index": 3039
     }
   },
   {
@@ -51,12 +51,12 @@
     "start": {
       "line": 118,
       "column": 12,
-      "index": 3049
+      "index": 3053
     },
     "end": {
       "line": 121,
       "column": 3,
-      "index": 3165
+      "index": 3169
     }
   }
 ]

--- a/packages/theme/src/themed-palettes/black.ts
+++ b/packages/theme/src/themed-palettes/black.ts
@@ -20,7 +20,7 @@ export const black: ThemedPalette = {
   text_success: darkPalette.secondary_c500, // success messages
   text_info: darkPalette.sys_cyan_c500, // info messages
 
-  bg_color_high: darkPalette.gray_cmin, // bottom surface
+  bg_color_high: darkPalette.gray_c50, // bottom surface
   bg_color_low: darkPalette.gray_c100, // upper surface
 
   el_primary_high: darkPalette.primary_c700, // hover'nd pressed state, actianable elements


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

Stuff from dark theme meeting.
The background color is off, using wrong variable. Problem is knowing which background colors should be affected. This applies to all of them, which is the most likely. But there could be some elements whose background color needs to be reverted back to `cmin`, maybe.