### PR TITLE
fix(wallet-mobile): Show bottom tabs only for specific routes

### DIFF
--- a/apps/wallet-mobile/src/WalletNavigator.tsx
+++ b/apps/wallet-mobile/src/WalletNavigator.tsx
@@ -28,7 +28,7 @@ import {dappExplorerEnabled} from './kernel/config'
 import {useMetrics} from './kernel/metrics/metricsManager'
 import {
   defaultStackNavigationOptions,
-  shouldHideTabBarForRoutes,
+  shouldShowTabBarForRoutes,
   WalletStackRoutes,
   WalletTabRoutes,
 } from './kernel/navigation'
@@ -38,8 +38,8 @@ import {DashboardNavigator} from './legacy/Dashboard'
 const Tab = createBottomTabNavigator<WalletTabRoutes>()
 
 const TabBarWithHiddenContent = (props: BottomTabBarProps) => {
-  const shouldHide = shouldHideTabBarForRoutes(props.state)
-  return shouldHide ? null : <BottomTabBar {...props} />
+  const shouldShow = shouldShowTabBarForRoutes(props.state)
+  return shouldShow ? <BottomTabBar {...props} /> : null
 }
 
 const WalletTabNavigator = () => {


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)
Show bottom tabs only for specific routes

##### Ticket

[YOMO-1548](https://emurgo.atlassian.net/jira/software/c/projects/YOMO/issues/YOMO-1548)


[YOMO-1548]: https://emurgo.atlassian.net/browse/YOMO-1548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ