### PR TITLE
chore(banners): Only show DRep promotion on mainnet

### DIFF
--- a/apps/wallet-mobile/src/features/Banners/useCases/ConsiderDRepToUsGovernanceBanner.tsx
+++ b/apps/wallet-mobile/src/features/Banners/useCases/ConsiderDRepToUsGovernanceBanner.tsx
@@ -5,16 +5,21 @@ import * as React from 'react'
 import {StyleSheet} from 'react-native'
 
 import {useGovernanceStatus} from '../../Staking/Governance/common/helpers'
+import {useSelectedWallet} from '../../WalletManager/common/hooks/useSelectedWallet'
 import {DelegateToYoroiDRepBanner} from '../common/DelegateToYoroiDRepBanner/DelegateToYoroiDRepBanner'
 
 export const ConsiderDRepToUsGovernanceBanner = () => {
   const {styles} = useStyles()
+  const {
+    wallet: {isMainnet},
+  } = useSelectedWallet()
 
   const action = useGovernanceStatus({suspense: true, refetchOnMount: true})
 
   const isVisible = shouldShowDrep2usOnGovernance({
     yoroiDRepIdHex: GOVERNANCE_YOROI_DREP_ID_HEX,
     currentDRepIdHex: action?.kind === 'delegate' && action.type === 'key' ? action.hash : '',
+    isMainnet,
   })
 
   return <DelegateToYoroiDRepBanner style={styles.root} isVisible={isVisible} />

--- a/apps/wallet-mobile/src/features/Banners/useCases/ConsiderDRepToUsStakingCenterBanner.tsx
+++ b/apps/wallet-mobile/src/features/Banners/useCases/ConsiderDRepToUsStakingCenterBanner.tsx
@@ -28,6 +28,7 @@ export const ConsiderDRepToUsStakingCenterBanner = () => {
     currentDRepIdHex: action?.kind === 'delegate' && action.type === 'key' ? action.hash : '',
     isStaking: hasStakingKeyRegistered,
     dismissedAt,
+    isMainnet: wallet.isMainnet,
   })
 
   return <DelegateToYoroiDRepBanner style={styles.root} onDismiss={dismiss} isVisible={isVisible} />

--- a/apps/wallet-mobile/src/features/Banners/useCases/ConsiderDRepToUsTxHistoryBanner.tsx
+++ b/apps/wallet-mobile/src/features/Banners/useCases/ConsiderDRepToUsTxHistoryBanner.tsx
@@ -34,6 +34,7 @@ export const ConsiderDRepToUsTxHistoryBanner = () => {
     dismissedAt,
     ptBalance: balance.quantity,
     ptMinBalance: BigInt(minBalanceToDisplayBanner) * BigInt(10 ** ptDecimals),
+    isMainnet: wallet.isMainnet,
   })
 
   return <DelegateToYoroiDRepBanner style={styles.root} onDismiss={dismiss} isVisible={isVisible} />

--- a/packages/banners/src/helpers/should-show-drep2us-on-governance.test.ts
+++ b/packages/banners/src/helpers/should-show-drep2us-on-governance.test.ts
@@ -1,23 +1,21 @@
 import {shouldShowDrep2usOnGovernance} from './should-show-drep2us-on-governance'
 
 describe('shouldShowDrep2usOnGovernance', () => {
-  it('should return true if the currentDRepIdHex is different from the yoroiDRepIdHex', () => {
-    const currentDRepIdHex = 'DE'
-    const yoroiDRepIdHex = 'AD'
-    const result = shouldShowDrep2usOnGovernance({
-      currentDRepIdHex,
-      yoroiDRepIdHex,
-    })
-    expect(result).toBe(true)
-  })
-
-  it('should return false if the currentDRepIdHex is the same as the yoroiDRepIdHex', () => {
-    const currentDRepIdHex = 'AD'
-    const yoroiDRepIdHex = 'AD'
-    const result = shouldShowDrep2usOnGovernance({
-      currentDRepIdHex,
-      yoroiDRepIdHex,
-    })
-    expect(result).toBe(false)
-  })
+  it.each`
+    currentDRepIdHex | yoroiDRepIdHex | isMainnet | expected
+    ${'DE'}          | ${'AD'}        | ${true}   | ${true}
+    ${'AD'}          | ${'AD'}        | ${true}   | ${false}
+    ${'DE'}          | ${'AD'}        | ${false}  | ${false}
+    ${'AD'}          | ${'AD'}        | ${false}  | ${false}
+  `(
+    'should return $expected when currentDRepIdHex is $currentDRepIdHex, yoroiDRepIdHex is $yoroiDRepIdHex and isMainnet is $isMainnet',
+    ({currentDRepIdHex, yoroiDRepIdHex, isMainnet, expected}) => {
+      const result = shouldShowDrep2usOnGovernance({
+        currentDRepIdHex,
+        yoroiDRepIdHex,
+        isMainnet,
+      })
+      expect(result).toBe(expected)
+    },
+  )
 })

--- a/packages/banners/src/helpers/should-show-drep2us-on-governance.ts
+++ b/packages/banners/src/helpers/should-show-drep2us-on-governance.ts
@@ -1,9 +1,11 @@
 export const shouldShowDrep2usOnGovernance = ({
   currentDRepIdHex,
   yoroiDRepIdHex,
+  isMainnet,
 }: Readonly<{
   currentDRepIdHex: string
   yoroiDRepIdHex: string
+  isMainnet: boolean
 }>) => {
-  return currentDRepIdHex !== yoroiDRepIdHex
+  return currentDRepIdHex !== yoroiDRepIdHex && isMainnet
 }

--- a/packages/banners/src/helpers/should-show-drep2us-on-staking-center.test.ts
+++ b/packages/banners/src/helpers/should-show-drep2us-on-staking-center.test.ts
@@ -7,19 +7,31 @@ describe('shouldShowDRep2UsOnStakingCenter', () => {
   const lessThanOneSecondAgo = Date.now() - time.oneSecond
 
   it.each`
-    isStaking | currentDRepIdHex | yoroiDRepIdHex | dismissedAt             | expected
-    ${true}   | ${'DE'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${true}
-    ${false}  | ${'DE'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${false}
-    ${true}   | ${'DE'}          | ${'AD'}        | ${lessThanOneSecondAgo} | ${false}
-    ${true}   | ${'AD'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${false}
+    isStaking | currentDRepIdHex | yoroiDRepIdHex | dismissedAt             | isMainnet | expected
+    ${true}   | ${'DE'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${true}   | ${true}
+    ${false}  | ${'DE'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${true}   | ${false}
+    ${true}   | ${'DE'}          | ${'AD'}        | ${lessThanOneSecondAgo} | ${true}   | ${false}
+    ${true}   | ${'AD'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${true}   | ${false}
+    ${true}   | ${'DE'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${false}  | ${false}
+    ${false}  | ${'DE'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${false}  | ${false}
+    ${true}   | ${'DE'}          | ${'AD'}        | ${lessThanOneSecondAgo} | ${false}  | ${false}
+    ${true}   | ${'AD'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${false}  | ${false}
   `(
-    'returns $expected when isStaking is $isStaking, currentDRepId is $currentDRepId, yoroiDRep is $yoroiDRepId, and dismissedAt is $dismissedAt',
-    ({isStaking, currentDRepIdHex, yoroiDRepIdHex, dismissedAt, expected}) => {
+    'returns $expected when isStaking is $isStaking, currentDRepId is $currentDRepId, yoroiDRep is $yoroiDRepId, isMainnet is $isMainnet, and dismissedAt is $dismissedAt',
+    ({
+      isStaking,
+      currentDRepIdHex,
+      yoroiDRepIdHex,
+      dismissedAt,
+      isMainnet,
+      expected,
+    }) => {
       const result = shouldShowDRep2UsOnStakingCenter({
         isStaking,
         currentDRepIdHex,
         yoroiDRepIdHex,
         dismissedAt,
+        isMainnet,
       })
       expect(result).toBe(expected)
     },

--- a/packages/banners/src/helpers/should-show-drep2us-on-staking-center.ts
+++ b/packages/banners/src/helpers/should-show-drep2us-on-staking-center.ts
@@ -5,13 +5,15 @@ export const shouldShowDRep2UsOnStakingCenter = ({
   currentDRepIdHex,
   yoroiDRepIdHex,
   dismissedAt,
+  isMainnet,
 }: Readonly<{
   isStaking: boolean
   currentDRepIdHex: string
   yoroiDRepIdHex: string
   dismissedAt: number
+  isMainnet: boolean
 }>) => {
   const isYoroiDRep = currentDRepIdHex === yoroiDRepIdHex
   const hasBeenThirtyDays = dismissedAt + time.oneMonth < Date.now()
-  return !isYoroiDRep && hasBeenThirtyDays && isStaking
+  return !isYoroiDRep && hasBeenThirtyDays && isStaking && isMainnet
 }

--- a/packages/banners/src/helpers/should-show-drep2us-on-tx-history.test.ts
+++ b/packages/banners/src/helpers/should-show-drep2us-on-tx-history.test.ts
@@ -9,17 +9,25 @@ describe('shouldShowDRep2UsOnTxHistory', () => {
   const notEnoughBalance = 4_999_999n
 
   it.each`
-    isStaking | currentDRepIdHex | yoroiDRepIdHex | dismissedAt             | ptBalance           | expected
-    ${true}   | ${'DE'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${enoughBalance}    | ${true}
-    ${false}  | ${'DE'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${enoughBalance}    | ${false}
-    ${true}   | ${'DE'}          | ${'AD'}        | ${lessThanOneSecondAgo} | ${enoughBalance}    | ${false}
-    ${true}   | ${'AD'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${enoughBalance}    | ${false}
-    ${true}   | ${'DE'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${notEnoughBalance} | ${false}
-    ${false}  | ${'DE'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${notEnoughBalance} | ${false}
-    ${true}   | ${'DE'}          | ${'AD'}        | ${lessThanOneSecondAgo} | ${notEnoughBalance} | ${false}
-    ${true}   | ${'AD'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${notEnoughBalance} | ${false}
+    isStaking | currentDRepIdHex | yoroiDRepIdHex | dismissedAt             | ptBalance           | isMainnet | expected
+    ${true}   | ${'DE'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${enoughBalance}    | ${true}   | ${true}
+    ${false}  | ${'DE'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${enoughBalance}    | ${true}   | ${false}
+    ${true}   | ${'DE'}          | ${'AD'}        | ${lessThanOneSecondAgo} | ${enoughBalance}    | ${true}   | ${false}
+    ${true}   | ${'AD'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${enoughBalance}    | ${true}   | ${false}
+    ${true}   | ${'DE'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${notEnoughBalance} | ${true}   | ${false}
+    ${false}  | ${'DE'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${notEnoughBalance} | ${true}   | ${false}
+    ${true}   | ${'DE'}          | ${'AD'}        | ${lessThanOneSecondAgo} | ${notEnoughBalance} | ${true}   | ${false}
+    ${true}   | ${'AD'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${notEnoughBalance} | ${true}   | ${false}
+    ${true}   | ${'DE'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${enoughBalance}    | ${false}  | ${false}
+    ${false}  | ${'DE'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${enoughBalance}    | ${false}  | ${false}
+    ${true}   | ${'DE'}          | ${'AD'}        | ${lessThanOneSecondAgo} | ${enoughBalance}    | ${false}  | ${false}
+    ${true}   | ${'AD'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${enoughBalance}    | ${false}  | ${false}
+    ${true}   | ${'DE'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${notEnoughBalance} | ${false}  | ${false}
+    ${false}  | ${'DE'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${notEnoughBalance} | ${false}  | ${false}
+    ${true}   | ${'DE'}          | ${'AD'}        | ${lessThanOneSecondAgo} | ${notEnoughBalance} | ${false}  | ${false}
+    ${true}   | ${'AD'}          | ${'AD'}        | ${moreThanOneMonthAgo}  | ${notEnoughBalance} | ${false}  | ${false}
   `(
-    'returns $expected when isStaking is $isStaking, currentDRepId is $currentDRepId, yoroiDRep is $yoroiDRepId, ptBalance is $ptBalance, and dismissedAt is $dismissedAt',
+    'returns $expected when isStaking is $isStaking, currentDRepId is $currentDRepId, yoroiDRep is $yoroiDRepId, ptBalance is $ptBalance, isMainnet is $isMainnet and dismissedAt is $dismissedAt',
     ({
       isStaking,
       currentDRepIdHex,
@@ -27,6 +35,7 @@ describe('shouldShowDRep2UsOnTxHistory', () => {
       dismissedAt,
       ptBalance,
       expected,
+      isMainnet,
     }) => {
       const result = shouldShowDRep2UsOnTxHistory({
         isStaking,
@@ -35,6 +44,7 @@ describe('shouldShowDRep2UsOnTxHistory', () => {
         dismissedAt,
         ptBalance,
         ptMinBalance: enoughBalance,
+        isMainnet,
       })
       expect(result).toBe(expected)
     },

--- a/packages/banners/src/helpers/should-show-drep2us-on-tx-history.ts
+++ b/packages/banners/src/helpers/should-show-drep2us-on-tx-history.ts
@@ -7,6 +7,7 @@ export const shouldShowDRep2UsOnTxHistory = ({
   dismissedAt,
   ptBalance,
   ptMinBalance,
+  isMainnet,
 }: Readonly<{
   isStaking: boolean
   currentDRepIdHex: string
@@ -14,9 +15,16 @@ export const shouldShowDRep2UsOnTxHistory = ({
   dismissedAt: number
   ptBalance: bigint
   ptMinBalance: bigint
+  isMainnet: boolean
 }>) => {
   const isYoroiDRep = currentDRepIdHex === yoroiDRepIdHex
   const hasBeenThirtyDays = dismissedAt + time.oneMonth < Date.now()
   const hasEnoughBalance = ptBalance >= ptMinBalance
-  return !isYoroiDRep && hasBeenThirtyDays && isStaking && hasEnoughBalance
+  return (
+    !isYoroiDRep &&
+    hasBeenThirtyDays &&
+    isStaking &&
+    hasEnoughBalance &&
+    isMainnet
+  )
 }


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

Since there is not DRep for the testnets it will hide the DRep promotion for them and only show on mainnet.