### PR TITLE
feature: update catalyst min ada for fund 13

### DIFF
--- a/apps/wallet-mobile/src/features/RegisterCatalyst/common/InsufficientFundsModal.tsx
+++ b/apps/wallet-mobile/src/features/RegisterCatalyst/common/InsufficientFundsModal.tsx
@@ -23,7 +23,7 @@ export const InsufficientFundsModal = () => {
   const primaryBalance = usePortfolioPrimaryBalance({wallet})
   const fmtMinPrimaryBalance = formatter({
     info: wallet.portfolioPrimaryTokenInfo,
-    quantity: catalystConfig.displayedMinAda,
+    quantity: catalystConfig.minAda,
   })
   const fmtPrimaryBalance = formatter(primaryBalance)
 

--- a/apps/wallet-mobile/src/features/WalletManager/common/adapters/cardano/catalyst-config.ts
+++ b/apps/wallet-mobile/src/features/WalletManager/common/adapters/cardano/catalyst-config.ts
@@ -3,6 +3,5 @@ import {freeze} from 'immer'
 import {cardanoConfig} from './cardano-config'
 
 export const catalystConfig = freeze({
-  minAda: 450n * cardanoConfig.denominations.ada,
-  displayedMinAda: 500n * cardanoConfig.denominations.ada,
+  minAda: 25n * cardanoConfig.denominations.ada,
 } as const)


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

https://projectcatalyst.io/f13launchguide.pdf

> Fund13 also levels up voter participation, meaning ada-holders
> need a minimum of ₳25 to cast votes to the time of the snapshot, instead of the 
> ₳450 instituted since Fund4 opening the door for more voices than ever. 