### PR TITLE
fix(wallet-mobile): Make navigation bar color transparent

### DIFF
--- a/apps/wallet-mobile/android/app/src/dev/res/values/styles.xml
+++ b/apps/wallet-mobile/android/app/src/dev/res/values/styles.xml
@@ -5,6 +5,8 @@
         <!-- Customize your theme here. -->
         <item name="android:forceDarkAllowed">false</item>
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:enforceNavigationBarContrast">false</item>
     </style>
 
     <!-- react-native-bootsplash -->

--- a/apps/wallet-mobile/android/app/src/nightly/res/values/styles.xml
+++ b/apps/wallet-mobile/android/app/src/nightly/res/values/styles.xml
@@ -5,6 +5,8 @@
         <!-- Customize your theme here. -->
         <item name="android:forceDarkAllowed">false</item>
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:enforceNavigationBarContrast">false</item>
     </style>
 
     <!-- react-native-bootsplash -->

--- a/apps/wallet-mobile/android/app/src/production/res/values/styles.xml
+++ b/apps/wallet-mobile/android/app/src/production/res/values/styles.xml
@@ -5,6 +5,8 @@
         <!-- Customize your theme here. -->
         <item name="android:forceDarkAllowed">false</item>
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:enforceNavigationBarContrast">false</item>
     </style>
 
     <!-- react-native-bootsplash -->


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

Make navigation bar color transparent

##### Ticket

[YV-50](https://emurgo.atlassian.net/browse/YV-50)
<img width="475" alt="Screenshot 2024-10-22 at 18 28 10" src="https://github.com/user-attachments/assets/45a02490-9a9b-4b0e-b5f1-1ab53c3d8694">


[YV-50]: https://emurgo.atlassian.net/browse/YV-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ