### PR TITLE
refactor(catalyst): split the generation of voting tx and voting key

### DIFF
--- a/apps/wallet-mobile/src/features/RegisterCatalyst/useCases/ConfirmVotingTx/ConfirmVotingTx.tsx
+++ b/apps/wallet-mobile/src/features/RegisterCatalyst/useCases/ConfirmVotingTx/ConfirmVotingTx.tsx
@@ -23,7 +23,7 @@ export const ConfirmVotingTx = () => {
   const styles = useStyles()
   const strings = useStrings()
   const {openModal, closeModal} = useModal()
-  const {votingKeyEncryptedChanged, pin} = useCatalyst()
+  const {catalystKeyHex, pin} = useCatalyst()
   const navigateTo = useNavigateTo()
 
   const onNext = () => {
@@ -31,12 +31,10 @@ export const ConfirmVotingTx = () => {
   }
 
   if (pin === null) throw new Error('pin cannot be null')
+  if (catalystKeyHex === null) throw new Error('catalystKeyHex cannot be null')
 
   const {wallet, meta} = useSelectedWallet()
-  const votingRegTx = useVotingRegTx(
-    {wallet, pin, supportsCIP36, addressMode: meta.addressMode},
-    {onSuccess: ({votingKeyEncrypted}) => votingKeyEncryptedChanged(votingKeyEncrypted)},
-  )
+  const votingRegTx = useVotingRegTx({wallet, supportsCIP36, catalystKeyHex, addressMode: meta.addressMode})
 
   const [useUSB, setUseUSB] = useState(false)
 

--- a/apps/wallet-mobile/src/yoroi-wallets/cardano/types.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/cardano/types.ts
@@ -120,10 +120,10 @@ export interface YoroiWallet {
 
   // Voting
   createVotingRegTx(params: {
-    pin: string
     supportsCIP36: boolean
     addressMode: Wallet.AddressMode
-  }): Promise<{votingRegTx: YoroiUnsignedTx; votingKeyEncrypted: string}>
+    catalystKeyHex: string
+  }): Promise<{votingRegTx: YoroiUnsignedTx}>
   fetchFundInfo(): Promise<FundInfoResponse>
 
   // Staking

--- a/apps/wallet-mobile/src/yoroi-wallets/hooks/index.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/hooks/index.ts
@@ -277,21 +277,20 @@ export const useWithdrawalTx = (
 
 export type VotingRegTxAndEncryptedKey = {
   votingRegTx: YoroiUnsignedTx
-  votingKeyEncrypted: string
 }
 
 export const useVotingRegTx = (
   {
     wallet,
-    pin,
+    catalystKeyHex,
     supportsCIP36,
     addressMode,
-  }: {wallet: YoroiWallet; pin: string; supportsCIP36: boolean; addressMode: Wallet.AddressMode},
+  }: {wallet: YoroiWallet; catalystKeyHex: string; supportsCIP36: boolean; addressMode: Wallet.AddressMode},
   options?: UseQueryOptions<
     VotingRegTxAndEncryptedKey,
     Error,
     VotingRegTxAndEncryptedKey,
-    [string, 'voting-reg-tx', string]
+    [string, string, 'voting-reg-tx', string]
   >,
 ) => {
   const query = useQuery({
@@ -299,8 +298,8 @@ export const useVotingRegTx = (
     retry: false,
     cacheTime: 0,
     suspense: true,
-    queryKey: [wallet.id, 'voting-reg-tx', JSON.stringify({supportsCIP36})],
-    queryFn: () => wallet.createVotingRegTx({pin, supportsCIP36, addressMode}),
+    queryKey: [catalystKeyHex, wallet.id, 'voting-reg-tx', JSON.stringify({supportsCIP36})],
+    queryFn: () => wallet.createVotingRegTx({catalystKeyHex, supportsCIP36, addressMode}),
   })
 
   if (!query.data) throw new Error('invalid state')

--- a/packages/staking/src/catalyst/translators/context.tsx
+++ b/packages/staking/src/catalyst/translators/context.tsx
@@ -53,6 +53,11 @@ export function CatalystProvider({
         type: CatalystActionType.VotingKeyEncryptedChanged,
         votingKeyEncrypted,
       }),
+    catalystKeyHexChanged: (catalystKeyHex: CatalystState['catalystKeyHex']) =>
+      dispatch({
+        type: CatalystActionType.CatalystKeyHexChanged,
+        catalystKeyHex,
+      }),
     reset: () =>
       dispatch({
         type: CatalystActionType.Reset,

--- a/packages/staking/src/catalyst/translators/state.test.tsx
+++ b/packages/staking/src/catalyst/translators/state.test.tsx
@@ -29,25 +29,45 @@ describe('State Actions', () => {
   })
 
   it('VotingKeyEncryptedChanged', () => {
+    const votingKeyEncrypted = 'super-complex-voting-key'
     const action: CatalystAction = {
       type: CatalystActionType.VotingKeyEncryptedChanged,
-      votingKeyEncrypted: 'very-strong-key',
+      votingKeyEncrypted,
     }
 
     const state = catalystReducer(catalystDefaultState, action)
-    expect(state.votingKeyEncrypted).toBe('very-strong-key')
+    expect(state.votingKeyEncrypted).toBe(votingKeyEncrypted)
+  })
+
+  it('CatalystKeyHexChanged', () => {
+    const catalystKeyHex = 'super-complex-hex'
+    const action: CatalystAction = {
+      type: CatalystActionType.CatalystKeyHexChanged,
+      catalystKeyHex,
+    }
+
+    const state = catalystReducer(catalystDefaultState, action)
+    expect(state.catalystKeyHex).toBe(catalystKeyHex)
   })
 
   it('Reset', () => {
+    const votingKeyEncrypted = 'super-complex-voting-key'
+    const catalystKeyHex = 'super-complex-catalyst-key'
     const action: CatalystAction = {
       type: CatalystActionType.Reset,
     }
 
     const state = catalystReducer(
-      {...catalystDefaultState, pin: '1234', votingKeyEncrypted: 'qwert'},
+      {
+        ...catalystDefaultState,
+        pin: '1234',
+        votingKeyEncrypted,
+        catalystKeyHex,
+      },
       action,
     )
     expect(state.pin).toBe(null)
     expect(state.votingKeyEncrypted).toBe(null)
+    expect(state.catalystKeyHex).toBe(null)
   })
 })

--- a/packages/staking/src/catalyst/translators/state.tsx
+++ b/packages/staking/src/catalyst/translators/state.tsx
@@ -14,9 +14,14 @@ export const catalystReducer = (
         draft.votingKeyEncrypted = action.votingKeyEncrypted
         break
 
+      case CatalystActionType.CatalystKeyHexChanged:
+        draft.catalystKeyHex = action.catalystKeyHex
+        break
+
       case CatalystActionType.Reset:
         draft.pin = catalystDefaultState.pin
         draft.votingKeyEncrypted = catalystDefaultState.votingKeyEncrypted
+        draft.catalystKeyHex = catalystDefaultState.catalystKeyHex
         break
 
       default:
@@ -29,6 +34,7 @@ export const catalystDefaultState: Readonly<CatalystState> = freeze(
   {
     pin: null,
     votingKeyEncrypted: null,
+    catalystKeyHex: null,
   },
   true,
 )
@@ -36,6 +42,7 @@ export const catalystDefaultState: Readonly<CatalystState> = freeze(
 export type CatalystState = {
   pin: string | null
   votingKeyEncrypted: string | null
+  catalystKeyHex: string | null
 }
 
 export type CatalystAction =
@@ -45,12 +52,17 @@ export type CatalystAction =
       votingKeyEncrypted: CatalystState['votingKeyEncrypted']
     }
   | {
+      type: CatalystActionType.CatalystKeyHexChanged
+      catalystKeyHex: CatalystState['catalystKeyHex']
+    }
+  | {
       type: CatalystActionType.Reset
     }
 
 export enum CatalystActionType {
   PinChanged = 'pinChanged',
   VotingKeyEncryptedChanged = 'votingKeyEncryptedChanged',
+  CatalystKeyHexChanged = 'catalystKeyHexChanged',
   Reset = 'reset',
 }
 
@@ -58,6 +70,9 @@ export type CatalystActions = {
   pinChanged: (type: CatalystState['pin']) => void
   votingKeyEncryptedChanged: (
     votingKeyEncrypted: CatalystState['votingKeyEncrypted'],
+  ) => void
+  catalystKeyHexChanged: (
+    catalystKeyHex: CatalystState['catalystKeyHex'],
   ) => void
   reset: () => void
 }
@@ -67,6 +82,7 @@ export const initialCatalystContext: CatalystState & CatalystActions = freeze(
     ...catalystDefaultState,
     pinChanged: missingInit,
     votingKeyEncryptedChanged: missingInit,
+    catalystKeyHexChanged: missingInit,
     reset: missingInit,
   },
   true,


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

The generation of the voting tx and the generation of the keys are separated in order to:

1) be able to use a common tx review more easily with the rest of the components
2) be able to implement the catalyst funnel following the specifications: put the tx review on the last screen

##### Ticket

YOMO-1874
