### PR TITLE
fix(wallet-mobile): Wait for selected wallet only sync to create notifications

### DIFF
--- a/apps/wallet-mobile/src/features/Notifications/useCases/NotificationUIHandler.tsx
+++ b/apps/wallet-mobile/src/features/Notifications/useCases/NotificationUIHandler.tsx
@@ -64,7 +64,7 @@ const useCollectNewNotifications = ({enabled}: {enabled: boolean}) => {
     return () => {
       subscription.unsubscribe()
     }
-  }, [manager, setEvents, selectedWalletId, enabled, isWalletSelectionScreen])
+  }, [manager, setEvents, selectedWalletId, enabled, isWalletSelectionScreen, walletManager.selected.network])
 
   const removeEvent = (id: number) => {
     setEvents((e) => e.filter((ev) => ev.id !== id))

--- a/apps/wallet-mobile/src/features/Notifications/useCases/NotificationUIHandler.tsx
+++ b/apps/wallet-mobile/src/features/Notifications/useCases/NotificationUIHandler.tsx
@@ -68,7 +68,15 @@ const useCollectNewNotifications = ({enabled}: {enabled: boolean}) => {
     return () => {
       subscription.unsubscribe()
     }
-  }, [manager, setEvents, selectedWalletId, enabled, isWalletSelectionScreen, isTxHistoryScreen, walletManager.selected.network])
+  }, [
+    manager,
+    setEvents,
+    selectedWalletId,
+    enabled,
+    isWalletSelectionScreen,
+    isTxHistoryScreen,
+    walletManager.selected.network,
+  ])
 
   const removeEvent = (id: number) => {
     setEvents((e) => e.filter((ev) => ev.id !== id))

--- a/apps/wallet-mobile/src/features/Notifications/useCases/common/transaction-received-notification.ts
+++ b/apps/wallet-mobile/src/features/Notifications/useCases/common/transaction-received-notification.ts
@@ -5,6 +5,7 @@ import {Subject} from 'rxjs'
 
 import {YoroiWallet} from '../../../../yoroi-wallets/cardano/types'
 import {TRANSACTION_DIRECTION} from '../../../../yoroi-wallets/types/other'
+import {SyncWalletInfo} from '../../../WalletManager/common/types'
 import {useWalletManager} from '../../../WalletManager/context/WalletManagerProvider'
 import {walletManager} from '../../../WalletManager/wallet-manager'
 import {generateNotificationId} from './notifications'
@@ -15,10 +16,10 @@ const storageKey = 'transaction-received-notification-history'
 type BuildNotificationsParams = {
   appStorage: App.Storage
   sinceDate: Date
+  walletIds: string[]
 }
 
-const buildNotifications = async ({appStorage, sinceDate}: BuildNotificationsParams) => {
-  const walletIds = [...walletManager.walletMetas.keys()]
+const buildNotifications = async ({appStorage, sinceDate, walletIds}: BuildNotificationsParams) => {
   const notifications: NotificationTypes.TransactionReceivedEvent[] = []
 
   for (const walletId of walletIds) {
@@ -87,22 +88,29 @@ export const transactionReceivedSubject = new Subject<NotificationTypes.Transact
 export const useTransactionReceivedNotifications = ({enabled}: {enabled: boolean}) => {
   const {walletManager} = useWalletManager()
   const asyncStorage = useAsyncStorage()
+  const walletId = walletManager.selectedWalledId
 
   React.useEffect(() => {
-    if (!enabled) return
+    if (!enabled || !walletId) return
     const subscriptionBeginDate = new Date()
+    let latestStatuses: Map<string, SyncWalletInfo> = new Map()
     const subscription = walletManager.syncWalletInfos$.subscribe(async (status) => {
-      const walletInfos = Array.from(status.values())
-      const walletsDoneSyncing = walletInfos.filter((info) => info.status === 'done')
-      const areAllDone = walletsDoneSyncing.length === walletInfos.length
-      if (!areAllDone) return
+      const selectedWalletOldStatus = latestStatuses.get(walletId)
+      const selectedWalletCurrentStatus = status.get(walletId)
+      latestStatuses = status
 
-      const notifications = await buildNotifications({appStorage: asyncStorage, sinceDate: subscriptionBeginDate})
-      notifications.forEach((notification) => transactionReceivedSubject.next(notification))
+      if (selectedWalletOldStatus?.status !== 'done' && selectedWalletCurrentStatus?.status === 'done') {
+        const notifications = await buildNotifications({
+          appStorage: asyncStorage,
+          sinceDate: subscriptionBeginDate,
+          walletIds: [walletId],
+        })
+        notifications.forEach((notification) => transactionReceivedSubject.next(notification))
+      }
     })
 
     return () => {
       subscription.unsubscribe()
     }
-  }, [walletManager, asyncStorage, enabled])
+  }, [walletManager, asyncStorage, enabled, walletId, walletManager.selectedNetwork])
 }


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

Wait for selected wallet only sync to create notifications

##### Ticket

[YV-238](https://emurgo.atlassian.net/browse/YV-238)


[YV-238]: https://emurgo.atlassian.net/browse/YV-238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ