### PR TITLE
fix(wallet-mobile): Critical button color text

### DIFF
--- a/apps/wallet-mobile/src/components/Button/Button.tsx
+++ b/apps/wallet-mobile/src/components/Button/Button.tsx
@@ -96,7 +96,7 @@ const useStyles = ({
       pressed: color.text_primary_max,
       disabled: color.text_primary_min,
     },
-    [ButtonType.Critical]: {idle: color.white_static, pressed: color.white_static, disabled: color.white_static},
+    [ButtonType.Critical]: {idle: color.gray_min, pressed: color.gray_min, disabled: color.gray_min},
     [ButtonType.Text]: {
       idle: color.text_primary_medium,
       pressed: color.text_primary_max,


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

##### Ticket

https://emurgo.atlassian.net/browse/YV-189
Confirmed with design, it was a mistake on the button figma variables https://www.figma.com/design/KeBVo6rWNYFLXwTphz9lHi?node-id=22196-137748#1092419754