### PR TITLE
fix(wallet-mobile): Reduce NetworkTag size to avoid misalignment on tx history

### DIFF
--- a/apps/wallet-mobile/src/features/Settings/ChangeNetwork/NetworkTag.tsx
+++ b/apps/wallet-mobile/src/features/Settings/ChangeNetwork/NetworkTag.tsx
@@ -83,14 +83,12 @@ export const NetworkTag = ({
       </Text>
 
       {Tag && (
-        <>
-          <Space width="sm" />
-
+        <View style={styles.tagContainer}>
           <Tag
             onPress={onPress}
             disabled={((directChangeActive && selectedNetwork === Chain.Network.Mainnet) || disabled) ?? false}
           />
-        </>
+        </View>
       )}
     </View>
   )
@@ -141,18 +139,23 @@ const MainnetWarningDialog = ({onCancel, onOk}: {onCancel: () => void; onOk: () 
 
 const useStyles = () => {
   const {color, atoms} = useTheme()
-  const width = useWindowDimensions().width - 140
+  const width = useWindowDimensions().width - 190
 
   const styles = StyleSheet.create({
     headerTitleStyle: {
       ...atoms.body_1_lg_medium,
       color: color.text_gray_normal,
+      flexShrink: 1,
     },
     headerTitleContainerStyle: {
       flexDirection: 'row',
       alignItems: 'center',
       justifyContent: 'center',
       width,
+    },
+    tagContainer: {
+      ...atoms.pl_sm,
+      flexShrink: 0,
     },
     preprodTag: {
       borderRadius: 1200,

--- a/apps/wallet-mobile/src/features/Transactions/TxHistoryNavigator.tsx
+++ b/apps/wallet-mobile/src/features/Transactions/TxHistoryNavigator.tsx
@@ -161,8 +161,6 @@ export const TxHistoryNavigator = () => {
                       title: meta.name,
                       headerTransparent: true,
                       headerRight: headerRightHistory,
-                      // marginRight override to compensate for the headerRight
-                      headerTitle: ({children}) => <NetworkTag style={{marginRight: 40}}>{children}</NetworkTag>,
                     }}
                   />
 

--- a/apps/wallet-mobile/translations/messages/src/features/Transactions/TxHistoryNavigator.json
+++ b/apps/wallet-mobile/translations/messages/src/features/Transactions/TxHistoryNavigator.json
@@ -4,14 +4,14 @@
     "defaultMessage": "!!!Receive",
     "file": "src/features/Transactions/TxHistoryNavigator.tsx",
     "start": {
-      "line": 449,
+      "line": 447,
       "column": 16,
-      "index": 17529
+      "index": 17335
     },
     "end": {
-      "line": 452,
+      "line": 450,
       "column": 3,
-      "index": 17618
+      "index": 17424
     }
   },
   {
@@ -19,14 +19,14 @@
     "defaultMessage": "!!!Address details",
     "file": "src/features/Transactions/TxHistoryNavigator.tsx",
     "start": {
-      "line": 453,
+      "line": 451,
       "column": 32,
-      "index": 17652
+      "index": 17458
     },
     "end": {
-      "line": 456,
+      "line": 454,
       "column": 3,
-      "index": 17765
+      "index": 17571
     }
   },
   {
@@ -34,14 +34,14 @@
     "defaultMessage": "!!!Swap",
     "file": "src/features/Transactions/TxHistoryNavigator.tsx",
     "start": {
-      "line": 457,
+      "line": 455,
       "column": 13,
-      "index": 17780
+      "index": 17586
     },
     "end": {
-      "line": 460,
+      "line": 458,
       "column": 3,
-      "index": 17853
+      "index": 17659
     }
   },
   {
@@ -49,14 +49,14 @@
     "defaultMessage": "!!!Swap from",
     "file": "src/features/Transactions/TxHistoryNavigator.tsx",
     "start": {
-      "line": 461,
+      "line": 459,
       "column": 17,
-      "index": 17872
+      "index": 17678
     },
     "end": {
-      "line": 464,
+      "line": 462,
       "column": 3,
-      "index": 17949
+      "index": 17755
     }
   },
   {
@@ -64,14 +64,14 @@
     "defaultMessage": "!!!Swap to",
     "file": "src/features/Transactions/TxHistoryNavigator.tsx",
     "start": {
-      "line": 465,
+      "line": 463,
       "column": 15,
-      "index": 17966
+      "index": 17772
     },
     "end": {
-      "line": 468,
+      "line": 466,
       "column": 3,
-      "index": 18039
+      "index": 17845
     }
   },
   {
@@ -79,14 +79,14 @@
     "defaultMessage": "!!!Slippage Tolerance",
     "file": "src/features/Transactions/TxHistoryNavigator.tsx",
     "start": {
-      "line": 469,
+      "line": 467,
       "column": 21,
-      "index": 18062
+      "index": 17868
     },
     "end": {
-      "line": 472,
+      "line": 470,
       "column": 3,
-      "index": 18157
+      "index": 17963
     }
   },
   {
@@ -94,14 +94,14 @@
     "defaultMessage": "!!!Select pool",
     "file": "src/features/Transactions/TxHistoryNavigator.tsx",
     "start": {
-      "line": 473,
+      "line": 471,
       "column": 14,
-      "index": 18173
+      "index": 17979
     },
     "end": {
-      "line": 476,
+      "line": 474,
       "column": 3,
-      "index": 18254
+      "index": 18060
     }
   },
   {
@@ -109,14 +109,14 @@
     "defaultMessage": "!!!Send",
     "file": "src/features/Transactions/TxHistoryNavigator.tsx",
     "start": {
-      "line": 477,
+      "line": 475,
       "column": 13,
-      "index": 18269
+      "index": 18075
     },
     "end": {
-      "line": 480,
+      "line": 478,
       "column": 3,
-      "index": 18349
+      "index": 18155
     }
   },
   {
@@ -124,14 +124,14 @@
     "defaultMessage": "!!!Scan QR code address",
     "file": "src/features/Transactions/TxHistoryNavigator.tsx",
     "start": {
-      "line": 481,
+      "line": 479,
       "column": 18,
-      "index": 18369
+      "index": 18175
     },
     "end": {
-      "line": 484,
+      "line": 482,
       "column": 3,
-      "index": 18470
+      "index": 18276
     }
   },
   {
@@ -139,14 +139,14 @@
     "defaultMessage": "!!!Select asset",
     "file": "src/features/Transactions/TxHistoryNavigator.tsx",
     "start": {
-      "line": 485,
+      "line": 483,
       "column": 20,
-      "index": 18492
+      "index": 18298
     },
     "end": {
-      "line": 488,
+      "line": 486,
       "column": 3,
-      "index": 18581
+      "index": 18387
     }
   },
   {
@@ -154,14 +154,14 @@
     "defaultMessage": "!!!Assets added",
     "file": "src/features/Transactions/TxHistoryNavigator.tsx",
     "start": {
-      "line": 489,
+      "line": 487,
       "column": 26,
-      "index": 18609
+      "index": 18415
     },
     "end": {
-      "line": 492,
+      "line": 490,
       "column": 3,
-      "index": 18710
+      "index": 18516
     }
   },
   {
@@ -169,14 +169,14 @@
     "defaultMessage": "!!!Edit amount",
     "file": "src/features/Transactions/TxHistoryNavigator.tsx",
     "start": {
-      "line": 493,
+      "line": 491,
       "column": 19,
-      "index": 18731
+      "index": 18537
     },
     "end": {
-      "line": 496,
+      "line": 494,
       "column": 3,
-      "index": 18824
+      "index": 18630
     }
   },
   {
@@ -184,14 +184,14 @@
     "defaultMessage": "!!!Confirm",
     "file": "src/features/Transactions/TxHistoryNavigator.tsx",
     "start": {
-      "line": 497,
+      "line": 495,
       "column": 16,
-      "index": 18842
+      "index": 18648
     },
     "end": {
-      "line": 500,
+      "line": 498,
       "column": 3,
-      "index": 18928
+      "index": 18734
     }
   },
   {
@@ -199,14 +199,14 @@
     "defaultMessage": "!!!Share this address to receive payments. To protect your privacy, new addresses are generated automatically once you use them.",
     "file": "src/features/Transactions/TxHistoryNavigator.tsx",
     "start": {
-      "line": 501,
+      "line": 499,
       "column": 19,
-      "index": 18949
+      "index": 18755
     },
     "end": {
-      "line": 507,
+      "line": 505,
       "column": 3,
-      "index": 19187
+      "index": 18993
     }
   },
   {
@@ -214,14 +214,14 @@
     "defaultMessage": "!!!Confirm transaction",
     "file": "src/features/Transactions/TxHistoryNavigator.tsx",
     "start": {
-      "line": 508,
+      "line": 506,
       "column": 27,
-      "index": 19216
+      "index": 19022
     },
     "end": {
-      "line": 511,
+      "line": 509,
       "column": 3,
-      "index": 19309
+      "index": 19115
     }
   },
   {
@@ -229,14 +229,14 @@
     "defaultMessage": "!!!Please scan a QR code",
     "file": "src/features/Transactions/TxHistoryNavigator.tsx",
     "start": {
-      "line": 512,
+      "line": 510,
       "column": 13,
-      "index": 19324
+      "index": 19130
     },
     "end": {
-      "line": 515,
+      "line": 513,
       "column": 3,
-      "index": 19399
+      "index": 19205
     }
   },
   {
@@ -244,14 +244,14 @@
     "defaultMessage": "!!!Success",
     "file": "src/features/Transactions/TxHistoryNavigator.tsx",
     "start": {
-      "line": 516,
+      "line": 514,
       "column": 25,
-      "index": 19426
+      "index": 19232
     },
     "end": {
-      "line": 519,
+      "line": 517,
       "column": 3,
-      "index": 19500
+      "index": 19306
     }
   },
   {
@@ -259,14 +259,14 @@
     "defaultMessage": "!!!Request specific amount",
     "file": "src/features/Transactions/TxHistoryNavigator.tsx",
     "start": {
-      "line": 520,
+      "line": 518,
       "column": 18,
-      "index": 19520
+      "index": 19326
     },
     "end": {
-      "line": 523,
+      "line": 521,
       "column": 3,
-      "index": 19634
+      "index": 19440
     }
   },
   {
@@ -274,14 +274,14 @@
     "defaultMessage": "!!!Buy/Sell ADA",
     "file": "src/features/Transactions/TxHistoryNavigator.tsx",
     "start": {
-      "line": 524,
+      "line": 522,
       "column": 28,
-      "index": 19664
+      "index": 19470
     },
     "end": {
-      "line": 527,
+      "line": 525,
       "column": 3,
-      "index": 19760
+      "index": 19566
     }
   },
   {
@@ -289,14 +289,14 @@
     "defaultMessage": "!!!Buy provider",
     "file": "src/features/Transactions/TxHistoryNavigator.tsx",
     "start": {
-      "line": 528,
+      "line": 526,
       "column": 29,
-      "index": 19791
+      "index": 19597
     },
     "end": {
-      "line": 531,
+      "line": 529,
       "column": 3,
-      "index": 19899
+      "index": 19705
     }
   },
   {
@@ -304,14 +304,14 @@
     "defaultMessage": "!!!Sell provider",
     "file": "src/features/Transactions/TxHistoryNavigator.tsx",
     "start": {
-      "line": 532,
+      "line": 530,
       "column": 30,
-      "index": 19931
+      "index": 19737
     },
     "end": {
-      "line": 535,
+      "line": 533,
       "column": 3,
-      "index": 20041
+      "index": 19847
     }
   },
   {
@@ -319,14 +319,14 @@
     "defaultMessage": "!!!Tx Details",
     "file": "src/features/Transactions/TxHistoryNavigator.tsx",
     "start": {
-      "line": 536,
+      "line": 534,
       "column": 18,
-      "index": 20061
+      "index": 19867
     },
     "end": {
-      "line": 539,
+      "line": 537,
       "column": 3,
-      "index": 20155
+      "index": 19961
     }
   }
 ]


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

Compromise fix to avoid aligning differently in tx history than the other screens.
[Screencast_20240808_120647.webm](https://github.com/user-attachments/assets/06350758-1038-4646-81e0-92ad06dca9e6)

##### Ticket

[YOMO-1822](https://emurgo.atlassian.net/browse/YOMO-1822)


[YOMO-1822]: https://emurgo.atlassian.net/browse/YOMO-1822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ