### PR TITLE
Suggestion to open PR

### DIFF
--- a/apps/wallet-mobile/src/features/ReviewTx/common/hooks/useFormattedTx.tsx
+++ b/apps/wallet-mobile/src/features/ReviewTx/common/hooks/useFormattedTx.tsx
@@ -1,4 +1,3 @@
-// import {CredKind} from '@emurgo/csl-mobile-bridge'
 import {CredKind} from '@emurgo/cross-csl-core'
 import {isNonNullable} from '@yoroi/common'
 import {infoExtractName} from '@yoroi/portfolio'
@@ -14,8 +13,7 @@ import {asQuantity} from '../../../../yoroi-wallets/utils/utils'
 import {usePortfolioTokenInfos} from '../../../Portfolio/common/hooks/usePortfolioTokenInfos'
 import {useSelectedWallet} from '../../../WalletManager/common/hooks/useSelectedWallet'
 import {
-  Certificates,
-  FormattedCertificates,
+  FormattedCertificate,
   FormattedFee,
   FormattedInputs,
   FormattedOutputs,
@@ -52,7 +50,7 @@ export const useFormattedTx = (data: TransactionBody): FormattedTx => {
   const formattedInputs = useFormattedInputs(wallet, inputs, portfolioTokenInfos)
   const formattedOutputs = useFormattedOutputs(wallet, outputs, portfolioTokenInfos)
   const formattedFee = formatFee(wallet, data)
-  const formattedCertificates = formatCertificates(data.certs as Certificates)
+  const formattedCertificates = formatCertificates(data.certs)
 
   return {
     inputs: formattedInputs,
@@ -223,8 +221,13 @@ export const formatFee = (wallet: YoroiWallet, data: TransactionBody): Formatted
   }
 }
 
-const formatCertificates = (certificates: Certificates) => {
-  return certificates.flatMap(Object.entries) as FormattedCertificates
+const formatCertificates = (certificates: TransactionBody['certs']) => {
+  return (
+    certificates?.map((cert) => {
+      const [type, certificate] = Object.entries(cert)[0]
+      return {type, certificate} as unknown as FormattedCertificate
+    }) ?? null
+  )
 }
 
 const deriveAddress = async (address: string, chainId: number) => {

--- a/apps/wallet-mobile/src/features/ReviewTx/common/operations.tsx
+++ b/apps/wallet-mobile/src/features/ReviewTx/common/operations.tsx
@@ -12,7 +12,7 @@ import {asQuantity} from '../../../yoroi-wallets/utils/utils'
 import {useSelectedNetwork} from '../../WalletManager/common/hooks/useSelectedNetwork'
 import {useSelectedWallet} from '../../WalletManager/common/hooks/useSelectedWallet'
 import {useStrings} from './hooks/useStrings'
-import {Certificate, CertificateTypes, FormattedCertificates} from './types'
+import {CertificateType, FormattedTx} from './types'
 
 export const StakeRegistrationOperation = () => {
   const {styles} = useStyles()
@@ -119,25 +119,25 @@ export const VoteDelegationOperation = ({drepID}: {drepID: string}) => {
   )
 }
 
-export const useOperations = (certificates: FormattedCertificates | null) => {
+export const useOperations = (certificates: FormattedTx['certificates']) => {
   if (certificates === null) return []
 
-  return certificates.reduce<React.ReactNode[]>((acc, [certificateKind, CertificateData], index) => {
-    switch (certificateKind) {
-      case CertificateTypes.StakeRegistration:
+  return certificates.reduce<React.ReactNode[]>((acc, certificate, index) => {
+    switch (certificate.type) {
+      case CertificateType.StakeRegistration:
         return [...acc, <StakeRegistrationOperation key={index} />]
 
-      case CertificateTypes.StakeDeregistration:
+      case CertificateType.StakeDeregistration:
         return [...acc, <StakeDeregistrationOperation key={index} />]
 
-      case CertificateTypes.StakeDelegation: {
-        const poolKeyHash = (CertificateData as Certificate[CertificateTypes.StakeDelegation]).pool_keyhash ?? null
+      case CertificateType.StakeDelegation: {
+        const poolKeyHash = certificate.value.pool_keyhash ?? null
         if (poolKeyHash == null) return acc
         return [...acc, <StakeDelegateOperation key={index} poolId={poolKeyHash} />]
       }
 
-      case CertificateTypes.VoteDelegation: {
-        const drep = (CertificateData as Certificate[CertificateTypes.VoteDelegation]).drep
+      case CertificateType.VoteDelegation: {
+        const drep = certificate.value.drep
 
         if (drep === 'AlwaysAbstain') return [...acc, <AbstainOperation key={index} />]
         if (drep === 'AlwaysNoConfidence') return [...acc, <NoConfidenceOperation key={index} />]

--- a/apps/wallet-mobile/src/features/ReviewTx/common/types.ts
+++ b/apps/wallet-mobile/src/features/ReviewTx/common/types.ts
@@ -1,24 +1,8 @@
 import {
-  CommitteeColdResignJSON,
-  CommitteeHotAuthJSON,
-  DRepDeregistrationJSON,
-  DRepRegistrationJSON,
-  DRepUpdateJSON,
-  GenesisKeyDelegationJSON,
-  MoveInstantaneousRewardsCertJSON,
-  PoolRegistrationJSON,
-  PoolRetirementJSON,
-  StakeAndVoteDelegationJSON,
-  StakeDelegationJSON,
-  StakeDeregistrationJSON,
-  StakeRegistrationAndDelegationJSON,
-  StakeRegistrationJSON,
-  StakeVoteRegistrationAndDelegationJSON,
+  CertificateJSON,
   TransactionBodyJSON,
   TransactionInputsJSON,
   TransactionOutputsJSON,
-  VoteDelegationJSON,
-  VoteRegistrationAndDelegationJSON,
 } from '@emurgo/cardano-serialization-lib-nodejs'
 import {CredKind} from '@emurgo/cross-csl-core'
 import {Balance, Portfolio} from '@yoroi/types'
@@ -73,7 +57,7 @@ export type FormattedTx = {
   inputs: FormattedInputs
   outputs: FormattedOutputs
   fee: FormattedFee
-  certificates: FormattedCertificates | null
+  certificates: FormattedCertificate[] | null
 }
 
 export type FormattedMetadata = {
@@ -81,45 +65,41 @@ export type FormattedMetadata = {
   metadata: {msg: Array<unknown>} | null
 }
 
-export type Certificates = Array<Certificate>
-export type FormattedCertificates = Array<[CertificateTypes, Certificate[CertificateTypes]]>
+type AssertEqual<T, Expected> = T extends Expected
+  ? Expected extends T
+    ? true
+    : ['Type', Expected, 'is not equal to', T]
+  : ['Type', T, 'is not equal to', Expected]
 
-export type Certificate = {
-  StakeRegistration: StakeRegistrationJSON
-  StakeDeregistration: StakeDeregistrationJSON
-  StakeDelegation: StakeDelegationJSON
-  PoolRegistration: PoolRegistrationJSON
-  PoolRetirement: PoolRetirementJSON
-  GenesisKeyDelegation: GenesisKeyDelegationJSON
-  MoveInstantaneousRewardsCert: MoveInstantaneousRewardsCertJSON
-  CommitteeHotAuth: CommitteeHotAuthJSON
-  CommitteeColdResign: CommitteeColdResignJSON
-  DRepDeregistration: DRepDeregistrationJSON
-  DRepRegistration: DRepRegistrationJSON
-  DRepUpdate: DRepUpdateJSON
-  StakeAndVoteDelegation: StakeAndVoteDelegationJSON
-  StakeRegistrationAndDelegation: StakeRegistrationAndDelegationJSON
-  StakeVoteRegistrationAndDelegation: StakeVoteRegistrationAndDelegationJSON
-  VoteDelegation: VoteDelegationJSON
-  VoteRegistrationAndDelegation: VoteRegistrationAndDelegationJSON
-}
+type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends (x: infer I) => void ? I : never
 
-export enum CertificateTypes {
-  StakeRegistration = 'StakeRegistration',
-  StakeDeregistration = 'StakeDeregistration',
-  StakeDelegation = 'StakeDelegation',
-  PoolRegistration = 'PoolRegistration',
-  PoolRetirement = 'PoolRetirement',
-  GenesisKeyDelegation = 'GenesisKeyDelegation',
-  MoveInstantaneousRewardsCert = 'MoveInstantaneousRewardsCert',
-  CommitteeHotAuth = 'CommitteeHotAuth',
-  CommitteeColdResign = 'CommitteeColdResign',
-  DRepDeregistration = 'DRepDeregistration',
-  DRepRegistration = 'DRepRegistration',
-  DRepUpdate = 'DRepUpdate',
-  StakeAndVoteDelegation = 'StakeAndVoteDelegation',
-  StakeRegistrationAndDelegation = 'StakeRegistrationAndDelegation',
-  StakeVoteRegistrationAndDelegation = 'StakeVoteRegistrationAndDelegation',
-  VoteDelegation = 'VoteDelegation',
-  VoteRegistrationAndDelegation = 'VoteRegistrationAndDelegation',
-}
+type Transformed<T> = {
+  [K in keyof UnionToIntersection<T>]: {type: K; value: UnionToIntersection<T>[K]}
+}[keyof UnionToIntersection<T>]
+
+export type FormattedCertificate = Transformed<CertificateJSON>
+
+export const CertificateType = {
+  StakeRegistration: 'StakeRegistration',
+  StakeDeregistration: 'StakeDeregistration',
+  StakeDelegation: 'StakeDelegation',
+  PoolRegistration: 'PoolRegistration',
+  PoolRetirement: 'PoolRetirement',
+  GenesisKeyDelegation: 'GenesisKeyDelegation',
+  MoveInstantaneousRewardsCert: 'MoveInstantaneousRewardsCert',
+  CommitteeHotAuth: 'CommitteeHotAuth',
+  CommitteeColdResign: 'CommitteeColdResign',
+  DRepDeregistration: 'DRepDeregistration',
+  DRepRegistration: 'DRepRegistration',
+  DRepUpdate: 'DRepUpdate',
+  StakeAndVoteDelegation: 'StakeAndVoteDelegation',
+  StakeRegistrationAndDelegation: 'StakeRegistrationAndDelegation',
+  StakeVoteRegistrationAndDelegation: 'StakeVoteRegistrationAndDelegation',
+  VoteDelegation: 'VoteDelegation',
+  VoteRegistrationAndDelegation: 'VoteRegistrationAndDelegation',
+} as const
+
+export type CerificateType = (typeof CertificateType)[keyof typeof CertificateType]
+
+// Makes sure CertificateType lists all the certificates in CertificateJSON
+export type AssertAllImplementedCertTypes = AssertEqual<CerificateType, keyof UnionToIntersection<CertificateJSON>>


### PR DESCRIPTION
For https://github.com/Emurgo/yoroi/pull/3707

This makes the certificate types more consistent, so there's no need to cast `as` them everywhere. 
Basically `FormattedCertificate` is more strict so once you discriminate by type, the value already has the correct shape:

```
type FormattedCertificate = {
    type: "StakeRegistration";
    value: StakeRegistrationJSON;
} | {
    type: "StakeDeregistration";
    value: StakeDeregistrationJSON;
} | {
    type: "StakeDelegation";
    value: StakeDelegationJSON;
} | {
    type: "PoolRegistration";
    value: PoolRegistrationJSON;
} | {
    type: "PoolRetirement";
    value: PoolRetirementJSON;
} | {
    type: "GenesisKeyDelegation";
    value: GenesisKeyDelegationJSON;
} | {
    type: "MoveInstantaneousRewardsCert";
    value: MoveInstantaneousRewardsCertJSON;
} | {
    type: "CommitteeHotAuth";
    value: CommitteeHotAuthJSON;
} | {
    type: "CommitteeColdResign";
    value: CommitteeColdResignJSON;
} | {
    type: "DRepDeregistration";
    value: DRepDeregistrationJSON;
} | {
    type: "DRepRegistration";
    value: DRepRegistrationJSON;
} | {
    type: "DRepUpdate";
    value: DRepUpdateJSON;
} | {
    type: "StakeAndVoteDelegation";
    value: StakeAndVoteDelegationJSON;
} | {
    type: "StakeRegistrationAndDelegation";
    value: StakeRegistrationAndDelegationJSON;
} | {
    type: "StakeVoteRegistrationAndDelegation";
    value: StakeVoteRegistrationAndDelegationJSON;
} | ... 2 more
```