### PR TITLE
fix(wallet-mobile): Update wanted price per protocol changed

### DIFF
--- a/apps/wallet-mobile/src/features/Swap/common/SwapProvider.tsx
+++ b/apps/wallet-mobile/src/features/Swap/common/SwapProvider.tsx
@@ -135,7 +135,7 @@ export const SwapProvider = ({children}: {children: React.ReactNode}) => {
     }
 
     const wantedPrice = limitOptions?.wantedPrice
-    if (wantedPrice !== undefined && wantedPrice > 0)
+    if (wantedPrice !== undefined && wantedPrice > 0 && state.selectedProtocol.value === limitOptions?.defaultProtocol)
       action({type: 'WantedPriceInputChanged', value: String(wantedPrice)})
   }, [
     limitOptions?.defaultProtocol,

--- a/apps/wallet-mobile/src/features/Swap/useCases/CreateOrder/SelectProtocolScreen.tsx
+++ b/apps/wallet-mobile/src/features/Swap/useCases/CreateOrder/SelectProtocolScreen.tsx
@@ -43,6 +43,7 @@ export const SelectProtocolScreen = () => {
         renderItem={({item}) => (
           <TouchableOpacity
             onPress={() => {
+              swapForm.action({type: 'WantedPriceInputChanged', value: String(item.initialPrice)})
               swapForm.action({type: 'ProtocolSelected', value: item.protocol})
               navigation.goBack()
             }}


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

Slight behavior change after discussion with product.

##### Ticket

https://emurgo.atlassian.net/browse/YV-405

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - When selecting a protocol in the swap order process, the initial price for the selected protocol is now automatically populated.
- **Bug Fixes**
  - Improved accuracy of wanted price updates by ensuring they are only triggered when the selected protocol matches the default protocol option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->