### PR TITLE
fix(wallet-mobile): Fix notification permission setting

### DIFF
--- a/apps/wallet-mobile/src/features/Notifications/common/tools.ts
+++ b/apps/wallet-mobile/src/features/Notifications/common/tools.ts
@@ -2,6 +2,10 @@ import messaging from '@react-native-firebase/messaging'
 import {PermissionsAndroid, Platform} from 'react-native'
 import {Notifications} from 'react-native-notifications'
 
+import {uiStorage} from './storage'
+
+const permissionModalStorageKey = 'triggerredNotificationsPermissionModal'
+
 export const triggerNotificationsPermissionModal = async () => {
   // Triggers iOS permission request
   Notifications.registerRemoteNotifications({})
@@ -10,9 +14,16 @@ export const triggerNotificationsPermissionModal = async () => {
   if (Platform.OS === 'android') {
     await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS)
   }
+
+  await uiStorage.setItem(permissionModalStorageKey, true)
 }
 
-export const hasAuthorizedNotifications = async () => {
-  const status = await messaging().requestPermission()
-  return status === messaging.AuthorizationStatus.AUTHORIZED
+export const getNotificationsAuthorizationStatus = async () => {
+  const status = await messaging().hasPermission()
+  const isAuthorized = status === messaging.AuthorizationStatus.AUTHORIZED
+  const isUndetermined =
+    status === messaging.AuthorizationStatus.NOT_DETERMINED ||
+    (await uiStorage.getItem(permissionModalStorageKey)) !== true
+
+  return isAuthorized ? 'authorized' : isUndetermined ? 'not_determined' : 'denied'
 }

--- a/apps/wallet-mobile/src/features/Notifications/common/tools.ts
+++ b/apps/wallet-mobile/src/features/Notifications/common/tools.ts
@@ -4,7 +4,7 @@ import {Notifications} from 'react-native-notifications'
 
 import {uiStorage} from './storage'
 
-const permissionModalStorageKey = 'triggerredNotificationsPermissionModal'
+const permissionModalStorageKey = 'triggeredNotificationsPermissionModal'
 
 export const triggerNotificationsPermissionModal = async () => {
   // Triggers iOS permission request

--- a/apps/wallet-mobile/src/features/Notifications/common/tools.ts
+++ b/apps/wallet-mobile/src/features/Notifications/common/tools.ts
@@ -20,10 +20,10 @@ export const triggerNotificationsPermissionModal = async () => {
 
 export const getNotificationsAuthorizationStatus = async () => {
   const status = await messaging().hasPermission()
+  const modalNeverTriggered = (await uiStorage.getItem(permissionModalStorageKey)) !== true
+
   const isAuthorized = status === messaging.AuthorizationStatus.AUTHORIZED
-  const isUndetermined =
-    status === messaging.AuthorizationStatus.NOT_DETERMINED ||
-    (await uiStorage.getItem(permissionModalStorageKey)) !== true
+  const isUndetermined = status === messaging.AuthorizationStatus.NOT_DETERMINED || modalNeverTriggered
 
   return isAuthorized ? 'authorized' : isUndetermined ? 'not_determined' : 'denied'
 }

--- a/apps/wallet-mobile/src/features/Notifications/common/tools.ts
+++ b/apps/wallet-mobile/src/features/Notifications/common/tools.ts
@@ -22,8 +22,17 @@ export const getNotificationsAuthorizationStatus = async () => {
   const status = await messaging().hasPermission()
   const modalNeverTriggered = (await uiStorage.getItem(permissionModalStorageKey)) !== true
 
-  const isAuthorized = status === messaging.AuthorizationStatus.AUTHORIZED
-  const isUndetermined = status === messaging.AuthorizationStatus.NOT_DETERMINED || modalNeverTriggered
+  if (status === messaging.AuthorizationStatus.AUTHORIZED) {
+    return 'authorized'
+  }
 
-  return isAuthorized ? 'authorized' : isUndetermined ? 'not_determined' : 'denied'
+  if (status === messaging.AuthorizationStatus.DENIED) {
+    return 'denied'
+  }
+
+  if (status === messaging.AuthorizationStatus.NOT_DETERMINED || modalNeverTriggered) {
+    return 'not_determined'
+  }
+
+  return 'denied'
 }

--- a/apps/wallet-mobile/src/features/Settings/useCases/changeWalletSettings/ManageNotifications/ManageNotificationSettings/ManageNotificationSettings.tsx
+++ b/apps/wallet-mobile/src/features/Settings/useCases/changeWalletSettings/ManageNotifications/ManageNotificationSettings/ManageNotificationSettings.tsx
@@ -1,4 +1,3 @@
-import messaging from '@react-native-firebase/messaging'
 import {useTheme} from '@yoroi/theme'
 import React from 'react'
 import {AppState, Linking, Platform, ScrollView, StyleSheet, View} from 'react-native'
@@ -11,7 +10,7 @@ import {Text} from '../../../../../../components/Text'
 import {useMetrics} from '../../../../../../kernel/metrics/metricsManager'
 import {useWalletNavigation} from '../../../../../../kernel/navigation'
 import {
-  hasAuthorizedNotifications,
+  getNotificationsAuthorizationStatus,
   triggerNotificationsPermissionModal,
 } from '../../../../../Notifications/common/tools'
 import {SettingsSwitch} from '../../../../common/SettingsSwitch'
@@ -54,10 +53,10 @@ export const ManageNotificationSettings = () => {
 }
 
 export function useNotificationPermission() {
-  const [hasPermission, setHasPermission] = React.useState<boolean | null>(null)
+  const [permission, setPermission] = React.useState<'authorized' | 'not_determined' | 'denied'>('not_determined')
 
   React.useEffect(() => {
-    const handleAppStateChange = async () => setHasPermission(await hasAuthorizedNotifications())
+    const handleAppStateChange = async () => setPermission(await getNotificationsAuthorizationStatus())
     const subscription = AppState.addEventListener('change', handleAppStateChange)
 
     return () => {
@@ -66,20 +65,21 @@ export function useNotificationPermission() {
   }, [])
 
   React.useEffect(() => {
-    const fetchPermission = async () => setHasPermission(await hasAuthorizedNotifications())
+    const fetchPermission = async () => setPermission(await getNotificationsAuthorizationStatus())
 
     fetchPermission()
   }, [])
 
   const togglePermissions = async () => {
-    const oldStatus = await messaging().requestPermission()
-    if (oldStatus === messaging.AuthorizationStatus.NOT_DETERMINED) {
+    const oldStatus = await getNotificationsAuthorizationStatus()
+
+    if (oldStatus === 'not_determined') {
       await triggerNotificationsPermissionModal()
     } else {
       await navigateToAppSettings()
     }
 
-    setHasPermission(await hasAuthorizedNotifications())
+    setPermission(await getNotificationsAuthorizationStatus())
   }
 
   const navigateToAppSettings = async () => {
@@ -90,19 +90,19 @@ export function useNotificationPermission() {
     }
   }
 
-  return {hasPermission, togglePermissions}
+  return {permission, togglePermissions}
 }
 
 const PushNotificationSettingsItem = () => {
   const {styles} = useStyles()
   const strings = useStrings()
 
-  const {hasPermission, togglePermissions} = useNotificationPermission()
+  const {permission, togglePermissions} = useNotificationPermission()
 
-  if (hasPermission) {
+  if (permission === 'authorized' || permission === 'not_determined') {
     return (
       <SettingsItem icon={<Icon.Bell {...styles.icon} />} label={strings.pushNotifications}>
-        <SettingsSwitch value={true} onValueChange={togglePermissions} />
+        <SettingsSwitch value={permission === 'authorized'} onValueChange={togglePermissions} />
       </SettingsItem>
     )
   }


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

Fix notification permission setting

##### Ticket

[YV-400](https://emurgo.atlassian.net/browse/YV-400)


[YV-400]: https://emurgo.atlassian.net/browse/YV-400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved notification permission handling with clearer status indicators: 'authorized', 'not_determined', or 'denied'.
- **Refactor**
  - Unified notification permission logic for a more consistent user experience.
  - Updated settings interface to reflect the new permission status options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->