### PR TITLE
chore(wallet-mobile): Refactor wallet transactions getters

### DIFF
--- a/apps/wallet-mobile/src/yoroi-wallets/cardano/cardano-wallet.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/cardano/cardano-wallet.ts
@@ -1039,8 +1039,12 @@ export const makeCardanoWallet = (networkManager: Network.Manager, implementatio
       return false
     }
 
+    private _getUtxos = defaultMemoize((utxos: RawUtxo[], collateralId: string) => {
+      return collateralId ? utxos.filter((utxo) => utxo.utxo_id !== collateralId) : utxos
+    })
+
     get utxos() {
-      return this._utxos.filter((utxo) => utxo.utxo_id !== this._collateralId)
+      return this._getUtxos(this._utxos, this._collateralId)
     }
 
     get allUtxos() {

--- a/apps/wallet-mobile/src/yoroi-wallets/cardano/cardano-wallet.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/cardano/cardano-wallet.ts
@@ -1040,7 +1040,7 @@ export const makeCardanoWallet = (networkManager: Network.Manager, implementatio
     }
 
     private _getUtxos = defaultMemoize((utxos: RawUtxo[], collateralId: string) => {
-      return collateralId ? utxos.filter((utxo) => utxo.utxo_id !== collateralId) : utxos
+      return collateralId.length > 0 ? utxos.filter((utxo) => utxo.utxo_id !== collateralId) : utxos
     })
 
     get utxos() {

--- a/apps/wallet-mobile/src/yoroi-wallets/cardano/cardano-wallet.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/cardano/cardano-wallet.ts
@@ -1214,7 +1214,7 @@ const parseTransactions = (
 ) => {
   const addresses =
     rewardAddressHex != ''
-      ? [...internalAddresses, ...externalAddresses, ...[rewardAddressHex]]
+      ? [...internalAddresses, ...externalAddresses, rewardAddressHex]
       : [...internalAddresses, ...externalAddresses]
 
   return _.mapValues(transactions, (tx: Transaction) => {

--- a/apps/wallet-mobile/src/yoroi-wallets/cardano/cardano-wallet.ts
+++ b/apps/wallet-mobile/src/yoroi-wallets/cardano/cardano-wallet.ts
@@ -1135,17 +1135,16 @@ export const makeCardanoWallet = (networkManager: Network.Manager, implementatio
 
     get transactions() {
       const memos = this.memosManager.getMemos()
-      return _.mapValues(this.transactionManager.transactions, (tx: Transaction) => {
-        return processTxHistoryData(
-          tx,
-          this.rewardAddressHex != ''
-            ? [...this.internalAddresses, ...this.externalAddresses, ...[this.rewardAddressHex]]
-            : [...this.internalAddresses, ...this.externalAddresses],
-          this.confirmationCounts[tx.id] || 0,
-          memos[tx.id] ?? null,
-          this.portfolioPrimaryTokenInfo,
-        )
-      })
+
+      return parseTransactionsMemoized(
+        memos,
+        this.internalAddresses,
+        this.externalAddresses,
+        this.rewardAddressHex,
+        this.confirmationCounts,
+        this.transactionManager.transactions,
+        this.portfolioPrimaryTokenInfo,
+      )
     }
 
     get confirmationCounts() {
@@ -1203,3 +1202,24 @@ const toHex = (bytes: Uint8Array) => Buffer.from(bytes).toString('hex')
 const isNonEmpty = (arr: unknown[] | undefined) => {
   return arr && arr.length > 0
 }
+
+const parseTransactions = (
+  memos: Record<string, string>,
+  internalAddresses: string[],
+  externalAddresses: string[],
+  rewardAddressHex: string,
+  confirmationCounts: Record<string, number | null>,
+  transactions: TransactionManager['transactions'],
+  primaryTokenInfo: Portfolio.Token.Info,
+) => {
+  const addresses =
+    rewardAddressHex != ''
+      ? [...internalAddresses, ...externalAddresses, ...[rewardAddressHex]]
+      : [...internalAddresses, ...externalAddresses]
+
+  return _.mapValues(transactions, (tx: Transaction) => {
+    return processTxHistoryData(tx, addresses, confirmationCounts[tx.id] || 0, memos[tx.id] ?? null, primaryTokenInfo)
+  })
+}
+
+const parseTransactionsMemoized = defaultMemoize(parseTransactions)


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

When working on the notifications feature I noticed that whenever we access the `wallet.transactions` we re-parse the metadata which slows down the app considerably. The refactoring of some getters in Yoroi wallet should lead to better performance.
