### PR TITLE
chore(wallet-mobile): wait for storage before showing anything

### DIFF
--- a/apps/wallet-mobile/src/features/Staking/Governance/useCases/Home/HomeScreen.tsx
+++ b/apps/wallet-mobile/src/features/Staking/Governance/useCases/Home/HomeScreen.tsx
@@ -50,7 +50,7 @@ export const HomeScreen = () => {
 
   useWalletEvent(wallet, 'utxos', refetchStakingKeyState)
 
-  const {data: lastSubmittedTx} = useLatestGovernanceAction(wallet.id)
+  const {data: lastSubmittedTx, isLoading} = useLatestGovernanceAction(wallet.id)
 
   const submittedTxId = lastSubmittedTx?.txID
 
@@ -64,6 +64,8 @@ export const HomeScreen = () => {
   }, [isTxPending, submittedTxId, refetchStakingKeyState, setIsPendingRefetchAfterTxConfirmation])
 
   const txPendingDisplayed = isTxPending || isPendingRefetchAfterTxConfirmation
+
+  if (isLoading) return null
 
   if (txPendingDisplayed && isNonNullable(lastSubmittedTx)) {
     if (lastSubmittedTx.kind === 'delegate-to-drep') {


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

Couldn't reproduce the issue, but this is the only thing looking at the code that might make sense from the description. Loading is from storage so should be fast enough not to need a spinner, but still avoid a flash from another state while waiting.

##### Ticket

https://emurgo.atlassian.net/browse/YV-417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved loading behavior on the Governance Home screen by hiding the UI until the latest governance action data has finished loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->