### PR TITLE
fix(wallet-mobile): fix withdraw modal height

### DIFF
--- a/apps/wallet-mobile/src/legacy/Dashboard/WithdrawStakingRewards/WithdrawStakingRewards.tsx
+++ b/apps/wallet-mobile/src/legacy/Dashboard/WithdrawStakingRewards/WithdrawStakingRewards.tsx
@@ -45,7 +45,7 @@ export const WithdrawStakingRewards = ({wallet}: Props) => {
           onCancel={() => closeModal()}
         />
       </Boundary>,
-      400,
+      450,
     )
   }
 


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

Between these 2 PRs the final height was reduced and now it has an unnecessary scroll inside

#3637 
#3645 

|before|after|
|-|-|
|![image](https://github.com/user-attachments/assets/d0109d2f-4274-4307-a4b3-3b07156a2fca)|![image](https://github.com/user-attachments/assets/5ce104c9-cf80-48d7-9606-3ee599322c56)|
