### PR TITLE
refactor(swap): dropped old token-info

### DIFF
--- a/packages/swap/src/helpers/orders/factories/makeOrderCalculations.test.ts
+++ b/packages/swap/src/helpers/orders/factories/makeOrderCalculations.test.ts
@@ -32,8 +32,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.a,
-        buyInfo: tokenInfoMocks.b,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -41,8 +39,6 @@ describe('makeOrderCalculations', () => {
       side: 'sell',
       frontendFeeTiers,
     })
-
-    console.error(JSON.stringify(calculations[0]?.prices))
 
     expect(calculations[0]).toStrictEqual<SwapOrderCalculation>({
       order: {
@@ -147,8 +143,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.b,
-        buyInfo: tokenInfoMocks.a,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -261,8 +255,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.a,
-        buyInfo: tokenInfoMocks.b,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -375,8 +367,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.a,
-        buyInfo: tokenInfoMocks.b,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -489,8 +479,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.a,
-        buyInfo: tokenInfoMocks.b,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -598,8 +586,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.a,
-        buyInfo: tokenInfoMocks.b,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -705,8 +691,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.a,
-        buyInfo: tokenInfoMocks.b,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -813,8 +797,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.b,
-        buyInfo: tokenInfoMocks.a,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -921,8 +903,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.a,
-        buyInfo: tokenInfoMocks.b,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -1029,8 +1009,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.a,
-        buyInfo: tokenInfoMocks.b,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -1137,8 +1115,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.b,
-        buyInfo: tokenInfoMocks.a,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -1242,8 +1218,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.b,
-        buyInfo: tokenInfoMocks.a,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -1350,8 +1324,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.b,
-        buyInfo: tokenInfoMocks.a,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -1458,8 +1430,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.b,
-        buyInfo: tokenInfoMocks.a,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -1566,8 +1536,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.a,
-        buyInfo: tokenInfoMocks.b,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -1671,8 +1639,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.a,
-        buyInfo: tokenInfoMocks.b,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -1779,8 +1745,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.b,
-        buyInfo: tokenInfoMocks.a,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -1887,8 +1851,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.a,
-        buyInfo: tokenInfoMocks.b,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -1995,8 +1957,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.a,
-        buyInfo: tokenInfoMocks.b,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -2103,8 +2063,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.b,
-        buyInfo: tokenInfoMocks.a,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -2211,8 +2169,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.b,
-        buyInfo: tokenInfoMocks.a,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -2319,8 +2275,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.b,
-        buyInfo: tokenInfoMocks.a,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -2438,8 +2392,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.b,
-        buyInfo: tokenInfoMocks.a,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -2557,8 +2509,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.b,
-        buyInfo: tokenInfoMocks.a,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -2676,8 +2626,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.b,
-        buyInfo: tokenInfoMocks.a,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -2787,8 +2735,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.b,
-        buyInfo: tokenInfoMocks.a,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -2897,8 +2843,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.b,
-        buyInfo: tokenInfoMocks.a,
         ptInfo: tokenInfoMocks.pt,
         priceDenomination: 0,
       },
@@ -3007,8 +2951,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.b,
-        buyInfo: tokenInfoMocks.a,
         ptInfo: tokenInfoMocks.a,
         priceDenomination: 0,
       },
@@ -3117,8 +3059,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.b,
-        buyInfo: tokenInfoMocks.a,
         ptInfo: tokenInfoMocks.a,
         priceDenomination: 0,
       },
@@ -3227,8 +3167,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.b,
-        buyInfo: tokenInfoMocks.a,
         ptInfo: tokenInfoMocks.a,
         priceDenomination: 0,
       },
@@ -3337,8 +3275,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.b,
-        buyInfo: tokenInfoMocks.a,
         ptInfo: tokenInfoMocks.a,
         priceDenomination: 0,
       },
@@ -3447,8 +3383,6 @@ describe('makeOrderCalculations', () => {
       slippage: slippage,
       pools: pools,
       tokens: {
-        sellInfo: tokenInfoMocks.b,
-        buyInfo: tokenInfoMocks.a,
         ptInfo: tokenInfoMocks.a,
         priceDenomination: 0,
       },

--- a/packages/swap/src/translators/reactjs/provider/SwapProvider.test.tsx
+++ b/packages/swap/src/translators/reactjs/provider/SwapProvider.test.tsx
@@ -512,8 +512,6 @@ describe('SwapProvider', () => {
           },
         },
         tokens: {
-          sellInfo: tokenInfoMocks.a,
-          buyInfo: tokenInfoMocks.b,
           ptInfo: tokenInfoMocks.pt,
           priceDenomination: 0,
         },
@@ -542,9 +540,6 @@ describe('SwapProvider', () => {
       quantity: 20n,
       info: tokenInfoMocks.c,
     })
-    expect(
-      result.current.orderData.tokens.buyInfo,
-    ).toEqual<Portfolio.Token.Info>(tokenInfoMocks.c)
     expect(result.current.orderData.tokens.priceDenomination).toBe(4)
   })
 
@@ -563,8 +558,6 @@ describe('SwapProvider', () => {
           },
         },
         tokens: {
-          sellInfo: tokenInfoMocks.a,
-          buyInfo: tokenInfoMocks.b,
           priceDenomination: 0,
         },
       },
@@ -592,9 +585,6 @@ describe('SwapProvider', () => {
       quantity: 100n,
       info: tokenInfoMocks.c,
     })
-    expect(
-      result.current.orderData.tokens.sellInfo,
-    ).toEqual<Portfolio.Token.Info>(tokenInfoMocks.c)
     expect(result.current.orderData.tokens.priceDenomination).toBe(-4)
   })
 

--- a/packages/swap/src/translators/reactjs/state/state.test.ts
+++ b/packages/swap/src/translators/reactjs/state/state.test.ts
@@ -362,8 +362,6 @@ describe('State Actions', () => {
           quantity: 0n,
         }
         draft.orderData.tokens = {
-          sellInfo: tokenInfoMocks.a,
-          buyInfo: tokenInfoMocks.b,
           ptInfo: tokenInfoMocks.pt,
           priceDenomination: 0,
         }
@@ -420,8 +418,6 @@ describe('State Actions', () => {
           quantity: 0n,
         }
         draft.orderData.tokens = {
-          sellInfo: tokenInfoMocks.a,
-          buyInfo: tokenInfoMocks.b,
           ptInfo: tokenInfoMocks.pt,
           priceDenomination: 0,
         }

--- a/packages/swap/src/translators/reactjs/state/state.ts
+++ b/packages/swap/src/translators/reactjs/state/state.ts
@@ -26,8 +26,6 @@ export type SwapState = Readonly<{
     // state from wallet
     lpTokenHeld?: Portfolio.Token.Amount
     tokens: {
-      sellInfo?: Portfolio.Token.Info
-      buyInfo?: Portfolio.Token.Info
       ptInfo?: Portfolio.Token.Info
       // diff sell - buy decimals
       priceDenomination: number
@@ -329,8 +327,6 @@ const orderReducer = (
           buy: state.orderData.amounts.sell,
         }
         draft.orderData.tokens = {
-          sellInfo: state.orderData.tokens.buyInfo,
-          buyInfo: state.orderData.tokens.sellInfo,
           priceDenomination: -state.orderData.tokens.priceDenomination,
           ptInfo: state.orderData.tokens.ptInfo,
         }
@@ -523,12 +519,11 @@ const orderReducer = (
       // and the selected pool is reset
       case SwapCreateOrderActionType.SellTokenInfoChanged:
         const decimalFactor =
-          (state.orderData.tokens.sellInfo?.decimals ?? 0) -
+          (state.orderData.amounts.sell?.info.decimals ?? 0) -
           action.tokenInfo.decimals
         const decimalScalingFactor =
           BigInt(10) ** BigInt(Math.abs(decimalFactor))
 
-        draft.orderData.tokens.sellInfo = action.tokenInfo
         if (draft.orderData.amounts.sell) {
           const quantity =
             decimalFactor > 0
@@ -548,7 +543,7 @@ const orderReducer = (
 
         draft.orderData.tokens.priceDenomination =
           action.tokenInfo.decimals -
-          (state.orderData.tokens.buyInfo?.decimals ?? 0)
+          (state.orderData.amounts.buy?.info.decimals ?? 0)
 
         draft.orderData.pools = []
 
@@ -561,7 +556,6 @@ const orderReducer = (
       // when changing token info, all the derivaded data is reset
       // and the selected pool is reset
       case SwapCreateOrderActionType.BuyTokenInfoChanged:
-        draft.orderData.tokens.buyInfo = action.tokenInfo
         if (draft.orderData.amounts.buy) {
           draft.orderData.amounts.buy = {
             ...draft.orderData.amounts.buy,
@@ -575,7 +569,7 @@ const orderReducer = (
         }
 
         draft.orderData.tokens.priceDenomination =
-          (state.orderData.tokens.sellInfo?.decimals ?? 0) -
+          (state.orderData.amounts.sell?.info.decimals ?? 0) -
           action.tokenInfo.decimals
 
         draft.orderData.pools = []


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

##### Ticket

- Old `tokens.{sellInfo,buyInfo}` are gone in favour of `amounts.{sell,buy}.info`