### PR TITLE
fix(wallet-mobile): ReviewTX onConfirm handleError

### DIFF
--- a/apps/wallet-mobile/src/features/ReviewTx/common/hooks/useOnConfirm.tsx
+++ b/apps/wallet-mobile/src/features/ReviewTx/common/hooks/useOnConfirm.tsx
@@ -101,6 +101,7 @@ export const useOnConfirm = ({
             await submitTx(cbor, rootKey, wallet, meta)
           } catch (e) {
             handleOnError(e)
+            return
           }
         }
 


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

Without the return, we're calling onError AND onSuccess, so user always ends up on success page.