### PR TITLE
fix(wallet-mobile): cbor wasnt cleaned after use

### DIFF
--- a/apps/wallet-mobile/src/features/Discover/useDappConnectorManager.tsx
+++ b/apps/wallet-mobile/src/features/Discover/useDappConnectorManager.tsx
@@ -8,7 +8,6 @@ import {useMutation} from 'react-query'
 import {logger} from '../../kernel/logger/logger'
 import {useWalletNavigation} from '../../kernel/navigation'
 import {cip30LedgerExtensionMaker} from '../../yoroi-wallets/cardano/cip30/cip30-ledger'
-import {useReviewTx} from '../ReviewTx/common/ReviewTxProvider'
 import {CreatedByInfoItem} from '../ReviewTx/useCases/ReviewTxScreen/ReviewTx/Overview/OverviewTab'
 import {useSelectedWallet} from '../WalletManager/common/hooks/useSelectedWallet'
 import {useBrowser} from './common/BrowserProvider'
@@ -27,7 +26,6 @@ export const useDappConnectorManager = () => {
   const navigateTo = useNavigateTo()
   const {wallet, meta} = useSelectedWallet()
   const {navigateToTxReview} = useWalletNavigation()
-  const {cborChanged} = useReviewTx()
   const {tabs, tabActiveIndex} = useBrowser()
   const activeTab = tabs[tabActiveIndex]
   const activeTabUrl = activeTab?.url
@@ -45,11 +43,11 @@ export const useDappConnectorManager = () => {
     ({cbor, manager}: {cbor: string; manager: DappConnector}) => {
       return new Promise<string>((resolve, reject) => {
         let shouldResolve = true
-        cborChanged(cbor)
         return manager.getDAppList().then(({dapps}) => {
           const matchingDapp =
             activeTabOrigin != null ? dapps.find((dapp) => dapp.origins.includes(activeTabOrigin)) : null
           navigateToTxReview({
+            cbor,
             createdBy: matchingDapp != null && <CreatedByInfoItem logo={matchingDapp.logo} url={matchingDapp.uri} />,
             onConfirm: async () => {
               if (!shouldResolve) return
@@ -67,18 +65,18 @@ export const useDappConnectorManager = () => {
         })
       })
     },
-    [activeTabOrigin, cborChanged, navigateToTxReview, promptRootKey, navigateTo],
+    [activeTabOrigin, navigateToTxReview, promptRootKey, navigateTo],
   )
 
   const handleSignTxWithHW = React.useCallback(
     ({cbor, partial, manager}: {cbor: string; partial?: boolean; manager: DappConnector}) => {
       return new Promise<Transaction>((resolve, reject) => {
         let shouldResolve = true
-        cborChanged(cbor)
         return manager.getDAppList().then(({dapps}) => {
           const matchingDapp =
             activeTabOrigin != null ? dapps.find((dapp) => dapp.origins.includes(activeTabOrigin)) : null
           navigateToTxReview({
+            cbor,
             createdBy: matchingDapp != null && <CreatedByInfoItem logo={matchingDapp.logo} url={matchingDapp.uri} />,
             onConfirm: () => {
               if (!shouldResolve) return
@@ -104,7 +102,7 @@ export const useDappConnectorManager = () => {
         })
       })
     },
-    [activeTabOrigin, cborChanged, navigateToTxReview, navigateTo, signTxWithHW],
+    [activeTabOrigin, navigateToTxReview, navigateTo, signTxWithHW],
   )
 
   return React.useMemo(

--- a/apps/wallet-mobile/src/features/ReviewTx/common/ReviewTxProvider.tsx
+++ b/apps/wallet-mobile/src/features/ReviewTx/common/ReviewTxProvider.tsx
@@ -1,3 +1,12 @@
+/**
+ * DEPRECATED: This provider needs to be maintained because unsignedTx
+ * can change during the CATALYST registration funnel (CIP36)
+ *
+ * will be eliminated in the very near future
+ *
+ * TODO: eliminate the use of unsigned tx entirely
+ */
+
 import {castDraft, produce} from 'immer'
 import _ from 'lodash'
 import React from 'react'
@@ -21,8 +30,6 @@ export const ReviewTxProvider = ({
   const actions = React.useRef<ReviewTxActions>({
     unsignedTxChanged: (unsignedTx: ReviewTxState['unsignedTx']) =>
       dispatch({type: ReviewTxActionType.UnsignedTxChanged, unsignedTx}),
-    cborChanged: (cbor: ReviewTxState['cbor']) => dispatch({type: ReviewTxActionType.CborChanged, cbor}),
-    reset: () => dispatch({type: ReviewTxActionType.Reset}),
   }).current
 
   const context = React.useMemo(
@@ -43,48 +50,27 @@ const reviewTxReducer = (state: ReviewTxState, action: ReviewTxAction) => {
         draft.unsignedTx = castDraft(action.unsignedTx)
         break
 
-      case ReviewTxActionType.CborChanged:
-        draft.cbor = action.cbor
-        break
-
-      case ReviewTxActionType.Reset:
-        draft.unsignedTx = castDraft(defaultState.unsignedTx)
-        draft.cbor = defaultState.cbor
-        break
-
       default:
         throw new Error('[ReviewTxContext] invalid action')
     }
   })
 }
 
-type ReviewTxAction =
-  | {
-      type: ReviewTxActionType.UnsignedTxChanged
-      unsignedTx: ReviewTxState['unsignedTx']
-    }
-  | {
-      type: ReviewTxActionType.CborChanged
-      cbor: ReviewTxState['cbor']
-    }
-  | {
-      type: ReviewTxActionType.Reset
-    }
+type ReviewTxAction = {
+  type: ReviewTxActionType.UnsignedTxChanged
+  unsignedTx: ReviewTxState['unsignedTx']
+}
 
 export type ReviewTxState = {
   unsignedTx: YoroiUnsignedTx | null
-  cbor: string | null
 }
 
 type ReviewTxActions = {
   unsignedTxChanged: (unsignedTx: ReviewTxState['unsignedTx']) => void
-  cborChanged: (cbor: ReviewTxState['cbor']) => void
-  reset: () => void
 }
 
 const defaultState: ReviewTxState = Object.freeze({
   unsignedTx: null,
-  cbor: null,
 })
 
 function missingInit() {
@@ -94,14 +80,10 @@ function missingInit() {
 const initialReviewTxContext: ReviewTxContext = {
   ...defaultState,
   unsignedTxChanged: missingInit,
-  cborChanged: missingInit,
-  reset: missingInit,
 }
 
 enum ReviewTxActionType {
   UnsignedTxChanged = 'unsignedTxChanged',
-  CborChanged = 'cborChanged',
-  Reset = 'reset',
 }
 
 type ReviewTxContext = ReviewTxState & ReviewTxActions

--- a/apps/wallet-mobile/src/features/ReviewTx/common/hooks/useTxBody.tsx
+++ b/apps/wallet-mobile/src/features/ReviewTx/common/hooks/useTxBody.tsx
@@ -14,6 +14,10 @@ export const useTxBody = ({
   const query = useQuery(
     ['useTxBody', cbor, unsignedTx],
     async () => {
+      // ORDER IS IMPORTANT
+      // cbor comes from navigation params and unsigned tx from provider
+      // Reason is unsignedTx can change during the CATALYST registration funnel (CIP36)
+      // TODO: eliminate the use of unsigned tx entirely
       if (cbor != undefined) {
         return getCborTxBody(cbor)
       } else if (unsignedTx != undefined) {

--- a/apps/wallet-mobile/src/features/ReviewTx/common/operations.tsx
+++ b/apps/wallet-mobile/src/features/ReviewTx/common/operations.tsx
@@ -334,6 +334,7 @@ export const useDrepBech32Id = (poolId: string) => {
   const query = useQuery({
     queryKey: ['drepBech32', poolId],
     queryFn: () => getDrepBech32Id(poolId),
+    suspense: true,
   })
 
   return query?.data ?? null

--- a/apps/wallet-mobile/src/features/ReviewTx/useCases/ReviewTxScreen/ReviewTxScreen.tsx
+++ b/apps/wallet-mobile/src/features/ReviewTx/useCases/ReviewTxScreen/ReviewTxScreen.tsx
@@ -9,10 +9,10 @@ import {useReviewTx} from '../../common/ReviewTxProvider'
 import {ReviewTx} from './ReviewTx/ReviewTx'
 
 export const ReviewTxScreen = () => {
-  const {unsignedTx, cbor} = useReviewTx()
+  const {unsignedTx} = useReviewTx()
   const params = useUnsafeParams<ReviewTxRoutes['review-tx']>()
 
-  if (unsignedTx == null && cbor == null) throw new Error('ReviewTxScreen: missing cbor and unsignedTx')
+  if (unsignedTx == null && params?.cbor == null) throw new Error('ReviewTxScreen: missing cbor and unsignedTx')
 
   const {onConfirm} = useOnConfirm({
     unsignedTx,
@@ -22,9 +22,9 @@ export const ReviewTxScreen = () => {
     onCIP36SupportChange: params?.onCIP36SupportChange,
   })
 
-  const txBody = useTxBody({cbor, unsignedTx})
+  const txBody = useTxBody({cbor: params?.cbor, unsignedTx})
   const formattedTx = useFormattedTx(txBody)
-  const formattedMetadata = useFormattedMetadata({txBody, unsignedTx, cbor})
+  const formattedMetadata = useFormattedMetadata({txBody, unsignedTx, cbor: params?.cbor ?? null})
 
   React.useEffect(() => {
     return () => {

--- a/apps/wallet-mobile/src/kernel/navigation.tsx
+++ b/apps/wallet-mobile/src/kernel/navigation.tsx
@@ -275,6 +275,7 @@ export type PortfolioRoutes = {
 
 export type ReviewTxRoutes = {
   'review-tx'?: {
+    cbor?: string
     operations?: Array<React.ReactNode>
     receiverCustomTitle?: React.ReactNode
     details?: {title: string; component: React.ReactNode}

--- a/apps/wallet-mobile/src/yoroi-wallets/hooks/index.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/hooks/index.ts
@@ -715,6 +715,7 @@ export const usePoolInfo = ({poolId}: {poolId: string}): FullPoolInfo => {
     queryFn: async () => {
       return poolInfoApi.getSingleFullPoolInfo(poolId)
     },
+    suspense: true,
   })
 
   return poolInfo?.data ?? {chain: null, explorer: null}


### PR DESCRIPTION
cbor was not cleaned up so when making a new transaction using unsigned tx the transactions were mixed

The use of unsigned tx and the provider is deprecated: it is still used because during catalyst registration unsigned tx can change due to CIP36. THE GOAL IS TO ELIMINATE THE USE OF UNSIGNED TX IN THE NEAR FUTURE💥💥💥💥💥