### PR TITLE
fix(wallet-mobile): adds log for token activity error

### DIFF
--- a/apps/wallet-mobile/src/features/Portfolio/common/PortfolioTokenActivityProvider.tsx
+++ b/apps/wallet-mobile/src/features/Portfolio/common/PortfolioTokenActivityProvider.tsx
@@ -7,6 +7,7 @@ import {useQuery, useQueryClient} from 'react-query'
 import {merge, switchMap} from 'rxjs'
 
 import {time} from '../../../kernel/constants'
+import {logger} from '../../../kernel/logger/logger'
 import {queryInfo} from '../../../kernel/query-client'
 import {useSelectedNetwork} from '../../WalletManager/common/hooks/useSelectedNetwork'
 import {useWalletManager} from '../../WalletManager/context/WalletManagerProvider'
@@ -121,7 +122,10 @@ export const PortfolioTokenActivityProvider = ({children}: Props) => {
 
       const response = await tokenManager.api.tokenActivity(state.secondaryTokenIds, state.activityWindow)
 
-      if (response.tag === 'left') throw response.error
+      if (response.tag === 'left') {
+        logger.error(JSON.stringify({endpoint: 'tokenActivity', ...response.error}))
+        return null
+      }
       return response.value.data
     },
   })


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

Previous log (called directly by react-query when throwing)
```
{"message": undefined, "responseData": {"reasons": {"": [Array]}}, "status": 500}
```

With this change:
 ```
{"endpoint":"tokenActivity","status":500,"responseData":{"reasons":{"":["unexpected error"]}}}
```

