### PR TITLE
fix(wallet-mobile): Fix route path comparison for TX history screen

### DIFF
--- a/apps/wallet-mobile/src/kernel/navigation.tsx
+++ b/apps/wallet-mobile/src/kernel/navigation.tsx
@@ -10,6 +10,7 @@ import {Dimensions, Platform, TouchableOpacity, TouchableOpacityProps, View} fro
 import {Icon} from '../components/Icon'
 import {OnConfirm} from '../features/ReviewTx/common/hooks/useOnConfirm'
 import {Routes as StakingGovernanceRoutes} from '../features/Staking/Governance/common/navigation'
+import {compareArrays} from '../yoroi-wallets/utils/utils'
 
 // prettier-ignore
 export const useUnsafeParams = <Params, >() => {
@@ -668,11 +669,8 @@ export const isWalletSelectionRoute = (state: Partial<NavigationState> | Navigat
 
 export const isTxHistoryRoute = (state: Partial<NavigationState> | NavigationState['routes'][0]['state']) => {
   const routes = getFocusedRouteName(state)
-
-  const historyListRouteName: keyof TxHistoryRoutes = 'history-list'
-  const mainHistoryRouteName: keyof WalletTabRoutes = 'history'
-
-  const lastRouteName = routes[routes.length - 1]
-
-  return lastRouteName === historyListRouteName || lastRouteName === mainHistoryRouteName
+  type RoutePath = keyof AppRoutes | keyof WalletStackRoutes | keyof WalletTabRoutes | keyof TxHistoryRoutes
+  const fullRoutePath: RoutePath[] = ['manage-wallets', 'main-wallet-routes', 'history', 'history-list']
+  const pathToCompare = fullRoutePath.slice(0, routes.length)
+  return routes.length > 1 && compareArrays(pathToCompare, routes)
 }


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

Fix route path comparison for TX history screen

##### Ticket

[YV-237](https://emurgo.atlassian.net/browse/YV-237)


[YV-237]: https://emurgo.atlassian.net/browse/YV-237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ