### PR TITLE
fix(wallet-mobile): Do not break app on swap config error, safe to ignore

### DIFF
--- a/apps/wallet-mobile/src/features/Swap/common/useSwapConfig.ts
+++ b/apps/wallet-mobile/src/features/Swap/common/useSwapConfig.ts
@@ -8,6 +8,7 @@ export const useSwapConfig = () => {
   const getSwapConfig = getSwapConfigApiMaker()
   const query = useQuery({
     suspense: true,
+    useErrorBoundary: false,
     queryKey: ['useSwapConfig'],
     queryFn: () => getSwapConfig(),
   })


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)
Additionally requested the file to have a non breaking value, but still app should just ignore the error
