### PR TITLE
feat(wallet-mobile): Add notification press action support

### DIFF
--- a/apps/wallet-mobile/src/features/Notifications/common/hooks.ts
+++ b/apps/wallet-mobile/src/features/Notifications/common/hooks.ts
@@ -7,17 +7,19 @@ import {Notifications} from 'react-native-notifications'
 
 import {logger} from '../../../kernel/logger/logger'
 import {pushNotificationsManager} from './notification-manager'
-import {generateNotificationId, parseNotificationId} from './notifications'
+import {parseNotificationId} from './notifications'
 import {usePrimaryTokenPriceChangedNotification} from './primary-token-price-changed-notification'
 import {useRewardsUpdatedNotifications} from './rewards-updated-notification'
+import {triggerNotificationAction} from './tools'
 import {useTransactionReceivedNotifications} from './transaction-received-notification'
 
-const initPushNotifications = (manager: YoroiNotifications.Manager) => {
+const initPushNotifications = () => {
   const unsubscribeFromForegroundMessage = messaging().onMessage((remoteMessage) => {
     const {notification} = remoteMessage
 
     if (notification && isString(notification.title) && isString(notification.body)) {
       const pushNotification = createPushNotification({
+        id: remoteMessage.sentTime ?? 0,
         title: notification.title,
         description: notification.body,
         data: remoteMessage.data,
@@ -30,9 +32,9 @@ const initPushNotifications = (manager: YoroiNotifications.Manager) => {
 
   const notificationOpenedSubscription = Notifications.events().registerNotificationOpened(
     (notification, completion) => {
-      const payloadId = notification.identifier || notification.payload.id
+      const payloadId = notification.payload['google.sent_time']
       const id = parseNotificationId(payloadId)
-      manager.events.markAsRead(id)
+      triggerNotificationAction(pushNotificationsManager, id)
       completion()
     },
   )
@@ -58,7 +60,7 @@ type UseInitNotificationsProps = {
 export const useInitNotifications = ({localEnabled, pushEnabled}: UseInitNotificationsProps) => {
   const manager = useNotificationManager()
   React.useEffect(() => (localEnabled ? initLocalNotifications(manager) : undefined), [localEnabled, manager])
-  React.useEffect(() => (pushEnabled ? initPushNotifications(manager) : undefined), [pushEnabled, manager])
+  React.useEffect(() => (pushEnabled ? initPushNotifications() : undefined), [pushEnabled, manager])
   useTransactionReceivedNotifications({enabled: localEnabled})
   usePrimaryTokenPriceChangedNotification({enabled: false}) // Temporarily disabled until requested by product team
   useRewardsUpdatedNotifications({enabled: localEnabled})
@@ -70,6 +72,7 @@ messaging().setBackgroundMessageHandler((remoteMessage) => {
     // Automatically shown by the OS
     pushNotificationsManager.events.push(
       createPushNotification({
+        id: remoteMessage.sentTime ?? 0,
         title: remoteNotification.title,
         description: remoteNotification.body,
         data: remoteMessage.data,
@@ -83,11 +86,12 @@ messaging().setBackgroundMessageHandler((remoteMessage) => {
 const createPushNotification = (options: {
   title: string
   description: string
+  id: number
   data?: Record<string, unknown>
 }): NotificationTypes.PushEvent => {
-  const {title, description, data} = options
+  const {title, description, data, id} = options
   return {
-    id: generateNotificationId(),
+    id,
     date: new Date().toISOString(),
     isRead: false,
     trigger: NotificationTypes.Trigger.Push,

--- a/apps/wallet-mobile/src/features/Notifications/common/tools.ts
+++ b/apps/wallet-mobile/src/features/Notifications/common/tools.ts
@@ -1,5 +1,7 @@
 import messaging from '@react-native-firebase/messaging'
-import {PermissionsAndroid, Platform} from 'react-native'
+import {isRecord, isString} from '@yoroi/common'
+import {Notifications as YoroiNotifications} from '@yoroi/types'
+import {Linking, PermissionsAndroid, Platform} from 'react-native'
 import {Notifications} from 'react-native-notifications'
 
 import {uiStorage} from './storage'
@@ -35,4 +37,19 @@ export const getNotificationsAuthorizationStatus = async () => {
   }
 
   return 'denied'
+}
+
+export const triggerNotificationAction = async (manager: YoroiNotifications.Manager, id: number) => {
+  const allEvents = await manager.events.read()
+  const event = allEvents.find((e) => e.id === id)
+  if (!event) return
+
+  await manager.events.markAsRead(id)
+
+  if (event.trigger === YoroiNotifications.Trigger.Push && isRecord(event.metadata.data)) {
+    const {data} = event.metadata
+    if (isString(data.action) && data.action === 'open_url' && isString(data.url)) {
+      await Linking.openURL(data.url)
+    }
+  }
 }

--- a/apps/wallet-mobile/src/features/Notifications/useCases/ViewNotificationHistory/ViewNotificationHistoryScreen.tsx
+++ b/apps/wallet-mobile/src/features/Notifications/useCases/ViewNotificationHistory/ViewNotificationHistoryScreen.tsx
@@ -14,6 +14,7 @@ import {Text} from '../../../../components/Text'
 import {useLanguage} from '../../../../kernel/i18n'
 import {useTransactionInfos} from '../../../../yoroi-wallets/hooks'
 import {useSelectedWallet} from '../../../WalletManager/common/hooks/useSelectedWallet'
+import {triggerNotificationAction} from '../../common/tools'
 import {
   getTransactionReceivedNotificationIcon,
   getTransactionReceivedNotificationTitle,
@@ -33,8 +34,8 @@ export const ViewNotificationHistoryScreen = () => {
     refetch()
   }
 
-  const handleMarkNotificationAsRead = async (id: number) => {
-    await manager.events.markAsRead(id)
+  const handlePressNotification = async (id: number) => {
+    await triggerNotificationAction(manager, id)
     refetch()
   }
 
@@ -56,7 +57,7 @@ export const ViewNotificationHistoryScreen = () => {
             <NotificationItem
               key={notification.id}
               event={notification}
-              onPress={() => handleMarkNotificationAsRead(notification.id)}
+              onPress={() => handlePressNotification(notification.id)}
             />
           ))}
         </View>


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

Add notification press action support
<img width="916" alt="Screenshot 2025-04-17 at 10 38 46" src="https://github.com/user-attachments/assets/9fdc5df3-6820-48f3-a1a6-205e719a7eca" />


https://github.com/user-attachments/assets/4ed10ba8-c71d-4900-90a8-bf980378197a


##### Ticket

[YV-394](https://emurgo.atlassian.net/browse/YV-394)


[YV-394]: https://emurgo.atlassian.net/browse/YV-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved notification handling by centralizing notification actions, such as marking as read or opening URLs, when a notification is pressed or opened.
- **Refactor**
  - Unified notification ID handling for consistency across the app.
  - Updated notification action logic to use a global manager and a new action handler for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->