### PR TITLE
WIP fix(wallet-mobile): Make keyboard respect the app theme on the notification duration screen

### DIFF
--- a/apps/wallet-mobile/src/features/Settings/useCases/changeWalletSettings/ManageNotificationDisplayDuration/ManageNotificationDisplayDurationScreen.tsx
+++ b/apps/wallet-mobile/src/features/Settings/useCases/changeWalletSettings/ManageNotificationDisplayDuration/ManageNotificationDisplayDurationScreen.tsx
@@ -48,6 +48,7 @@ export const ManageNotificationDisplayDurationScreen = () => {
   const selectedChoice = getChoiceById(selectedChoiceId)
   const defaultInputValue = savedChoice.id === 'Manual' ? formatNumber(config.displayDuration) : ''
   const [inputValue, setInputValue] = React.useState(defaultInputValue)
+  const {isDark} = useTheme()
 
   const isSelectedChoiceManual = selectedChoiceId === 'Manual'
   const isInputEnabled = isSelectedChoiceManual
@@ -109,6 +110,7 @@ export const ManageNotificationDisplayDurationScreen = () => {
               right={<Text style={styles.percentLabel}>{strings.seconds}</Text>}
               error={shouldDisplayError}
               errorText={shouldDisplayError ? strings.inputError : undefined}
+              keyboardAppearance={isDark ? 'dark' : 'light'}
             />
           </View>
         </ScrollView>


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

Make keyboard respect the app theme on the notification duration screen

##### Ticket

[YV-301](https://emurgo.atlassian.net/browse/YV-301)


[YV-301]: https://emurgo.atlassian.net/browse/YV-301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ