### PR TITLE
release(wallet-mobile): v4.28.3

### DIFF
--- a/apps/wallet-mobile/android/app/build.gradle
+++ b/apps/wallet-mobile/android/app/build.gradle
@@ -108,7 +108,7 @@ android {
         applicationId "com.emurgo"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 708
+        versionCode 709
         versionName "4.28.1"
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/apps/wallet-mobile/android/app/build.gradle
+++ b/apps/wallet-mobile/android/app/build.gradle
@@ -108,7 +108,7 @@ android {
         applicationId "com.emurgo"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 710
+        versionCode 711
         versionName "4.28.3"
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/apps/wallet-mobile/android/app/build.gradle
+++ b/apps/wallet-mobile/android/app/build.gradle
@@ -108,8 +108,8 @@ android {
         applicationId "com.emurgo"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 709
-        versionName "4.28.1"
+        versionCode 710
+        versionName "4.28.3"
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/apps/wallet-mobile/android/app/build.gradle
+++ b/apps/wallet-mobile/android/app/build.gradle
@@ -108,7 +108,7 @@ android {
         applicationId "com.emurgo"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 707
+        versionCode 708
         versionName "4.28.1"
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/apps/wallet-mobile/ios/nightly.plist
+++ b/apps/wallet-mobile/ios/nightly.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>595</string>
+	<string>596</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/apps/wallet-mobile/ios/nightly.plist
+++ b/apps/wallet-mobile/ios/nightly.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>594</string>
+	<string>595</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/apps/wallet-mobile/ios/nightly.plist
+++ b/apps/wallet-mobile/ios/nightly.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>597</string>
+	<string>598</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/apps/wallet-mobile/ios/nightly.plist
+++ b/apps/wallet-mobile/ios/nightly.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.28.1</string>
+	<string>4.28.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>596</string>
+	<string>597</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/apps/wallet-mobile/ios/yoroi.xcodeproj/project.pbxproj
+++ b/apps/wallet-mobile/ios/yoroi.xcodeproj/project.pbxproj
@@ -839,7 +839,7 @@
 				CODE_SIGN_ENTITLEMENTS = yoroi/yoroi.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 594;
+				CURRENT_PROJECT_VERSION = 595;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = F8NVT2G2L4;
 				ENABLE_BITCODE = NO;
@@ -884,7 +884,7 @@
 				CODE_SIGN_ENTITLEMENTS = yoroi/yoroi.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 594;
+				CURRENT_PROJECT_VERSION = 595;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = F8NVT2G2L4;
 				ENVFILE = "$(PODS_ROOT)/../../.env.production";
@@ -1079,7 +1079,7 @@
 				CODE_SIGN_ENTITLEMENTS = nightly.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 594;
+				CURRENT_PROJECT_VERSION = 595;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = F8NVT2G2L4;
 				ENABLE_BITCODE = NO;
@@ -1124,7 +1124,7 @@
 				CODE_SIGN_ENTITLEMENTS = nightly.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 594;
+				CURRENT_PROJECT_VERSION = 595;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = F8NVT2G2L4;
 				ENVFILE = "$(PODS_ROOT)/../../.env.nightly";

--- a/apps/wallet-mobile/ios/yoroi.xcodeproj/project.pbxproj
+++ b/apps/wallet-mobile/ios/yoroi.xcodeproj/project.pbxproj
@@ -839,7 +839,7 @@
 				CODE_SIGN_ENTITLEMENTS = yoroi/yoroi.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 596;
+				CURRENT_PROJECT_VERSION = 597;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = F8NVT2G2L4;
 				ENABLE_BITCODE = NO;
@@ -884,7 +884,7 @@
 				CODE_SIGN_ENTITLEMENTS = yoroi/yoroi.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 596;
+				CURRENT_PROJECT_VERSION = 597;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = F8NVT2G2L4;
 				ENVFILE = "$(PODS_ROOT)/../../.env.production";
@@ -1079,7 +1079,7 @@
 				CODE_SIGN_ENTITLEMENTS = nightly.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 596;
+				CURRENT_PROJECT_VERSION = 597;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = F8NVT2G2L4;
 				ENABLE_BITCODE = NO;
@@ -1124,7 +1124,7 @@
 				CODE_SIGN_ENTITLEMENTS = nightly.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 596;
+				CURRENT_PROJECT_VERSION = 597;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = F8NVT2G2L4;
 				ENVFILE = "$(PODS_ROOT)/../../.env.nightly";

--- a/apps/wallet-mobile/ios/yoroi.xcodeproj/project.pbxproj
+++ b/apps/wallet-mobile/ios/yoroi.xcodeproj/project.pbxproj
@@ -839,7 +839,7 @@
 				CODE_SIGN_ENTITLEMENTS = yoroi/yoroi.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 597;
+				CURRENT_PROJECT_VERSION = 598;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = F8NVT2G2L4;
 				ENABLE_BITCODE = NO;
@@ -884,7 +884,7 @@
 				CODE_SIGN_ENTITLEMENTS = yoroi/yoroi.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 597;
+				CURRENT_PROJECT_VERSION = 598;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = F8NVT2G2L4;
 				ENVFILE = "$(PODS_ROOT)/../../.env.production";
@@ -1079,7 +1079,7 @@
 				CODE_SIGN_ENTITLEMENTS = nightly.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 597;
+				CURRENT_PROJECT_VERSION = 598;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = F8NVT2G2L4;
 				ENABLE_BITCODE = NO;
@@ -1124,7 +1124,7 @@
 				CODE_SIGN_ENTITLEMENTS = nightly.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 597;
+				CURRENT_PROJECT_VERSION = 598;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = F8NVT2G2L4;
 				ENVFILE = "$(PODS_ROOT)/../../.env.nightly";

--- a/apps/wallet-mobile/ios/yoroi.xcodeproj/project.pbxproj
+++ b/apps/wallet-mobile/ios/yoroi.xcodeproj/project.pbxproj
@@ -839,7 +839,7 @@
 				CODE_SIGN_ENTITLEMENTS = yoroi/yoroi.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 595;
+				CURRENT_PROJECT_VERSION = 596;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = F8NVT2G2L4;
 				ENABLE_BITCODE = NO;
@@ -884,7 +884,7 @@
 				CODE_SIGN_ENTITLEMENTS = yoroi/yoroi.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 595;
+				CURRENT_PROJECT_VERSION = 596;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = F8NVT2G2L4;
 				ENVFILE = "$(PODS_ROOT)/../../.env.production";
@@ -1079,7 +1079,7 @@
 				CODE_SIGN_ENTITLEMENTS = nightly.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 595;
+				CURRENT_PROJECT_VERSION = 596;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = F8NVT2G2L4;
 				ENABLE_BITCODE = NO;
@@ -1124,7 +1124,7 @@
 				CODE_SIGN_ENTITLEMENTS = nightly.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 595;
+				CURRENT_PROJECT_VERSION = 596;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = F8NVT2G2L4;
 				ENVFILE = "$(PODS_ROOT)/../../.env.nightly";

--- a/apps/wallet-mobile/ios/yoroi/Info.plist
+++ b/apps/wallet-mobile/ios/yoroi/Info.plist
@@ -34,7 +34,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>597</string>
+	<string>598</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/apps/wallet-mobile/ios/yoroi/Info.plist
+++ b/apps/wallet-mobile/ios/yoroi/Info.plist
@@ -34,7 +34,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>595</string>
+	<string>596</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/apps/wallet-mobile/ios/yoroi/Info.plist
+++ b/apps/wallet-mobile/ios/yoroi/Info.plist
@@ -34,7 +34,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>594</string>
+	<string>595</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/apps/wallet-mobile/ios/yoroi/Info.plist
+++ b/apps/wallet-mobile/ios/yoroi/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.28.1</string>
+	<string>4.28.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -34,7 +34,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>596</string>
+	<string>597</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/apps/wallet-mobile/ios/yoroiTests/Info.plist
+++ b/apps/wallet-mobile/ios/yoroiTests/Info.plist
@@ -19,6 +19,6 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>595</string>
+	<string>596</string>
 </dict>
 </plist>

--- a/apps/wallet-mobile/ios/yoroiTests/Info.plist
+++ b/apps/wallet-mobile/ios/yoroiTests/Info.plist
@@ -19,6 +19,6 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>597</string>
+	<string>598</string>
 </dict>
 </plist>

--- a/apps/wallet-mobile/ios/yoroiTests/Info.plist
+++ b/apps/wallet-mobile/ios/yoroiTests/Info.plist
@@ -19,6 +19,6 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>594</string>
+	<string>595</string>
 </dict>
 </plist>

--- a/apps/wallet-mobile/ios/yoroiTests/Info.plist
+++ b/apps/wallet-mobile/ios/yoroiTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.28.1</string>
+	<string>4.28.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>596</string>
+	<string>597</string>
 </dict>
 </plist>

--- a/apps/wallet-mobile/package.json
+++ b/apps/wallet-mobile/package.json
@@ -98,7 +98,7 @@
     "@emurgo/cross-csl-mobile": "^5.1.0-beta.1",
     "@emurgo/csl-mobile-bridge": "^6.1.0-beta.1",
     "@emurgo/react-native-blockies-svg": "^0.0.2",
-    "@emurgo/react-native-hid": "5.15.7",
+    "@emurgo/react-native-hid": "5.15.8",
     "@emurgo/yoroi-lib": "^1.2.1",
     "@formatjs/intl-datetimeformat": "^6.7.0",
     "@formatjs/intl-getcanonicallocales": "^2.1.0",

--- a/apps/wallet-mobile/package.json
+++ b/apps/wallet-mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoroi/wallet-mobile",
-  "version": "4.28.1",
+  "version": "4.28.3",
   "private": true,
   "scripts": {
     "android-bundle": "react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res",
@@ -98,7 +98,7 @@
     "@emurgo/cross-csl-mobile": "^5.1.0-beta.1",
     "@emurgo/csl-mobile-bridge": "^6.1.0-beta.1",
     "@emurgo/react-native-blockies-svg": "^0.0.2",
-    "@emurgo/react-native-hid": "^5.15.6",
+    "@emurgo/react-native-hid": "5.15.7",
     "@emurgo/yoroi-lib": "^1.2.1",
     "@formatjs/intl-datetimeformat": "^6.7.0",
     "@formatjs/intl-getcanonicallocales": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2744,10 +2744,10 @@
   dependencies:
     react-native-svg "13.8.0"
 
-"@emurgo/react-native-hid@^5.15.6":
-  version "5.15.6"
-  resolved "https://registry.yarnpkg.com/@emurgo/react-native-hid/-/react-native-hid-5.15.6.tgz#bade99f9434a1d4080b777e9f724f4634a73330f"
-  integrity sha512-jtWsp0QfkWRWAGgNVp9ThTtAEqNmddSRk/yABQTK1vrVhZKxwc66l9ejl9YZw1crIr7W4FTqDThQ0KWuj9TlPw==
+"@emurgo/react-native-hid@5.15.7":
+  version "5.15.7"
+  resolved "https://registry.yarnpkg.com/@emurgo/react-native-hid/-/react-native-hid-5.15.7.tgz#d481f5268be96945f9b6a91c5e0d98c6ac4e3e20"
+  integrity sha512-/5dalbT+L8WajKWBUZCiXHIfcgDECTmx0KJAStAj3k3RKqHziCTAz9s2q24/7pUocj9+w5cWueDzCno64tOuMA==
   dependencies:
     "@ledgerhq/devices" "^5.15.0"
     "@ledgerhq/errors" "^5.15.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2744,10 +2744,10 @@
   dependencies:
     react-native-svg "13.8.0"
 
-"@emurgo/react-native-hid@5.15.7":
-  version "5.15.7"
-  resolved "https://registry.yarnpkg.com/@emurgo/react-native-hid/-/react-native-hid-5.15.7.tgz#d481f5268be96945f9b6a91c5e0d98c6ac4e3e20"
-  integrity sha512-/5dalbT+L8WajKWBUZCiXHIfcgDECTmx0KJAStAj3k3RKqHziCTAz9s2q24/7pUocj9+w5cWueDzCno64tOuMA==
+"@emurgo/react-native-hid@5.15.8":
+  version "5.15.8"
+  resolved "https://registry.yarnpkg.com/@emurgo/react-native-hid/-/react-native-hid-5.15.8.tgz#10db96befce4b7f621ab8f477a63c28e1aa082d0"
+  integrity sha512-wqW/alaHBMUXAbqkaNAe1q/qc4RG4X0vEfSRwp7ZwCP9NyJ6+1DJj7TesWTPtbkSr9U2iDbvGSpWR9Fe8vdDPA==
   dependencies:
     "@ledgerhq/devices" "^5.15.0"
     "@ledgerhq/errors" "^5.15.0"


### PR DESCRIPTION
QA Summary
- Test HW (withdraw, send tx) USB+Bluetooth Android

v4.28.3-rc.0 (iOS nightly: 🟢 598, Android nightly: 🟢 711)

- [x] update `react-native-hid` #[eb0e3eb](https://github.com/Emurgo/yoroi/pull/3616/commits/eb0e3eb2927b4e910d2a8f7fd14d4dc3f1fb9174)