### PR TITLE
fix(theme): dropped BasePalette from export index

### DIFF
--- a/apps/wallet-mobile/.storybook/storybook.requires.js
+++ b/apps/wallet-mobile/.storybook/storybook.requires.js
@@ -103,7 +103,6 @@ const getStories = () => {
     "./src/features/Claim/illustrations/Ilustrations.stories.tsx": require("../src/features/Claim/illustrations/Ilustrations.stories.tsx"),
     "./src/features/Claim/useCases/AskConfirmation.stories.tsx": require("../src/features/Claim/useCases/AskConfirmation.stories.tsx"),
     "./src/features/Claim/useCases/ShowSuccessScreen.stories.tsx": require("../src/features/Claim/useCases/ShowSuccessScreen.stories.tsx"),
-    "./src/features/Dev/Palettes.stories.tsx": require("../src/features/Dev/Palettes.stories.tsx"),
     "./src/features/Discover/common/ConfirmConnectionModal.stories.tsx": require("../src/features/Discover/common/ConfirmConnectionModal.stories.tsx"),
     "./src/features/Discover/common/LabelCategoryDApp.stories.tsx": require("../src/features/Discover/common/LabelCategoryDApp.stories.tsx"),
     "./src/features/Discover/common/LabelConnected.stories.tsx": require("../src/features/Discover/common/LabelConnected.stories.tsx"),

--- a/apps/wallet-mobile/package.json
+++ b/apps/wallet-mobile/package.json
@@ -141,7 +141,7 @@
     "@yoroi/setup-wallet": "2.0.0",
     "@yoroi/staking": "2.0.0",
     "@yoroi/swap": "2.1.0",
-    "@yoroi/theme": "3.0.1",
+    "@yoroi/theme": "3.0.2",
     "@yoroi/transfer": "2.0.0",
     "add": "2.0.6",
     "axios": "^1.5.0",

--- a/apps/wallet-mobile/src/features/Dev/Palettes.stories.tsx
+++ b/apps/wallet-mobile/src/features/Dev/Palettes.stories.tsx
@@ -1,7 +1,0 @@
-import {storiesOf} from '@storybook/react-native'
-import {StorybookBasePalette} from '@yoroi/theme'
-import React from 'react'
-
-storiesOf('Theme Palettes', module).add('base', () => {
-  return <StorybookBasePalette />
-})

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoroi/theme",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "The theme package of Yoroi",
   "keywords": [
     "yoroi",

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -9,4 +9,3 @@ export * from './atoms/atoms'
 export * from './tokens/tokens'
 export * from './adapters/mmkv-storage/theme-storage-maker'
 export * from './helpers/detect-theme'
-

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -10,4 +10,3 @@ export * from './tokens/tokens'
 export * from './adapters/mmkv-storage/theme-storage-maker'
 export * from './helpers/detect-theme'
 
-export * from './storybook/BasePalette'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the @yoroi/theme package version to 3.0.2.
  - Removed the theme palette preview from the mobile wallet's developer stories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->