### PR TITLE
fix(wallet-mobile): Navigate to portfolio after clicking back on NFT detail

### DIFF
--- a/apps/wallet-mobile/src/features/Portfolio/common/hooks/useNavigateTo.tsx
+++ b/apps/wallet-mobile/src/features/Portfolio/common/hooks/useNavigateTo.tsx
@@ -14,7 +14,7 @@ export const useNavigateTo = () => {
       navigation.navigate('portfolio-token-details', {id: params.id}),
     nftsList: () => navigation.navigate('portfolio-nfts', {screen: 'nft-gallery'}),
     nftDetails: (id: Portfolio.Token.Id) =>
-      navigation.navigate('portfolio-nfts', {screen: 'nft-details', params: {id}, initial: false}),
+      navigation.navigate('portfolio-nfts', {screen: 'nft-details', params: {id}, initial: true}),
     resetTabAndSend: () => {
       navigation.reset({index: 0, routes: [{name: 'dashboard-portfolio'}]})
       navigation.navigate('history', {screen: 'send-start-tx'})


### PR DESCRIPTION


## Description / Change(s) / Related issue(s)
Navigate to portfolio after clicking back on NFT detail

##### Ticket

[YV-46](https://emurgo.atlassian.net/browse/YV-46)


[YV-46]: https://emurgo.atlassian.net/browse/YV-46?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ