### PR TITLE
feat(wallet-mobile): remove trailing zeros from tx list amounts

### DIFF
--- a/apps/wallet-mobile/src/yoroi-wallets/utils/format.test.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/utils/format.test.ts
@@ -37,17 +37,17 @@ describe('formatAda', () => {
 
 describe('formatAdaFractional', () => {
   it('formats zero', () => {
-    expect(formatTokenFractional(asQuantity(0), primaryTokenInfoMainnet)).toEqual('.000000')
+    expect(formatTokenFractional(asQuantity(0), primaryTokenInfoMainnet)).toEqual('')
   })
 
   it('formats positive', () => {
     const tests = [
       ['12', '.000012'],
       ['999999', '.999999'],
-      ['1000000', '.000000'],
+      ['1000000', ''],
       ['1000001', '.000001'],
       ['9999999', '.999999'],
-      ['9999999000000', '.000000'],
+      ['9999999000000', ''],
     ]
     tests.forEach(([ada, formatted]) => {
       expect(formatTokenFractional(asQuantity(ada), primaryTokenInfoMainnet)).toEqual(formatted)
@@ -57,10 +57,10 @@ describe('formatAdaFractional', () => {
     const tests = [
       ['-12', '.000012'],
       ['-999999', '.999999'],
-      ['-1000000', '.000000'],
+      ['-1000000', ''],
       ['-1000001', '.000001'],
       ['-9999999', '.999999'],
-      ['-9999999000000', '.000000'],
+      ['-9999999000000', ''],
     ]
     tests.forEach(([ada, formatted]) => {
       expect(formatTokenFractional(asQuantity(ada), primaryTokenInfoMainnet)).toEqual(formatted)

--- a/apps/wallet-mobile/src/yoroi-wallets/utils/format.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/utils/format.ts
@@ -154,8 +154,11 @@ export const formatTokenFractional = (
   const decimals = 'metadata' in token ? token.metadata.numberOfDecimals : token.decimals
   const normalizationFactor = Math.pow(10, decimals)
   const fractional = new BigNumber(quantity).abs().modulo(normalizationFactor).dividedBy(normalizationFactor)
-  // remove leading '0'
-  return fractional.toFormat(decimals).substring(1)
+  // remove leading '0', and trailing '0's
+  return fractional
+    .toFormat(decimals)
+    .substring(1)
+    .replace(/\.?0+$/, '')
 }
 
 const truncateWithEllipsis = (s: string, n: number) => {

--- a/apps/wallet-mobile/translations/messages/src/yoroi-wallets/utils/format.json
+++ b/apps/wallet-mobile/translations/messages/src/yoroi-wallets/utils/format.json
@@ -4,14 +4,14 @@
     "defaultMessage": "!!!Today",
     "file": "src/yoroi-wallets/utils/format.ts",
     "start": {
-      "line": 242,
+      "line": 245,
       "column": 9,
-      "index": 7708
+      "index": 7764
     },
     "end": {
-      "line": 245,
+      "line": 248,
       "column": 3,
-      "index": 7775
+      "index": 7831
     }
   },
   {
@@ -19,14 +19,14 @@
     "defaultMessage": "!!!Yesterday",
     "file": "src/yoroi-wallets/utils/format.ts",
     "start": {
-      "line": 246,
+      "line": 249,
       "column": 13,
-      "index": 7790
+      "index": 7846
     },
     "end": {
-      "line": 249,
+      "line": 252,
       "column": 3,
-      "index": 7865
+      "index": 7921
     }
   },
   {
@@ -34,14 +34,14 @@
     "defaultMessage": "!!![Unknown asset name]",
     "file": "src/yoroi-wallets/utils/format.ts",
     "start": {
-      "line": 250,
+      "line": 253,
       "column": 20,
-      "index": 7887
+      "index": 7943
     },
     "end": {
-      "line": 253,
+      "line": 256,
       "column": 3,
-      "index": 7980
+      "index": 8036
     }
   }
 ]


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

Simplest change with just the trailing zeros removed for the token amount (not the paired balance subtext) in tx list items (tx history and portfolio token tx list).

The "feature" still needed some defining for the rest of the amounts in the app.

##### Ticket

https://emurgo.atlassian.net/browse/YV-132

![image](https://github.com/user-attachments/assets/8288ded3-5b40-4d1a-b917-c2206538a130)
