### PR TITLE
fix(wallet-mobile): Fallback number for missing data in fetchPtPrice

### DIFF
--- a/apps/wallet-mobile/src/yoroi-wallets/cardano/usePrimaryTokenActivity.tsx
+++ b/apps/wallet-mobile/src/yoroi-wallets/cardano/usePrimaryTokenActivity.tsx
@@ -46,8 +46,8 @@ export const usePrimaryTokenActivity = ({
         // NOTE: transformer
         const tickers = response.value.data.tickers
         const ts = tickers[0]?.timestamp ?? 0
-        const close = tickers[0]?.prices[to] ?? 1
-        const open = tickers[1]?.prices[to] ?? 1
+        const close = tickers[0]?.prices[to] ?? 0
+        const open = tickers[1]?.prices[to] ?? 0
         return {
           ts,
           close,


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

Shouldn't happen, because if the whole request fails we use the already fixed default. But just in case we had a response, but the response had an invalid entry, the fallback should also be 0.