### PR TITLE
fix(wallet-mobile): default pt to zero

### DIFF
--- a/apps/wallet-mobile/src/yoroi-wallets/cardano/usePrimaryTokenActivity.tsx
+++ b/apps/wallet-mobile/src/yoroi-wallets/cardano/usePrimaryTokenActivity.tsx
@@ -19,8 +19,8 @@ type PrimaryTokenActivity = {
 }
 const defaultPrimaryTokenActivity: PrimaryTokenActivity = {
   ts: 0,
-  close: 1,
-  open: 1,
+  close: 0,
+  open: 0,
 }
 
 export const usePrimaryTokenActivity = ({


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

When API fails, having 1 Ada = 1 of everything is wrong. Zero would be more clear as an error.
