### PR TITLE
fix(wallet-mobile): Network tag size edge case

### DIFF
--- a/apps/wallet-mobile/src/features/Settings/ChangeNetwork/NetworkTag.tsx
+++ b/apps/wallet-mobile/src/features/Settings/ChangeNetwork/NetworkTag.tsx
@@ -145,6 +145,7 @@ const useStyles = () => {
     headerTitleStyle: {
       ...atoms.body_1_lg_medium,
       color: color.text_gray_normal,
+      flexShrink: 1,
     },
     headerTitleContainerStyle: {
       flexDirection: 'row',
@@ -164,7 +165,7 @@ const useStyles = () => {
     },
     sanchonetLabel: {
       borderRadius: 1200,
-      backgroundColor: '#66F2D6',
+      backgroundColor: color.el_secondary_medium,
       ...atoms.px_sm,
       ...atoms.py_xs,
     },


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

Seems like the flex shrink is necessary when the text doesn't contain spaces to not get out of it's own space.

##### Ticket

[YOMO-1837](https://emurgo.atlassian.net/browse/YOMO-1837)

![image](https://github.com/user-attachments/assets/28b4da40-1863-4bc1-baf8-30ab8ce7ae20)



[YOMO-1837]: https://emurgo.atlassian.net/browse/YOMO-1837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ