### PR TITLE
chore(types): Use new @yoroi/types version

### DIFF
--- a/apps/wallet-mobile/package.json
+++ b/apps/wallet-mobile/package.json
@@ -266,7 +266,7 @@
     "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.32.0",
-    "@yoroi/types": "1.5.9",
+    "@yoroi/types": "1.5.10",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^29.2.1",
     "babel-loader": "8.2.2",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -148,7 +148,7 @@
     "@types/jest": "^29.5.12",
     "@types/react": "^18.2.55",
     "@types/react-test-renderer": "^18.0.7",
-    "@yoroi/types": "1.5.9",
+    "@yoroi/types": "1.5.10",
     "axios": "^1.5.0",
     "axios-mock-adapter": "^1.21.5",
     "commitlint": "^17.0.2",

--- a/packages/claim/package.json
+++ b/packages/claim/package.json
@@ -154,7 +154,7 @@
     "@types/react-test-renderer": "^18.0.7",
     "@yoroi/common": "^1.5.4",
     "@yoroi/portfolio": "1.0.3",
-    "@yoroi/types": "1.5.9",
+    "@yoroi/types": "1.5.10",
     "bignumber.js": "^9.0.1",
     "commitlint": "^17.0.2",
     "del-cli": "^5.0.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -146,7 +146,7 @@
     "@types/jest": "^29.5.12",
     "@types/react": "^18.2.55",
     "@types/react-test-renderer": "^18.0.7",
-    "@yoroi/types": "1.5.9",
+    "@yoroi/types": "1.5.10",
     "axios": "^1.5.0",
     "axios-mock-adapter": "^1.21.5",
     "bignumber.js": "^9.0.1",

--- a/packages/dapp-connector/package.json
+++ b/packages/dapp-connector/package.json
@@ -155,7 +155,7 @@
     "@types/jest": "^29.5.12",
     "@types/react": "^18.2.55",
     "@types/react-test-renderer": "^18.0.7",
-    "@yoroi/types": "1.5.9",
+    "@yoroi/types": "1.5.10",
     "axios-mock-adapter": "^1.21.5",
     "bignumber.js": "^9.0.1",
     "commitlint": "^17.0.2",

--- a/packages/exchange/package.json
+++ b/packages/exchange/package.json
@@ -139,7 +139,7 @@
     "@types/jest": "^29.5.12",
     "@types/react": "^18.2.55",
     "@types/react-test-renderer": "^18.0.7",
-    "@yoroi/types": "1.5.9",
+    "@yoroi/types": "1.5.10",
     "axios": "^1.5.0",
     "commitlint": "^17.0.2",
     "del-cli": "^5.0.0",

--- a/packages/explorers/package.json
+++ b/packages/explorers/package.json
@@ -144,7 +144,7 @@
     "@types/jest": "^29.5.12",
     "@types/react": "^18.2.55",
     "@types/react-test-renderer": "^18.0.7",
-    "@yoroi/types": "1.5.9",
+    "@yoroi/types": "1.5.10",
     "bignumber.js": "^9.0.1",
     "commitlint": "^17.0.2",
     "del-cli": "^5.0.0",

--- a/packages/links/package.json
+++ b/packages/links/package.json
@@ -147,7 +147,7 @@
     "@types/jest": "^29.5.12",
     "@types/react": "^18.2.55",
     "@types/react-test-renderer": "^18.0.7",
-    "@yoroi/types": "1.5.9",
+    "@yoroi/types": "1.5.10",
     "commitlint": "^17.0.2",
     "del-cli": "^5.0.0",
     "dependency-cruiser": "^13.1.1",

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -144,7 +144,7 @@
     "@types/react": "^18.2.55",
     "@types/react-test-renderer": "^18.0.7",
     "@yoroi/common": "1.5.4",
-    "@yoroi/types": "1.5.9",
+    "@yoroi/types": "1.5.10",
     "axios": "^1.5.0",
     "axios-mock-adapter": "^1.21.5",
     "commitlint": "^17.0.2",

--- a/packages/portfolio/package.json
+++ b/packages/portfolio/package.json
@@ -145,7 +145,7 @@
     "@types/jest": "^29.5.12",
     "@types/react": "^18.2.55",
     "@types/react-test-renderer": "^18.0.7",
-    "@yoroi/types": "1.5.9",
+    "@yoroi/types": "1.5.10",
     "bignumber.js": "^9.0.1",
     "commitlint": "^17.0.2",
     "del-cli": "^5.0.0",

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -154,7 +154,7 @@
     "@types/jest": "^29.5.12",
     "@types/react": "^18.2.55",
     "@types/react-test-renderer": "^18.0.7",
-    "@yoroi/types": "1.5.9",
+    "@yoroi/types": "1.5.10",
     "axios": "^1.5.0",
     "commitlint": "^17.0.2",
     "del-cli": "^5.0.0",

--- a/packages/setup-wallet/package.json
+++ b/packages/setup-wallet/package.json
@@ -140,7 +140,7 @@
     "@types/jest": "^29.5.12",
     "@types/react": "^18.2.55",
     "@types/react-test-renderer": "^18.0.7",
-    "@yoroi/types": "1.5.9",
+    "@yoroi/types": "1.5.10",
     "commitlint": "^17.0.2",
     "del-cli": "^5.0.0",
     "dependency-cruiser": "^13.1.1",
@@ -162,7 +162,7 @@
     "typescript": "^5.3.3"
   },
   "peerDependencies": {
-    "@yoroi/types": "1.5.9",
+    "@yoroi/types": "1.5.10",
     "immer": "^10.0.2",
     "react": ">= 16.8.0 <= 19.0.0",
     "react-query": "^3.39.3"

--- a/packages/staking/package.json
+++ b/packages/staking/package.json
@@ -149,7 +149,7 @@
     "@types/react": "^18.2.55",
     "@types/react-test-renderer": "^18.0.7",
     "@yoroi/common": "1.5.4",
-    "@yoroi/types": "1.5.9",
+    "@yoroi/types": "1.5.10",
     "axios": "^1.5.0",
     "axios-mock-adapter": "^1.21.5",
     "commitlint": "^17.0.2",

--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -151,7 +151,7 @@
     "@yoroi/api": "1.5.3",
     "@yoroi/common": "1.5.4",
     "@yoroi/portfolio": "1.0.3",
-    "@yoroi/types": "1.5.9",
+    "@yoroi/types": "1.5.10",
     "bignumber.js": "^9.0.1",
     "commitlint": "^17.0.2",
     "del-cli": "^5.0.0",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -141,7 +141,7 @@
     "@types/react": "^18.2.55",
     "@types/react-test-renderer": "^18.0.7",
     "@yoroi/common": "^1.5.4",
-    "@yoroi/types": "1.5.9",
+    "@yoroi/types": "1.5.10",
     "axios-mock-adapter": "^1.21.5",
     "commitlint": "^17.0.2",
     "del-cli": "^5.0.0",

--- a/packages/transfer/package.json
+++ b/packages/transfer/package.json
@@ -139,7 +139,7 @@
     "@types/react": "^18.2.55",
     "@types/react-test-renderer": "^18.0.7",
     "@yoroi/portfolio": "1.0.3",
-    "@yoroi/types": "1.5.9",
+    "@yoroi/types": "1.5.10",
     "commitlint": "^17.0.2",
     "del-cli": "^5.0.0",
     "dependency-cruiser": "^13.1.1",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoroi/types",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "description": "The Yoroi Types package of Yoroi SDK",
   "keywords": [
     "yoroi",


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

The types of notifications have changed since version 1.5.9 so a new version is needed in order to integrate this library on extension

##### Ticket

[YV-207](https://emurgo.atlassian.net/browse/YV-207)


[YV-207]: https://emurgo.atlassian.net/browse/YV-207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ