### PR TITLE
fix(wallet-mobile): last graph timestamp to match between periods

### DIFF
--- a/apps/wallet-mobile/src/features/Portfolio/common/hooks/useGetPortfolioTokenChart.ts
+++ b/apps/wallet-mobile/src/features/Portfolio/common/hooks/useGetPortfolioTokenChart.ts
@@ -45,7 +45,9 @@ const getTimestamps = (timeInterval: TokenChartInterval) => {
   }[timeInterval ?? TokenChartInterval.DAY]
 
   const step = (now - from) / resolution
-  return Array.from({length: resolution}, (_, i) => from + Math.round(step * i))
+  const spread = Array.from({length: resolution}, (_, i) => from + Math.round(step * i))
+  spread.push(now)
+  return spread
 }
 
 const ptTicker = networkConfigs[Chain.Network.Mainnet].primaryTokenInfo.ticker


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

Due to precision in the steps between periods, the last datapoint is getting slight differences in price based on the period selected. Adding "now" at the end should mitigate it.

[ticket](https://emurgo.atlassian.net/browse/YV-142)