### PR TITLE
fix(wallet-mobile): expo-img resizeMode is deprecated

### DIFF
--- a/apps/wallet-mobile/src/features/Discover/useCases/SelectDappFromList/DAppListItem/DAppListItem.tsx
+++ b/apps/wallet-mobile/src/features/Discover/useCases/SelectDappFromList/DAppListItem/DAppListItem.tsx
@@ -203,7 +203,7 @@ const useStyles = () => {
     dAppLogo: {
       width: 40,
       height: 40,
-      resizeMode: 'contain',
+      contentFit: 'contain',
     },
     dAppLogoDialog: {
       width: 48,

--- a/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokenDetails/PortfolioTokenInfo/Overview/Overview.tsx
+++ b/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokenDetails/PortfolioTokenInfo/Overview/Overview.tsx
@@ -147,7 +147,6 @@ const useStyles = () => {
     tokenLogo: {
       width: 32,
       height: 32,
-      resizeMode: 'cover',
       ...atoms.rounded_sm,
     },
     textBody: {

--- a/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokenDetails/PortfolioTokenInfo/PortfolioTokenInfo.tsx
+++ b/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokenDetails/PortfolioTokenInfo/PortfolioTokenInfo.tsx
@@ -4,7 +4,7 @@ import {StyleSheet, View} from 'react-native'
 
 import {TabPanel, TabPanels} from '../../../../../components/Tabs'
 import {usePortfolioTokenDetailContext} from '../../../common/PortfolioTokenDetailContext'
-import {Overview} from './Overview'
+import {Overview} from './Overview/Overview'
 import {Performance} from './Performance'
 
 export const PortfolioTokenInfo = () => {


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

- `expo-image` has deprecated `resizeMode` in favour of `contentFit`

> [!NOTE]
> Please create the ticket if missing it.
