### PR TITLE
fix(wallet-mobile): Do not display notifications for intrawallet transactions

### DIFF
--- a/apps/wallet-mobile/src/features/Notifications/useCases/common/transaction-received-notification.ts
+++ b/apps/wallet-mobile/src/features/Notifications/useCases/common/transaction-received-notification.ts
@@ -47,9 +47,8 @@ const buildNotifications = async ({appStorage, sinceDate, walletIds}: BuildNotif
     newTxIds.forEach((id) => {
       const txDate = wallet.transactions[id].submittedAt ?? new Date().toISOString()
       const isReceived = wallet.transactions[id].direction === TRANSACTION_DIRECTION.RECEIVED
-      const isIntraWallet = wallet.transactions[id].direction === TRANSACTION_DIRECTION.SELF
       const isConfirmedAfterDeadline = new Date(txDate).getTime() > sinceDate.getTime()
-      const shouldBeDisplayed = (isReceived || isIntraWallet) && isConfirmedAfterDeadline
+      const shouldBeDisplayed = isReceived && isConfirmedAfterDeadline
       if (!shouldBeDisplayed) return
       const metadata: NotificationTypes.TransactionReceivedEvent['metadata'] = {
         txId: id,


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

Do not display notifications for intrawallet transactions

##### Ticket

[YV-294](https://emurgo.atlassian.net/browse/YV-294)


[YV-294]: https://emurgo.atlassian.net/browse/YV-294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ