### PR TITLE
fix(wallet-mobile): Make caret color white for dark theme in staking center webview

### DIFF
--- a/apps/wallet-mobile/src/legacy/Staking/StakingCenter/StakingCenter.tsx
+++ b/apps/wallet-mobile/src/legacy/Staking/StakingCenter/StakingCenter.tsx
@@ -92,6 +92,7 @@ export const StakingCenter = () => {
               injectedJavaScript: `
               document.body.style.backgroundColor = "#222"
               document.body.style.filter = "invert(0.9) hue-rotate(180deg)"
+              document.body.style.caretColor = "#FFFFFF"
               setTimeout(() => 
                 [...document.images].forEach(i => i.style = 'filter:invert(1) hue-rotate(180deg)')
               , 1000)

--- a/apps/wallet-mobile/translations/messages/src/legacy/Staking/StakingCenter/StakingCenter.json
+++ b/apps/wallet-mobile/translations/messages/src/legacy/Staking/StakingCenter/StakingCenter.json
@@ -4,14 +4,14 @@
     "defaultMessage": "!!!Invalid Pool Data",
     "file": "src/legacy/Staking/StakingCenter/StakingCenter.tsx",
     "start": {
-      "line": 125,
+      "line": 126,
       "column": 9,
-      "index": 4351
+      "index": 4408
     },
     "end": {
-      "line": 128,
+      "line": 129,
       "column": 3,
-      "index": 4459
+      "index": 4516
     }
   },
   {
@@ -19,14 +19,14 @@
     "defaultMessage": "!!!The data from the stake pool(s) you selected is invalid. Please try again",
     "file": "src/legacy/Staking/StakingCenter/StakingCenter.tsx",
     "start": {
-      "line": 129,
+      "line": 130,
       "column": 11,
-      "index": 4472
+      "index": 4529
     },
     "end": {
-      "line": 132,
+      "line": 133,
       "column": 3,
-      "index": 4638
+      "index": 4695
     }
   }
 ]


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)
Make caret color white for dark theme in staking center webview

##### Ticket

[YOMO-1799](https://emurgo.atlassian.net/browse/YOMO-1799)



[YOMO-1799]: https://emurgo.atlassian.net/browse/YOMO-1799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ