### PR TITLE
fix(wallet-mobile): loading inputs rnp

### DIFF
--- a/apps/wallet-mobile/src/features/SetupWallet/legacy/ImportReadOnlyWallet/ImportReadOnlyWalletScreen.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/legacy/ImportReadOnlyWallet/ImportReadOnlyWalletScreen.tsx
@@ -57,8 +57,6 @@ export const ImportReadOnlyWalletScreen = () => {
   )
 }
 
-const _CameraOverlay = () => <View style={styles.scannerOverlay} />
-
 const messages = defineMessages({
   paragraph: {
     id: 'components.walletinit.importreadonlywalletscreen.paragraph',
@@ -107,14 +105,6 @@ const styles = StyleSheet.create({
   paragraph: {
     fontSize: 14,
     lineHeight: 22,
-  },
-  scannerOverlay: {
-    height: '75%',
-    width: '75%',
-    borderWidth: 2,
-    borderColor: 'white',
-    borderRadius: 24,
-    marginTop: 100,
   },
 })
 

--- a/apps/wallet-mobile/src/features/SetupWallet/useCases/CreateWallet/WalletDetailsScreen.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/useCases/CreateWallet/WalletDetailsScreen.tsx
@@ -99,12 +99,6 @@ export const WalletDetailsScreen = () => {
     features.prefillWalletInfo ? debugWalletInfo.PASSWORD : '',
   )
   const passwordErrors = validatePassword(password, passwordConfirmation)
-  const passwordErrorText = passwordErrors.passwordIsWeak
-    ? strings.passwordStrengthRequirement({requiredPasswordLength: REQUIRED_PASSWORD_LENGTH})
-    : undefined
-  const passwordConfirmationErrorText = passwordErrors.matchesConfirmation
-    ? strings.repeatPasswordInputError
-    : undefined
 
   const {
     createWallet,
@@ -134,6 +128,13 @@ export const WalletDetailsScreen = () => {
       })
     },
   })
+
+  const passwordErrorText =
+    passwordErrors.passwordIsWeak && !isLoading
+      ? strings.passwordStrengthRequirement({requiredPasswordLength: REQUIRED_PASSWORD_LENGTH})
+      : undefined
+  const passwordConfirmationErrorText =
+    passwordErrors.matchesConfirmation && !isLoading ? strings.repeatPasswordInputError : undefined
 
   const nameErrors = validateWalletName(name, null, !isCreateWalletSuccess ? walletNames : [])
   const walletNameErrorText = getWalletNameError(
@@ -282,13 +283,12 @@ export const WalletDetailsScreen = () => {
             label={strings.walletDetailsNameInput}
             value={name}
             onChangeText={(walletName: string) => setName(walletName)}
-            errorText={!isEmptyString(walletNameErrorText) ? walletNameErrorText : undefined}
+            errorText={!isEmptyString(walletNameErrorText) && !isLoading ? walletNameErrorText : undefined}
             errorDelay={0}
             returnKeyType="next"
             onSubmitEditing={() => passwordRef.current?.focus()}
             testID="walletNameInput"
             autoComplete="off"
-            disabled={isLoading}
             showErrorOnBlur
           />
 
@@ -307,7 +307,6 @@ export const WalletDetailsScreen = () => {
             onSubmitEditing={() => passwordConfirmationRef.current?.focus()}
             testID="walletPasswordInput"
             autoComplete="off"
-            disabled={isLoading}
             showErrorOnBlur
             textContentType="oneTimeCode"
           />
@@ -325,7 +324,6 @@ export const WalletDetailsScreen = () => {
             errorText={passwordConfirmationErrorText}
             testID="walletRepeatPasswordInput"
             autoComplete="off"
-            disabled={isLoading}
             showErrorOnBlur
             textContentType="oneTimeCode"
           />

--- a/apps/wallet-mobile/src/features/SetupWallet/useCases/RestoreWallet/RestoreWalletDetailsScreen.tsx
+++ b/apps/wallet-mobile/src/features/SetupWallet/useCases/RestoreWallet/RestoreWalletDetailsScreen.tsx
@@ -85,13 +85,6 @@ export const RestoreWalletDetailsScreen = () => {
   )
   const passwordErrors = validatePassword(password, passwordConfirmation)
 
-  const passwordErrorText = passwordErrors.passwordIsWeak
-    ? strings.passwordStrengthRequirement({requiredPasswordLength: REQUIRED_PASSWORD_LENGTH})
-    : undefined
-  const passwordConfirmationErrorText = passwordErrors.matchesConfirmation
-    ? strings.repeatPasswordInputError
-    : undefined
-
   const intl = useIntl()
   const {
     createWallet,
@@ -122,6 +115,13 @@ export const RestoreWalletDetailsScreen = () => {
     },
   })
 
+  const passwordErrorText =
+    passwordErrors.passwordIsWeak && !isLoading
+      ? strings.passwordStrengthRequirement({requiredPasswordLength: REQUIRED_PASSWORD_LENGTH})
+      : undefined
+  const passwordConfirmationErrorText =
+    passwordErrors.matchesConfirmation && !isLoading ? strings.repeatPasswordInputError : undefined
+
   useFocusEffect(
     React.useCallback(() => {
       track.restoreWalletDetailsStepViewed()
@@ -137,7 +137,7 @@ export const RestoreWalletDetailsScreen = () => {
   const showModalTipsPassword = () => {
     openModal(
       strings.walletDetailsModalTitle,
-      <View style={styles.modal}>
+      <View style={styles.flex}>
         <ScrollView bounces={false}>
           <View>
             <CardAboutPhrase
@@ -175,7 +175,7 @@ export const RestoreWalletDetailsScreen = () => {
   const showModalTipsPlateNumber = () => {
     openModal(
       strings.walletDetailsModalTitle,
-      <View style={styles.modal}>
+      <View style={styles.flex}>
         <ScrollView bounces={false}>
           <View>
             <CardAboutPhrase
@@ -210,14 +210,9 @@ export const RestoreWalletDetailsScreen = () => {
   }
 
   return (
-    <SafeAreaView edges={['left', 'right', 'bottom']} style={styles.root}>
-      <KeyboardAvoidingView style={{flex: 1}}>
-        <StepperProgress
-          style={styles.steps}
-          currentStep={2}
-          currentStepTitle={strings.stepWalletDetails}
-          totalSteps={2}
-        />
+    <SafeAreaView edges={['left', 'right', 'bottom']} style={[styles.root, styles.flex]}>
+      <KeyboardAvoidingView style={styles.flex}>
+        <StepperProgress currentStep={2} currentStepTitle={strings.stepWalletDetails} totalSteps={2} />
 
         <View style={styles.info}>
           <Text style={styles.title}>{strings.walletDetailsTitle(bold)}</Text>
@@ -227,20 +222,19 @@ export const RestoreWalletDetailsScreen = () => {
 
         <Space height="xl" />
 
-        <ScrollView style={styles.form}>
+        <ScrollView style={styles.flex}>
           <TextInput
             enablesReturnKeyAutomatically
             autoFocus
             label={strings.walletDetailsNameInput}
             value={name}
             onChangeText={(walletName: string) => setName(walletName)}
-            errorText={!isEmptyString(walletNameErrorText) ? walletNameErrorText : undefined}
+            errorText={!isEmptyString(walletNameErrorText) && !isLoading ? walletNameErrorText : undefined}
             errorDelay={0}
             returnKeyType="next"
             onSubmitEditing={() => passwordRef.current?.focus()}
             testID="walletNameInput"
             autoComplete="off"
-            disabled={isLoading}
             showErrorOnBlur
           />
 
@@ -259,7 +253,6 @@ export const RestoreWalletDetailsScreen = () => {
             onSubmitEditing={() => passwordConfirmationRef.current?.focus()}
             testID="walletPasswordInput"
             autoComplete="off"
-            disabled={isLoading}
             showErrorOnBlur
             textContentType="oneTimeCode"
           />
@@ -277,7 +270,6 @@ export const RestoreWalletDetailsScreen = () => {
             errorText={passwordConfirmationErrorText}
             testID="walletRepeatPasswordInput"
             autoComplete="off"
-            disabled={isLoading}
             textContentType="oneTimeCode"
           />
 
@@ -345,24 +337,15 @@ const useBold = () => {
 const useStyles = () => {
   const {color, atoms} = useTheme()
   const styles = StyleSheet.create({
-    form: {
-      ...atoms.px_lg,
-      flex: 1,
-    },
-    steps: {
-      ...atoms.px_lg,
+    flex: {
+      ...atoms.flex_1,
     },
     root: {
-      flex: 1,
       justifyContent: 'space-between',
       backgroundColor: color.bg_color_high,
-    },
-    modal: {
-      flex: 1,
       ...atoms.px_lg,
     },
     info: {
-      ...atoms.px_lg,
       flexDirection: 'row',
     },
     title: {
@@ -393,7 +376,7 @@ const useStyles = () => {
       height: 24,
     },
     actions: {
-      ...atoms.p_lg,
+      ...atoms.pt_lg,
     },
   })
 

--- a/apps/wallet-mobile/translations/messages/src/components/ErrorModal/ErrorModal.json
+++ b/apps/wallet-mobile/translations/messages/src/components/ErrorModal/ErrorModal.json
@@ -6,12 +6,12 @@
     "start": {
       "line": 152,
       "column": 13,
-      "index": 4230
+      "index": 4222
     },
     "end": {
       "line": 155,
       "column": 3,
-      "index": 4330
+      "index": 4322
     }
   },
   {
@@ -21,12 +21,12 @@
     "start": {
       "line": 156,
       "column": 13,
-      "index": 4345
+      "index": 4337
     },
     "end": {
       "line": 159,
       "column": 3,
-      "index": 4445
+      "index": 4437
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/features/SetupWallet/legacy/ImportReadOnlyWallet/ImportReadOnlyWalletScreen.json
+++ b/apps/wallet-mobile/translations/messages/src/features/SetupWallet/legacy/ImportReadOnlyWallet/ImportReadOnlyWalletScreen.json
@@ -4,14 +4,14 @@
     "defaultMessage": "!!!To import a read-only wallet from the Yoroi extension, you will need to:",
     "file": "src/features/SetupWallet/legacy/ImportReadOnlyWallet/ImportReadOnlyWalletScreen.tsx",
     "start": {
-      "line": 63,
+      "line": 61,
       "column": 13,
-      "index": 2159
+      "index": 2090
     },
     "end": {
-      "line": 66,
+      "line": 64,
       "column": 3,
-      "index": 2333
+      "index": 2264
     }
   },
   {
@@ -19,14 +19,14 @@
     "defaultMessage": "!!!Open \"My wallets\" page in the Yoroi extension.",
     "file": "src/features/SetupWallet/legacy/ImportReadOnlyWallet/ImportReadOnlyWalletScreen.tsx",
     "start": {
-      "line": 67,
+      "line": 65,
       "column": 9,
-      "index": 2344
+      "index": 2275
     },
     "end": {
-      "line": 70,
+      "line": 68,
       "column": 3,
-      "index": 2488
+      "index": 2419
     }
   },
   {
@@ -34,14 +34,14 @@
     "defaultMessage": "!!!Look for the {buttonType} for the wallet you want to import in the mobile app.",
     "file": "src/features/SetupWallet/legacy/ImportReadOnlyWallet/ImportReadOnlyWalletScreen.tsx",
     "start": {
-      "line": 71,
+      "line": 69,
       "column": 9,
-      "index": 2499
+      "index": 2430
     },
     "end": {
-      "line": 74,
+      "line": 72,
       "column": 3,
-      "index": 2675
+      "index": 2606
     }
   },
   {
@@ -49,14 +49,14 @@
     "defaultMessage": "!!!export read-only wallet button",
     "file": "src/features/SetupWallet/legacy/ImportReadOnlyWallet/ImportReadOnlyWalletScreen.tsx",
     "start": {
-      "line": 75,
+      "line": 73,
       "column": 14,
-      "index": 2691
+      "index": 2622
     },
     "end": {
-      "line": 78,
+      "line": 76,
       "column": 3,
-      "index": 2824
+      "index": 2755
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/features/SetupWallet/legacy/SaveNanoX/SaveNanoXScreen.json
+++ b/apps/wallet-mobile/translations/messages/src/features/SetupWallet/legacy/SaveNanoX/SaveNanoXScreen.json
@@ -4,14 +4,14 @@
     "defaultMessage": "!!!My Ledger Wallet",
     "file": "src/features/SetupWallet/legacy/SaveNanoX/SaveNanoXScreen.tsx",
     "start": {
-      "line": 78,
+      "line": 95,
       "column": 30,
-      "index": 2484
+      "index": 3191
     },
     "end": {
-      "line": 81,
+      "line": 98,
       "column": 3,
-      "index": 2621
+      "index": 3328
     }
   }
 ]

--- a/apps/wallet-mobile/translations/messages/src/features/SetupWallet/legacy/SaveReadOnlyWallet/SaveReadOnlyWalletScreen.json
+++ b/apps/wallet-mobile/translations/messages/src/features/SetupWallet/legacy/SaveReadOnlyWallet/SaveReadOnlyWalletScreen.json
@@ -4,14 +4,14 @@
     "defaultMessage": "!!!My read-only wallet",
     "file": "src/features/SetupWallet/legacy/SaveReadOnlyWallet/SaveReadOnlyWalletScreen.tsx",
     "start": {
-      "line": 138,
+      "line": 154,
       "column": 21,
-      "index": 4081
+      "index": 4787
     },
     "end": {
-      "line": 141,
+      "line": 157,
       "column": 3,
-      "index": 4208
+      "index": 4914
     }
   },
   {
@@ -19,14 +19,14 @@
     "defaultMessage": "!!!Checksum label",
     "file": "src/features/SetupWallet/legacy/SaveReadOnlyWallet/SaveReadOnlyWalletScreen.tsx",
     "start": {
-      "line": 142,
+      "line": 158,
       "column": 17,
-      "index": 4227
+      "index": 4933
     },
     "end": {
-      "line": 145,
+      "line": 161,
       "column": 3,
-      "index": 4341
+      "index": 5047
     }
   },
   {
@@ -34,14 +34,14 @@
     "defaultMessage": "!!!Wallet Address(es):",
     "file": "src/features/SetupWallet/legacy/SaveReadOnlyWallet/SaveReadOnlyWalletScreen.tsx",
     "start": {
-      "line": 146,
+      "line": 162,
       "column": 22,
-      "index": 4365
+      "index": 5071
     },
     "end": {
-      "line": 149,
+      "line": 165,
       "column": 3,
-      "index": 4489
+      "index": 5195
     }
   },
   {
@@ -49,14 +49,14 @@
     "defaultMessage": "!!!Key:",
     "file": "src/features/SetupWallet/legacy/SaveReadOnlyWallet/SaveReadOnlyWalletScreen.tsx",
     "start": {
-      "line": 150,
+      "line": 166,
       "column": 7,
-      "index": 4498
+      "index": 5204
     },
     "end": {
-      "line": 153,
+      "line": 169,
       "column": 3,
-      "index": 4596
+      "index": 5302
     }
   },
   {
@@ -64,14 +64,14 @@
     "defaultMessage": "!!!Derivation path:",
     "file": "src/features/SetupWallet/legacy/SaveReadOnlyWallet/SaveReadOnlyWalletScreen.tsx",
     "start": {
-      "line": 154,
+      "line": 170,
       "column": 18,
-      "index": 4616
+      "index": 5322
     },
     "end": {
-      "line": 157,
+      "line": 173,
       "column": 3,
-      "index": 4737
+      "index": 5443
     }
   }
 ]


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

- `react-native-paper` disabled + outlined just don't work great together, tried even the new version still bad, it needs to be dropped
- Basically the app can't have disabled inputs on dark mode, unless it moves away from rnp. 
- Normalized to create/restore to move to preparing wallet always

##### Ticket

YOMO-1738

> [!NOTE]
> Please create the ticket if missing it.
