### PR TITLE
fix(wallet-mobile): Normalise primary token id when parsing orders

### DIFF
--- a/apps/wallet-mobile/src/features/Swap/common/helpers.ts
+++ b/apps/wallet-mobile/src/features/Swap/common/helpers.ts
@@ -2,6 +2,7 @@ import {createTypeGuardFromSchema, parseSafe} from '@yoroi/common'
 import {useTheme} from '@yoroi/theme'
 import {Balance} from '@yoroi/types'
 import {SwapApi} from '@yoroi/types/src/swap/api'
+import {freeze} from 'immer'
 import {useMutation, UseMutationOptions} from 'react-query'
 import {z} from 'zod'
 
@@ -11,7 +12,6 @@ import {generateCIP30UtxoCbor} from '../../../yoroi-wallets/cardano/utils'
 import {useSelectedWallet} from '../../WalletManager/Context/SelectedWalletContext'
 import {PRICE_IMPACT_HIGH_RISK, PRICE_IMPACT_MODERATE_RISK} from './constants'
 import {SwapPriceImpactRisk} from './types'
-import {freeze} from 'immer'
 
 export const useCancelOrderWithHw = (
   {cancelOrder}: {cancelOrder: SwapApi['cancelOrder']},

--- a/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/ListOrders/CompletedOrders.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/StartSwapScreen/ListOrders/CompletedOrders.tsx
@@ -52,7 +52,7 @@ const compareByDate = (a: MappedRawOrder, b: MappedRawOrder) => {
   return new Date(b.date).getTime() - new Date(a.date).getTime()
 }
 
-const findCompletedOrderTx = (transactions: TransactionInfo[]): MappedRawOrder[] => {
+const findCompletedOrderTx = (transactions: TransactionInfo[], primaryTokenId: string): MappedRawOrder[] => {
   const sentTransactions = transactions.filter((tx) => tx.direction === 'SENT')
   const receivedTransactions = transactions.filter((tx) => tx.direction === 'RECEIVED')
 
@@ -67,7 +67,7 @@ const findCompletedOrderTx = (transactions: TransactionInfo[]): MappedRawOrder[]
           if (Boolean(input.id) && input?.id?.slice(0, -1) === sentTx?.id && receivedTx.inputs.length > 1) {
             result['id'] = sentTx?.id
             result['date'] = receivedTx?.lastUpdatedAt
-            const metadata = parseOrderTxMetadata(sentTx?.metadata?.['674'])
+            const metadata = parseOrderTxMetadata(sentTx?.metadata?.['674'], primaryTokenId)
             if (metadata) {
               result['metadata'] = metadata
               return acc.push(result as MappedRawOrder)
@@ -114,7 +114,7 @@ export const CompletedOrders = () => {
   }, [])
 
   const transactionsInfos = useTransactionInfos(wallet)
-  const completeOrders = findCompletedOrderTx(Object.values(transactionsInfos))
+  const completeOrders = findCompletedOrderTx(Object.values(transactionsInfos), wallet.primaryTokenInfo.id)
   const tokenIds = React.useMemo(
     () => _.uniq(completeOrders?.flatMap((o) => [o.metadata.sellTokenId, o.metadata.buyTokenId])),
     [completeOrders],


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

Normalise primary token id when parsing orders. This should not affect any existing users, only users who used Yoroi v5.0.0 who are mostly just us developers.

##### Ticket

[YOMO-1904](https://emurgo.atlassian.net/browse/YOMO-1904)



[YOMO-1904]: https://emurgo.atlassian.net/browse/YOMO-1904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ