### PR TITLE
fix(wallet-mobile): crash reporting persistence and catalyst voting

### DIFF
--- a/apps/wallet-mobile/src/features/Menu/Menu.tsx
+++ b/apps/wallet-mobile/src/features/Menu/Menu.tsx
@@ -171,7 +171,7 @@ const KnowledgeBase = Item
 const Catalyst = ({label, left, onPress}: {label: string; left: React.ReactElement; onPress: () => void}) => {
   const strings = useStrings()
   const {wallet} = useSelectedWallet()
-  const {canVote, sufficientFunds} = useCanVote(wallet)
+  const {sufficientFunds} = useCanVote(wallet)
   const {openModal} = useModal()
   const screenHeight = useWindowDimensions().height
   const modalHeight = Math.min(screenHeight * 0.8, 256)
@@ -183,7 +183,7 @@ const Catalyst = ({label, left, onPress}: {label: string; left: React.ReactEleme
       openModal(strings.attention, <InsufficientFundsModal />, modalHeight)
     }
   }
-  return <Item label={label} onPress={handlePress} left={left} disabled={!canVote} />
+  return <Item label={label} onPress={handlePress} left={left} />
 }
 
 const SUPPORT_TICKET_LINK = 'https://emurgohelpdesk.zendesk.com/hc/en-us/requests/new?ticket_form_id=360013330335'

--- a/apps/wallet-mobile/src/features/Settings/ApplicationSettings/ApplicationSettingsScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/ApplicationSettings/ApplicationSettingsScreen.tsx
@@ -205,9 +205,9 @@ const CrashReportsSwitch = ({crashReportEnabled}: {crashReportEnabled: boolean})
   const onToggleCrashReports = () => {
     setIsLocalEnabled((prevState) => {
       if (prevState) {
-        enable()
-      } else {
         disable()
+      } else {
+        enable()
       }
 
       return !prevState

--- a/apps/wallet-mobile/src/features/Settings/ApplicationSettings/ApplicationSettingsScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/ApplicationSettings/ApplicationSettingsScreen.tsx
@@ -7,7 +7,7 @@ import {SafeAreaView} from 'react-native-safe-area-context'
 
 import {Icon} from '../../../components/Icon'
 import {Spacer} from '../../../components/Spacer/Spacer'
-import {isNightly, isProduction} from '../../../kernel/env'
+import {isDev, isNightly, isProduction} from '../../../kernel/env'
 import {useLanguage} from '../../../kernel/i18n'
 import {themeNames} from '../../../kernel/i18n/global-messages'
 import {defaultLanguage} from '../../../kernel/i18n/languages'
@@ -214,7 +214,7 @@ const CrashReportsSwitch = ({crashReportEnabled}: {crashReportEnabled: boolean})
     })
   }
 
-  return <SettingsSwitch value={isLocalEnabled} onValueChange={onToggleCrashReports} disabled={isNightly} />
+  return <SettingsSwitch value={isLocalEnabled} onValueChange={onToggleCrashReports} disabled={isNightly || isDev} />
 }
 
 // to avoid switch jumps

--- a/apps/wallet-mobile/src/yoroi-wallets/hooks/index.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/hooks/index.ts
@@ -34,7 +34,6 @@ import {Utxos} from '../utils/utils'
 const crashReportsStorageKey = 'sendCrashReports'
 
 export const getCrashReportsEnabled = async (storage: AsyncStorageStatic = AsyncStorage) => {
-  if (isNightly || isDev) return true
   const data = await storage.getItem(crashReportsStorageKey)
   return parseBoolean(data) ?? false
 }
@@ -44,10 +43,12 @@ const useCrashReportsEnabled = (storage: AsyncStorageStatic = AsyncStorage) => {
     suspense: true,
     queryKey: [crashReportsStorageKey],
     queryFn: () => getCrashReportsEnabled(storage),
+    enabled: !isNightly && !isDev,
   })
 
   if (query.data == null) throw new Error('invalid state')
 
+  if (isNightly || isDev) return true
   return query.data
 }
 


### PR DESCRIPTION
The settings related to crash report are set to true in the UI on dev and nightly. A disable has been applied to the switch to reflect this state.

A bug has also been found: the switch was setting the state in reverse.

Ticket
[YV-92](https://emurgo.atlassian.net/browse/YV-92)
[YV-102](https://emurgo.atlassian.net/browse/YV-102)

[YV-92]: https://emurgo.atlassian.net/browse/YV-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[YV-102]: https://emurgo.atlassian.net/browse/YV-102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ