### PR TITLE
fix(wallet-mobile): Discover apps failing

### DIFF
--- a/apps/wallet-mobile/src/features/Discover/useCases/SelectDappFromList/SelectDappFromListScreen.tsx
+++ b/apps/wallet-mobile/src/features/Discover/useCases/SelectDappFromList/SelectDappFromListScreen.tsx
@@ -77,7 +77,7 @@ export const SelectDappFromListScreen = () => {
 
   return (
     <>
-      <WelcomeDAppModal />
+      <WelcomeDAppModal disabled={isShowedWelcomeDApp} />
 
       <ShowDisclaimer type="dapps" disabled={!isShowedWelcomeDApp} />
 

--- a/apps/wallet-mobile/src/features/Discover/useCases/SelectDappFromList/WelcomeDAppModal.tsx
+++ b/apps/wallet-mobile/src/features/Discover/useCases/SelectDappFromList/WelcomeDAppModal.tsx
@@ -9,15 +9,15 @@ import {useModal} from '../../../../components/Modal/ModalContext'
 import {useShowWelcomeDApp} from '../../common/useShowWelcomeDApp'
 import {useStrings} from '../../common/useStrings'
 
-export const WelcomeDAppModal = () => {
+export const WelcomeDAppModal = ({disabled}: {disabled?: boolean}) => {
   const strings = useStrings()
   const {styles} = useStyles()
   const insets = useSafeAreaInsets()
   const {openModal, closeModal} = useModal()
-  const {isShowedWelcomeDApp, setShowedWelcomeDApp, loadingGetShowedWelcomeDApp} = useShowWelcomeDApp()
+  const {setShowedWelcomeDApp, loadingGetShowedWelcomeDApp} = useShowWelcomeDApp()
 
   React.useEffect(() => {
-    if (loadingGetShowedWelcomeDApp || isShowedWelcomeDApp) return
+    if (disabled || loadingGetShowedWelcomeDApp) return
 
     openModal({
       title: strings.welcomeToYoroiDAppExplorer,
@@ -34,8 +34,8 @@ export const WelcomeDAppModal = () => {
     setShowedWelcomeDApp()
   }, [
     closeModal,
+    disabled,
     insets.bottom,
-    isShowedWelcomeDApp,
     loadingGetShowedWelcomeDApp,
     openModal,
     setShowedWelcomeDApp,


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

@rahulnr7 could you double check that the Welcome to dapps feature modal shows the first time, and then the disclaimer for using a third party shows up, and then after both are accepted, the feature works?

##### Ticket

https://emurgo.atlassian.net/browse/YV-225