### PR TITLE
chore(wallet-mobile): prevent prod from calling missing history chart endpoint

### DIFF
--- a/apps/wallet-mobile/src/features/Portfolio/common/hooks/useGetPortfolioTokenChart.ts
+++ b/apps/wallet-mobile/src/features/Portfolio/common/hooks/useGetPortfolioTokenChart.ts
@@ -4,6 +4,7 @@ import {Chain, Portfolio} from '@yoroi/types'
 import {useQuery, UseQueryOptions} from 'react-query'
 
 import {supportedCurrencies, time} from '../../../../kernel/constants'
+import {features} from '../../../../kernel/features'
 import {useLanguage} from '../../../../kernel/i18n'
 import {logger} from '../../../../kernel/logger/logger'
 import {fetchPtPriceActivity} from '../../../../yoroi-wallets/cardano/usePrimaryTokenActivity'
@@ -118,6 +119,8 @@ export const useGetPortfolioTokenChart = (
     ...options,
     queryKey: ['useGetPortfolioTokenChart', tokenInfo?.info.id ?? '', timeInterval],
     queryFn: async () => {
+      if (!features.portfolioSecondaryCharts) return null
+
       const response = await tokenManager.api.tokenHistory(tokenId, chartIntervalToHistoryPeriod(timeInterval))
       if (isRight(response)) {
         const prices = response.value.data.prices

--- a/apps/wallet-mobile/src/kernel/features.ts
+++ b/apps/wallet-mobile/src/kernel/features.ts
@@ -6,6 +6,7 @@ export const features = {
   showProdPoolsInDev: isDev,
   moderatingNftsEnabled: false,
   poolTransition: true,
+  portfolioSecondaryCharts: isDev,
   portfolioPerformance: false,
   portfolioNews: false,
   portfolioExport: false,


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

Will need release to activate once endpoint is ready

##### Ticket

[YOMO-1861](https://emurgo.atlassian.net/browse/YOMO-1861)


[YOMO-1861]: https://emurgo.atlassian.net/browse/YOMO-1861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ