### PR TITLE
hotfix(wallet-mobile): crash reporting, catalyst and formatting issues

### DIFF
--- a/apps/wallet-mobile/android/app/build.gradle
+++ b/apps/wallet-mobile/android/app/build.gradle
@@ -109,7 +109,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionName "5.0.1"
-        versionCode 732
+        versionCode 733
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/apps/wallet-mobile/ios/nightly.plist
+++ b/apps/wallet-mobile/ios/nightly.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>619</string>
+	<string>620</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/apps/wallet-mobile/ios/yoroi.xcodeproj/project.pbxproj
+++ b/apps/wallet-mobile/ios/yoroi.xcodeproj/project.pbxproj
@@ -839,7 +839,7 @@
 				CODE_SIGN_ENTITLEMENTS = yoroi/yoroi.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 619;
+				CURRENT_PROJECT_VERSION = 620;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = F8NVT2G2L4;
 				ENABLE_BITCODE = NO;
@@ -884,7 +884,7 @@
 				CODE_SIGN_ENTITLEMENTS = yoroi/yoroi.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 619;
+				CURRENT_PROJECT_VERSION = 620;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = F8NVT2G2L4;
 				ENVFILE = "$(PODS_ROOT)/../../.env.production";
@@ -1079,7 +1079,7 @@
 				CODE_SIGN_ENTITLEMENTS = nightly.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 619;
+				CURRENT_PROJECT_VERSION = 620;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = F8NVT2G2L4;
 				ENABLE_BITCODE = NO;
@@ -1124,7 +1124,7 @@
 				CODE_SIGN_ENTITLEMENTS = nightly.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 619;
+				CURRENT_PROJECT_VERSION = 620;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = F8NVT2G2L4;
 				ENVFILE = "$(PODS_ROOT)/../../.env.nightly";

--- a/apps/wallet-mobile/ios/yoroi/Info.plist
+++ b/apps/wallet-mobile/ios/yoroi/Info.plist
@@ -34,7 +34,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>619</string>
+	<string>620</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/apps/wallet-mobile/ios/yoroiTests/Info.plist
+++ b/apps/wallet-mobile/ios/yoroiTests/Info.plist
@@ -19,6 +19,6 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>619</string>
+	<string>620</string>
 </dict>
 </plist>

--- a/apps/wallet-mobile/src/features/Exchange/useCases/CreateExchangeOrderScreen/CreateExchangeOrderScreen.tsx
+++ b/apps/wallet-mobile/src/features/Exchange/useCases/CreateExchangeOrderScreen/CreateExchangeOrderScreen.tsx
@@ -12,6 +12,7 @@ import {Icon} from '../../../../components/Icon'
 import {KeyboardAvoidingView} from '../../../../components/KeyboardAvoidingView/KeyboardAvoidingView'
 import {useModal} from '../../../../components/Modal/ModalContext'
 import {banxaTestWallet} from '../../../../kernel/env'
+import {decimalDot} from '../../../../kernel/i18n/languages'
 import {useMetrics} from '../../../../kernel/metrics/metricsManager'
 import {useWalletNavigation} from '../../../../kernel/navigation'
 import {delay} from '../../../../yoroi-wallets/utils/timeUtils'
@@ -58,7 +59,7 @@ export const CreateExchangeOrderScreen = () => {
 
   const quantity = BigInt(amount.value)
   const orderAmount = Number(
-    atomicFormatter({value: quantity, decimalPlaces: wallet.portfolioPrimaryTokenInfo.decimals}),
+    atomicFormatter({value: quantity, decimalPlaces: wallet.portfolioPrimaryTokenInfo.decimals, format: decimalDot}),
   )
   const returnUrl = encodeURIComponent(
     linksYoroiModuleMaker('yoroi').exchange.order.showCreateResult({

--- a/apps/wallet-mobile/src/features/Menu/Menu.tsx
+++ b/apps/wallet-mobile/src/features/Menu/Menu.tsx
@@ -171,7 +171,7 @@ const KnowledgeBase = Item
 const Catalyst = ({label, left, onPress}: {label: string; left: React.ReactElement; onPress: () => void}) => {
   const strings = useStrings()
   const {wallet} = useSelectedWallet()
-  const {canVote, sufficientFunds} = useCanVote(wallet)
+  const {sufficientFunds} = useCanVote(wallet)
   const {openModal} = useModal()
   const screenHeight = useWindowDimensions().height
   const modalHeight = Math.min(screenHeight * 0.8, 256)
@@ -183,7 +183,7 @@ const Catalyst = ({label, left, onPress}: {label: string; left: React.ReactEleme
       openModal(strings.attention, <InsufficientFundsModal />, modalHeight)
     }
   }
-  return <Item label={label} onPress={handlePress} left={left} disabled={!canVote} />
+  return <Item label={label} onPress={handlePress} left={left} />
 }
 
 const SUPPORT_TICKET_LINK = 'https://emurgohelpdesk.zendesk.com/hc/en-us/requests/new?ticket_form_id=360013330335'

--- a/apps/wallet-mobile/src/features/Settings/ApplicationSettings/ApplicationSettingsScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/ApplicationSettings/ApplicationSettingsScreen.tsx
@@ -205,9 +205,9 @@ const CrashReportsSwitch = ({crashReportEnabled}: {crashReportEnabled: boolean})
   const onToggleCrashReports = () => {
     setIsLocalEnabled((prevState) => {
       if (prevState) {
-        enable()
-      } else {
         disable()
+      } else {
+        enable()
       }
 
       return !prevState

--- a/apps/wallet-mobile/src/features/Settings/ApplicationSettings/ApplicationSettingsScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/ApplicationSettings/ApplicationSettingsScreen.tsx
@@ -7,7 +7,7 @@ import {SafeAreaView} from 'react-native-safe-area-context'
 
 import {Icon} from '../../../components/Icon'
 import {Spacer} from '../../../components/Spacer/Spacer'
-import {isNightly, isProduction} from '../../../kernel/env'
+import {isDev, isNightly, isProduction} from '../../../kernel/env'
 import {useLanguage} from '../../../kernel/i18n'
 import {themeNames} from '../../../kernel/i18n/global-messages'
 import {defaultLanguage} from '../../../kernel/i18n/languages'
@@ -214,7 +214,7 @@ const CrashReportsSwitch = ({crashReportEnabled}: {crashReportEnabled: boolean})
     })
   }
 
-  return <SettingsSwitch value={isLocalEnabled} onValueChange={onToggleCrashReports} disabled={isNightly} />
+  return <SettingsSwitch value={isLocalEnabled} onValueChange={onToggleCrashReports} disabled={isNightly || isDev} />
 }
 
 // to avoid switch jumps

--- a/apps/wallet-mobile/src/yoroi-wallets/hooks/index.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/hooks/index.ts
@@ -34,7 +34,6 @@ import {Utxos} from '../utils/utils'
 const crashReportsStorageKey = 'sendCrashReports'
 
 export const getCrashReportsEnabled = async (storage: AsyncStorageStatic = AsyncStorage) => {
-  if (isNightly || isDev) return true
   const data = await storage.getItem(crashReportsStorageKey)
   return parseBoolean(data) ?? false
 }
@@ -44,10 +43,12 @@ const useCrashReportsEnabled = (storage: AsyncStorageStatic = AsyncStorage) => {
     suspense: true,
     queryKey: [crashReportsStorageKey],
     queryFn: () => getCrashReportsEnabled(storage),
+    enabled: !isNightly && !isDev,
   })
 
   if (query.data == null) throw new Error('invalid state')
 
+  if (isNightly || isDev) return true
   return query.data
 }
 


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

The settings related to crash report are set to true in the UI on dev and nightly. A disable has been applied to the switch to reflect this state.

A bug has also been found: the switch was setting the state in reverse.

#####  Tickets
[YV-92](https://emurgo.atlassian.net/browse/YV-92)
[YV-102](https://emurgo.atlassian.net/browse/YV-102)
[YV-118](https://emurgo.atlassian.net/browse/YV-118)

[YV-92]: https://emurgo.atlassian.net/browse/YV-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[YV-102]: https://emurgo.atlassian.net/browse/YV-102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[YV-118]: https://emurgo.atlassian.net/browse/YV-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ