### PR TITLE
feat(wallet-mobile, notifications): Adds notification for buy ada and remove banners

### DIFF
--- a/apps/wallet-mobile/src/features/Exchange/common/ShowBuyBanner/ShowBuyBanner.tsx
+++ b/apps/wallet-mobile/src/features/Exchange/common/ShowBuyBanner/ShowBuyBanner.tsx
@@ -51,6 +51,9 @@ export const ShowBuyBanner = () => {
 export const useBuyBannerNotification = () => {
   const {wallet} = useSelectedWallet()
   const manager = useNotificationManager()
+  const {
+    selected: {network},
+  } = useWalletManager()
 
   const strings = useStrings()
 
@@ -59,18 +62,27 @@ export const useBuyBannerNotification = () => {
   const hasZeroPt = Quantities.isZero(primaryAmount.quantity)
 
   useQuery({
-    queryKey: ['buyCryptoBanner', wallet?.id],
+    queryKey: ['buyCryptoBanner', wallet?.id, network],
     staleTime: time.oneHour,
     queryFn: () => {
       if (hasZeroPt) {
-        showBanner({
-          id: BannerIds.BuyCrypto,
-          title: strings.needMoreCrypto,
-          body: strings.ourTrustedPartners,
-        })
+        if (network === Chain.Network.Preprod) {
+          showBanner({
+            id: BannerIds.TestAda,
+            title: strings.preprodFaucetBannerTitle,
+            body: strings.preprodFaucetBannerText,
+          })
+        } else {
+          showBanner({
+            id: BannerIds.BuyCrypto,
+            title: strings.needMoreCrypto,
+            body: strings.ourTrustedPartners,
+          })
+        }
         return true
       } else {
         manager.events.remove(BannerIds.BuyCrypto)
+        manager.events.remove(BannerIds.TestAda)
         return false
       }
     },

--- a/apps/wallet-mobile/src/features/Exchange/common/ShowBuyBanner/ShowBuyBanner.tsx
+++ b/apps/wallet-mobile/src/features/Exchange/common/ShowBuyBanner/ShowBuyBanner.tsx
@@ -1,4 +1,5 @@
 import {time} from '@yoroi/common'
+import {useNotificationManager} from '@yoroi/notifications'
 import {Chain} from '@yoroi/types'
 import _ from 'lodash'
 import * as React from 'react'
@@ -7,7 +8,7 @@ import {useQuery} from 'react-query'
 
 import {useBalances, useTransactionInfos} from '../../../../yoroi-wallets/hooks'
 import {Amounts, Quantities} from '../../../../yoroi-wallets/utils/utils'
-import {bannerIds, triggerBanner} from '../../../Notifications/common/banner-triggers'
+import {BannerIds, showBanner} from '../../../Notifications/common/show-banners'
 import {useSelectedWallet} from '../../../WalletManager/common/hooks/useSelectedWallet'
 import {useWalletManager} from '../../../WalletManager/context/WalletManagerProvider'
 import {useResetShowBuyBannerSmall} from '../useResetShowBuyBannerSmall'
@@ -49,6 +50,8 @@ export const ShowBuyBanner = () => {
 
 export const useBuyBannerNotification = () => {
   const {wallet} = useSelectedWallet()
+  const manager = useNotificationManager()
+
   const strings = useStrings()
 
   const balances = useBalances(wallet)
@@ -56,18 +59,20 @@ export const useBuyBannerNotification = () => {
   const hasZeroPt = Quantities.isZero(primaryAmount.quantity)
 
   useQuery({
-    queryKey: ['buyBanner', wallet?.id],
-    staleTime: time.hours(1),
+    queryKey: ['buyCryptoBanner', wallet?.id],
+    staleTime: time.oneHour,
     queryFn: () => {
       if (hasZeroPt) {
-        triggerBanner({
-          id: bannerIds.buyCryptoBanner,
+        showBanner({
+          id: BannerIds.BuyCrypto,
           title: strings.needMoreCrypto,
           body: strings.ourTrustedPartners,
         })
         return true
+      } else {
+        manager.events.remove(BannerIds.BuyCrypto)
+        return false
       }
-      return false
     },
   })
 }

--- a/apps/wallet-mobile/src/features/Exchange/common/ShowBuyBanner/ShowBuyBanner.tsx
+++ b/apps/wallet-mobile/src/features/Exchange/common/ShowBuyBanner/ShowBuyBanner.tsx
@@ -1,3 +1,4 @@
+import {time} from '@yoroi/common'
 import {Chain} from '@yoroi/types'
 import _ from 'lodash'
 import * as React from 'react'
@@ -56,6 +57,7 @@ export const useBuyBannerNotification = () => {
 
   useQuery({
     queryKey: ['buyBanner', wallet?.id],
+    staleTime: time.hours(1),
     queryFn: () => {
       if (hasZeroPt) {
         triggerBanner({
@@ -63,7 +65,9 @@ export const useBuyBannerNotification = () => {
           title: strings.needMoreCrypto,
           body: strings.ourTrustedPartners,
         })
+        return true
       }
+      return false
     },
   })
 }

--- a/apps/wallet-mobile/src/features/Exchange/common/ShowBuyBanner/ShowBuyBanner.tsx
+++ b/apps/wallet-mobile/src/features/Exchange/common/ShowBuyBanner/ShowBuyBanner.tsx
@@ -2,13 +2,16 @@ import {Chain} from '@yoroi/types'
 import _ from 'lodash'
 import * as React from 'react'
 import {View} from 'react-native'
+import {useQuery} from 'react-query'
 
 import {useBalances, useTransactionInfos} from '../../../../yoroi-wallets/hooks'
 import {Amounts, Quantities} from '../../../../yoroi-wallets/utils/utils'
+import {bannerIds, triggerBanner} from '../../../Notifications/common/banner-triggers'
 import {useSelectedWallet} from '../../../WalletManager/common/hooks/useSelectedWallet'
 import {useWalletManager} from '../../../WalletManager/context/WalletManagerProvider'
 import {useResetShowBuyBannerSmall} from '../useResetShowBuyBannerSmall'
 import {useShowBuyBannerSmall} from '../useShowBuyBannerSmall'
+import {useStrings} from '../useStrings'
 import {BuyBannerBig} from './BuyBannerBig'
 import {BuyBannerSmall} from './BuyBannerSmall'
 import {PreprodFaucetBanner} from './PreprodFaucetBanner'
@@ -41,4 +44,26 @@ export const ShowBuyBanner = () => {
   }
 
   return banner ? <View style={{paddingBottom: 18}}>{banner}</View> : null
+}
+
+export const useBuyBannerNotification = () => {
+  const {wallet} = useSelectedWallet()
+  const strings = useStrings()
+
+  const balances = useBalances(wallet)
+  const primaryAmount = Amounts.getAmount(balances, wallet.portfolioPrimaryTokenInfo.id)
+  const hasZeroPt = Quantities.isZero(primaryAmount.quantity)
+
+  useQuery({
+    queryKey: ['buyBanner', wallet?.id],
+    queryFn: () => {
+      if (hasZeroPt) {
+        triggerBanner({
+          id: bannerIds.buyCryptoBanner,
+          title: strings.needMoreCrypto,
+          body: strings.ourTrustedPartners,
+        })
+      }
+    },
+  })
 }

--- a/apps/wallet-mobile/src/features/Notifications/common/NotificationPopup.tsx
+++ b/apps/wallet-mobile/src/features/Notifications/common/NotificationPopup.tsx
@@ -9,6 +9,7 @@ import {IconProps} from '../../../components/Icon/type'
 import {useMetrics} from '../../../kernel/metrics/metricsManager'
 import {useWalletNavigation} from '../../../kernel/navigation'
 import {NotificationItem} from './NotificationPopupItem'
+import {BannerIds} from './show-banners'
 import {SwipeOutWrapper} from './SwipeOutWrapper'
 import {TransactionReceivedNotificationPopup} from './TransactionReceivedNotificationPopup'
 import {useStrings} from './useStrings'
@@ -69,7 +70,9 @@ export const NotificationPopup = ({event, onPress, onCancel, onExpired}: Props) 
 
     if (event.trigger === Notifications.Trigger.Banner) {
       track.inAppNotificationOpened()
-      navigation.navigateToExchange()
+      if (event.id === BannerIds.BuyCrypto || event.id === BannerIds.TestAda) {
+        navigation.navigateToExchange()
+      }
     }
   }
 

--- a/apps/wallet-mobile/src/features/Notifications/common/NotificationPopup.tsx
+++ b/apps/wallet-mobile/src/features/Notifications/common/NotificationPopup.tsx
@@ -5,6 +5,7 @@ import {StyleSheet, View} from 'react-native'
 import Svg, {ClipPath, Defs, G, Path, Rect} from 'react-native-svg'
 
 import {Icon} from '../../../components/Icon'
+import {IconProps} from '../../../components/Icon/type'
 import {useMetrics} from '../../../kernel/metrics/metricsManager'
 import {useWalletNavigation} from '../../../kernel/navigation'
 import {NotificationItem} from './NotificationPopupItem'
@@ -43,6 +44,10 @@ export const NotificationPopup = ({event, onPress, onCancel, onExpired}: Props) 
     if (event.trigger === Notifications.Trigger.RewardsUpdated) {
       track.inAppNotificationClosed({type: 'staking_rewards'})
     }
+
+    if (event.trigger === Notifications.Trigger.Banner) {
+      track.inAppNotificationClosed({type: 'banner'})
+    }
   }
 
   const handleOnPress = () => {
@@ -59,6 +64,11 @@ export const NotificationPopup = ({event, onPress, onCancel, onExpired}: Props) 
 
     if (event.trigger === Notifications.Trigger.RewardsUpdated) {
       track.inAppNotificationOpened({type: 'staking_rewards'})
+      navigation.navigateToStakingDashboard()
+    }
+
+    if (event.trigger === Notifications.Trigger.Banner) {
+      track.inAppNotificationOpened()
       navigation.navigateToStakingDashboard()
     }
   }
@@ -79,9 +89,22 @@ export const NotificationPopup = ({event, onPress, onCancel, onExpired}: Props) 
       <SwipeOutWrapper onSwipeOut={handleOnSwipeOut} onExpired={onExpired} onPress={handleOnPress}>
         <NotificationItem
           onPress={handleOnPress}
-          icon={<RewardsUpdatedIcon />}
+          icon={<ColoredIcon icon={Icon.Staking} />}
           title={strings.stakingRewardsReceived}
           description={strings.tapToView}
+        />
+      </SwipeOutWrapper>
+    )
+  }
+
+  if (event.trigger === Notifications.Trigger.Banner) {
+    return (
+      <SwipeOutWrapper onSwipeOut={handleOnSwipeOut} onExpired={onExpired} onPress={handleOnPress}>
+        <NotificationItem
+          onPress={handleOnPress}
+          icon={<ColoredIcon icon={Icon.Exchange} />}
+          title={event.metadata.title}
+          description={event.metadata.body}
         />
       </SwipeOutWrapper>
     )
@@ -124,11 +147,12 @@ const PushNotificationIcon = () => {
   )
 }
 
-const RewardsUpdatedIcon = () => {
+const ColoredIcon = (props: {icon: (p: IconProps) => React.JSX.Element}) => {
   const {styles, colors} = useStyles()
+  const Icon = props.icon
   return (
     <View style={[styles.icon, {backgroundColor: colors.iconBackground}]}>
-      <Icon.Staking color={colors.iconColor} />
+      <Icon color={colors.iconColor} />
     </View>
   )
 }

--- a/apps/wallet-mobile/src/features/Notifications/common/NotificationPopup.tsx
+++ b/apps/wallet-mobile/src/features/Notifications/common/NotificationPopup.tsx
@@ -69,7 +69,7 @@ export const NotificationPopup = ({event, onPress, onCancel, onExpired}: Props) 
 
     if (event.trigger === Notifications.Trigger.Banner) {
       track.inAppNotificationOpened()
-      navigation.navigateToStakingDashboard()
+      navigation.navigateToExchange()
     }
   }
 

--- a/apps/wallet-mobile/src/features/Notifications/common/NotificationPopupItem.tsx
+++ b/apps/wallet-mobile/src/features/Notifications/common/NotificationPopupItem.tsx
@@ -31,7 +31,6 @@ const useStyles = () => {
   const styles = StyleSheet.create({
     container: {
       flex: 1,
-      height: 76,
       borderRadius: 6,
       ...atoms.p_lg,
       ...atoms.gap_lg,
@@ -45,6 +44,7 @@ const useStyles = () => {
       shadowRadius: 20,
     },
     content: {
+      ...atoms.flex_1,
       ...atoms.flex_col,
       ...atoms.gap_xs,
     },
@@ -54,7 +54,6 @@ const useStyles = () => {
     },
     description: {
       ...atoms.link_2_md,
-      color: color.gray_600,
     },
   })
 

--- a/apps/wallet-mobile/src/features/Notifications/common/banner-triggers.ts
+++ b/apps/wallet-mobile/src/features/Notifications/common/banner-triggers.ts
@@ -1,0 +1,21 @@
+import {Notifications as NotificationTypes} from '@yoroi/types'
+import {Subject} from 'rxjs'
+
+export const bannerTriggersSubject = new Subject<NotificationTypes.BannerEvent>()
+
+export const triggerBanner = (params: {id: number; title: string; body: string}) => {
+  bannerTriggersSubject.next({
+    trigger: NotificationTypes.Trigger.Banner,
+    id: params.id,
+    date: new Date().toISOString(),
+    isRead: false,
+    metadata: {
+      title: params.title,
+      body: params.body,
+    },
+  })
+}
+
+export const bannerIds = {
+  buyCryptoBanner: 23478934728,
+} as const

--- a/apps/wallet-mobile/src/features/Notifications/common/notification-manager.ts
+++ b/apps/wallet-mobile/src/features/Notifications/common/notification-manager.ts
@@ -3,6 +3,7 @@ import {Notifications} from '@yoroi/types'
 import * as React from 'react'
 
 import {useWalletManager} from '../../WalletManager/context/WalletManagerProvider'
+import {bannerTriggersSubject} from './banner-triggers'
 import {primaryTokenPriceChangedSubject} from './primary-token-price-changed-notification'
 import {rewardsUpdatedSubject} from './rewards-updated-notification'
 import {configStorage, eventsStorage} from './storage'
@@ -25,6 +26,7 @@ export const useNotificationManagerMaker = () => {
           [Notifications.Trigger.TransactionReceived]: transactionReceivedSubject,
           [Notifications.Trigger.PrimaryTokenPriceChanged]: primaryTokenPriceChangedSubject,
           [Notifications.Trigger.RewardsUpdated]: rewardsUpdatedSubject,
+          [Notifications.Trigger.Banner]: bannerTriggersSubject,
         },
       }),
     [walletId],

--- a/apps/wallet-mobile/src/features/Notifications/common/notification-manager.ts
+++ b/apps/wallet-mobile/src/features/Notifications/common/notification-manager.ts
@@ -3,9 +3,9 @@ import {Notifications} from '@yoroi/types'
 import * as React from 'react'
 
 import {useWalletManager} from '../../WalletManager/context/WalletManagerProvider'
-import {bannerTriggersSubject} from './banner-triggers'
 import {primaryTokenPriceChangedSubject} from './primary-token-price-changed-notification'
 import {rewardsUpdatedSubject} from './rewards-updated-notification'
+import {bannerTriggersSubject} from './show-banners'
 import {configStorage, eventsStorage} from './storage'
 import {transactionReceivedSubject} from './transaction-received-notification'
 

--- a/apps/wallet-mobile/src/features/Notifications/common/show-banners.ts
+++ b/apps/wallet-mobile/src/features/Notifications/common/show-banners.ts
@@ -24,4 +24,5 @@ export const showBanner = ({id, title, body}: BannerProps) => {
 
 export const BannerIds = {
   BuyCrypto: 23478934728,
+  TestAda: 234682356,
 } as const

--- a/apps/wallet-mobile/src/features/Notifications/common/show-banners.ts
+++ b/apps/wallet-mobile/src/features/Notifications/common/show-banners.ts
@@ -3,19 +3,25 @@ import {Subject} from 'rxjs'
 
 export const bannerTriggersSubject = new Subject<NotificationTypes.BannerEvent>()
 
-export const triggerBanner = (params: {id: number; title: string; body: string}) => {
+type BannerProps = {
+  id: number
+  title: string
+  body: string
+}
+
+export const showBanner = ({id, title, body}: BannerProps) => {
   bannerTriggersSubject.next({
     trigger: NotificationTypes.Trigger.Banner,
-    id: params.id,
+    id,
     date: new Date().toISOString(),
     isRead: false,
     metadata: {
-      title: params.title,
-      body: params.body,
+      title,
+      body,
     },
   })
 }
 
-export const bannerIds = {
-  buyCryptoBanner: 23478934728,
+export const BannerIds = {
+  BuyCrypto: 23478934728,
 } as const

--- a/apps/wallet-mobile/src/features/Notifications/common/tools.ts
+++ b/apps/wallet-mobile/src/features/Notifications/common/tools.ts
@@ -5,7 +5,7 @@ import {Linking, PermissionsAndroid, Platform} from 'react-native'
 import {Notifications} from 'react-native-notifications'
 
 import {WalletNavigation} from '../../../kernel/navigation'
-import {bannerIds} from './banner-triggers'
+import {BannerIds} from './show-banners'
 import {uiStorage} from './storage'
 
 const permissionModalStorageKey = 'triggeredNotificationsPermissionModal'
@@ -56,7 +56,7 @@ export const triggerNotificationAction = async (options: {
 
   if (event.trigger === YoroiNotifications.Trigger.Banner) {
     switch (event.id) {
-      case bannerIds.buyCryptoBanner:
+      case BannerIds.BuyCrypto:
         walletNavigation.navigateToExchange()
         break
       default:

--- a/apps/wallet-mobile/src/features/Notifications/common/tools.ts
+++ b/apps/wallet-mobile/src/features/Notifications/common/tools.ts
@@ -5,6 +5,7 @@ import {Linking, PermissionsAndroid, Platform} from 'react-native'
 import {Notifications} from 'react-native-notifications'
 
 import {WalletNavigation} from '../../../kernel/navigation'
+import {bannerIds} from './banner-triggers'
 import {uiStorage} from './storage'
 
 const permissionModalStorageKey = 'triggeredNotificationsPermissionModal'
@@ -52,6 +53,15 @@ export const triggerNotificationAction = async (options: {
   if (!event) return
 
   await manager.events.markAsRead(id)
+
+  if (event.trigger === YoroiNotifications.Trigger.Banner) {
+    switch (event.id) {
+      case bannerIds.buyCryptoBanner:
+        walletNavigation.navigateToExchange()
+        break
+      default:
+    }
+  }
 
   if (event.trigger === YoroiNotifications.Trigger.Push && isRecord(event.metadata.data)) {
     const {data} = event.metadata

--- a/apps/wallet-mobile/src/features/Notifications/common/useWalletNotifications.ts
+++ b/apps/wallet-mobile/src/features/Notifications/common/useWalletNotifications.ts
@@ -16,7 +16,9 @@ export const useWalletNotifications = () => {
   }, [refetch])
 
   const data = React.useMemo(() => {
-    return receivedNotifications.filter((e) => e.trigger === Notifications.Trigger.Push)
+    return receivedNotifications.filter(
+      (e) => e.trigger === Notifications.Trigger.Push || e.trigger === Notifications.Trigger.Banner,
+    )
   }, [receivedNotifications])
   return {data, refetch}
 }

--- a/apps/wallet-mobile/src/features/Notifications/useCases/NotificationUIHandler.tsx
+++ b/apps/wallet-mobile/src/features/Notifications/useCases/NotificationUIHandler.tsx
@@ -75,6 +75,10 @@ const useCollectNewNotifications = ({enabled}: {enabled: boolean}) => {
       ) {
         pushEvent(event)
       }
+
+      if (event.trigger === Notifications.Trigger.Banner) {
+        pushEvent(event)
+      }
     })
     return () => {
       localSubscription.unsubscribe()

--- a/apps/wallet-mobile/src/features/Notifications/useCases/ViewNotificationHistory/ViewNotificationHistoryScreen.tsx
+++ b/apps/wallet-mobile/src/features/Notifications/useCases/ViewNotificationHistory/ViewNotificationHistoryScreen.tsx
@@ -86,13 +86,16 @@ const NotificationItem = React.memo(({event, onPress}: {event: Notifications.Eve
 
   const isUnread = !event.isRead
 
-  const description = event.trigger === Notifications.Trigger.Push ? event.metadata.body : null
+  const description =
+    event.trigger === Notifications.Trigger.Push || event.trigger === Notifications.Trigger.Banner
+      ? event.metadata.body
+      : null
   const time = React.useMemo(() => formatDate(event.date, languageCode), [event.date, languageCode])
 
   const title =
     event.trigger === Notifications.Trigger.TransactionReceived
       ? getTransactionReceivedNotificationTitle(event, strings, transactionInfos, wallet)
-      : event.trigger === Notifications.Trigger.Push
+      : event.trigger === Notifications.Trigger.Push || event.trigger === Notifications.Trigger.Banner
       ? event.metadata.title
       : event.id
 

--- a/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioDashboard/DashboardTokensList/DashboardTokensList.tsx
+++ b/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioDashboard/DashboardTokensList/DashboardTokensList.tsx
@@ -1,19 +1,15 @@
 import {isPrimaryToken} from '@yoroi/portfolio'
 import {useTheme} from '@yoroi/theme'
-import {Chain} from '@yoroi/types'
 import * as React from 'react'
 import {FlatList, StyleSheet, Text, TouchableOpacity, useWindowDimensions, View} from 'react-native'
 
 import {Icon} from '../../../../../components/Icon'
 import {Spacer} from '../../../../../components/Spacer/Spacer'
-import {PreprodFaucetBanner} from '../../../../Exchange/common/ShowBuyBanner/PreprodFaucetBanner'
 import {useSelectedWallet} from '../../../../WalletManager/common/hooks/useSelectedWallet'
-import {useWalletManager} from '../../../../WalletManager/context/WalletManagerProvider'
 import {useNavigateTo} from '../../../common/hooks/useNavigateTo'
 import {usePortfolioBalances} from '../../../common/hooks/usePortfolioBalances'
 import {useStrings} from '../../../common/hooks/useStrings'
 import {useZeroBalance} from '../../../common/hooks/useZeroBalance'
-import {BuyADABanner} from './BuyADABanner/BuyADABanner'
 import {DashboardTokenItem} from './DashboardTokenItem'
 import {TradeTokensBanner} from './TradeTokensBanner'
 
@@ -23,11 +19,6 @@ export const DashboardTokensList = () => {
   const isZeroADABalance = useZeroBalance()
   const {wallet} = useSelectedWallet()
   const balances = usePortfolioBalances({wallet})
-  const {
-    selected: {network},
-  } = useWalletManager()
-
-  const isPreprod = network === Chain.Network.Preprod
 
   const tokensList = React.useMemo(() => balances.fts ?? [], [balances.fts])
 
@@ -45,10 +36,6 @@ export const DashboardTokensList = () => {
   }
 
   const renderTokensList = () => {
-    if (tokensList.length === 0 || isZeroADABalance) {
-      return <View style={styles.container}>{isPreprod ? <PreprodFaucetBanner /> : <BuyADABanner />}</View>
-    }
-
     if (isJustADA) {
       return (
         <View style={styles.justAdaContainer}>

--- a/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokenDetails/PortfolioTokenDetailsScreen.tsx
+++ b/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokenDetails/PortfolioTokenDetailsScreen.tsx
@@ -16,7 +16,6 @@ import {useSelectedWallet} from '../../../WalletManager/common/hooks/useSelected
 import {usePortfolioTokenDetailParams} from '../../common/hooks/useNavigateTo'
 import {useStrings} from '../../common/hooks/useStrings'
 import {PortfolioDetailsTab, usePortfolio} from '../../common/PortfolioProvider'
-import {BuyADABanner} from '../PortfolioDashboard/DashboardTokensList/BuyADABanner/BuyADABanner'
 import {Actions} from './Actions'
 import {PortfolioTokenBalance} from './PortfolioTokenBalance/PortfolioTokenBalance'
 import {PortfolioTokenChart} from './PortfolioTokenChart/PortfolioTokenChart'
@@ -111,7 +110,6 @@ export const PortfolioTokenDetailsScreen = () => {
             </>
           }
           {...(detailsTab !== PortfolioDetailsTab.Transactions && {data: []})}
-          {...(detailsTab === PortfolioDetailsTab.Transactions && {ListEmptyComponent: <BuyADABanner />})}
         />
 
         <Actions tokenInfo={tokenInfo} />

--- a/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokensList/PortfolioWalletTokenList/PortfolioWalletTokenList.tsx
+++ b/apps/wallet-mobile/src/features/Portfolio/useCases/PortfolioTokensList/PortfolioWalletTokenList/PortfolioWalletTokenList.tsx
@@ -2,7 +2,7 @@ import {useFocusEffect} from '@react-navigation/native'
 import {FlashList} from '@shopify/flash-list'
 import {amountBreakdown, infoExtractName, isPrimaryToken} from '@yoroi/portfolio'
 import {useTheme} from '@yoroi/theme'
-import {Chain, Portfolio} from '@yoroi/types'
+import {Portfolio} from '@yoroi/types'
 import BigNumber from 'bignumber.js'
 import * as React from 'react'
 import {StyleSheet, Text, View} from 'react-native'
@@ -10,10 +10,8 @@ import {StyleSheet, Text, View} from 'react-native'
 import {Spacer} from '../../../../../components/Spacer/Spacer'
 import {useMetrics} from '../../../../../kernel/metrics/metricsManager'
 import {makeList} from '../../../../../kernel/utils'
-import {PreprodFaucetBanner} from '../../../../Exchange/common/ShowBuyBanner/PreprodFaucetBanner'
 import {useSearch} from '../../../../Search/SearchContext'
 import {useSelectedWallet} from '../../../../WalletManager/common/hooks/useSelectedWallet'
-import {useWalletManager} from '../../../../WalletManager/context/WalletManagerProvider'
 import {aggregatePrimaryAmount} from '../../../common/helpers/aggregatePrimaryAmount'
 import {useStrings} from '../../../common/hooks/useStrings'
 import {useZeroBalance} from '../../../common/hooks/useZeroBalance'
@@ -21,7 +19,6 @@ import {Line} from '../../../common/Line'
 import {usePortfolio} from '../../../common/PortfolioProvider'
 import {usePortfolioTokenActivity} from '../../../common/PortfolioTokenActivityProvider'
 import {TokenEmptyList} from '../../../common/TokenEmptyList/TokenEmptyList'
-import {BuyADABanner} from '../../PortfolioDashboard/DashboardTokensList/BuyADABanner/BuyADABanner'
 import {TotalTokensValue} from '../TotalTokensValue/TotalTokensValue'
 import {TokenBalanceItem} from './TokenBalanceItem'
 import {TokenBalanceSkeletonItem} from './TokenBalanceSkeletonItem'
@@ -33,9 +30,6 @@ export const PortfolioWalletTokenList = () => {
   const isZeroADABalance = useZeroBalance()
   const {resetTabs} = usePortfolio()
   const {track} = useMetrics()
-  const {
-    selected: {network},
-  } = useWalletManager()
 
   const {
     wallet: {balances, portfolioPrimaryTokenInfo},
@@ -102,8 +96,6 @@ export const PortfolioWalletTokenList = () => {
     return () => clearTimeout(timeout)
   }, [isSearching, search, track])
 
-  const isPreprod = network === Chain.Network.Preprod
-
   const renderFooterList = () => {
     if (isSearching) return null
     if (isLoading) {
@@ -117,15 +109,7 @@ export const PortfolioWalletTokenList = () => {
         </View>
       )
     }
-    if (isZeroADABalance) {
-      return (
-        <View>
-          <Spacer height={16} />
 
-          {isPreprod ? <PreprodFaucetBanner /> : <BuyADABanner />}
-        </View>
-      )
-    }
     if (isJustPt)
       return (
         <View>

--- a/apps/wallet-mobile/src/features/Transactions/useCases/TxHistory/TxHistory.tsx
+++ b/apps/wallet-mobile/src/features/Transactions/useCases/TxHistory/TxHistory.tsx
@@ -12,6 +12,7 @@ import {useMetrics} from '../../../../kernel/metrics/metricsManager'
 import {usePoolTransitionModal} from '../../../../legacy/Staking/PoolTransition/usePoolTransitionModal'
 import {useSync} from '../../../../yoroi-wallets/hooks'
 import {ConsiderDRepToUsTxHistoryBanner} from '../../../Banners/useCases/ConsiderDRepToUsTxHistoryBanner'
+import {useBuyBannerNotification} from '../../../Exchange/common/ShowBuyBanner/ShowBuyBanner'
 import {useGetImportantAlertsModal} from '../../../Notifications/common/GetImportantAlertsModal'
 import {useSelectedWallet} from '../../../WalletManager/common/hooks/useSelectedWallet'
 import {useStrings} from '../../common/strings'
@@ -27,6 +28,8 @@ export const TxHistory = () => {
   const strings = useStrings()
   const {styles, colors} = useStyles()
   const {isDark} = useTheme()
+
+  useBuyBannerNotification()
 
   const {track} = useMetrics()
   useGetImportantAlertsModal({enabled: true})

--- a/apps/wallet-mobile/src/features/Transactions/useCases/TxList/TxList.tsx
+++ b/apps/wallet-mobile/src/features/Transactions/useCases/TxList/TxList.tsx
@@ -7,7 +7,6 @@ import {StyleSheet, View} from 'react-native'
 import {Space} from '../../../../components/Space/Space'
 import {useTransactionInfos} from '../../../../yoroi-wallets/hooks'
 import {TransactionInfo} from '../../../../yoroi-wallets/types/other'
-import {ShowBuyBanner} from '../../../Exchange/common/ShowBuyBanner/ShowBuyBanner'
 import {useSelectedWallet} from '../../../WalletManager/common/hooks/useSelectedWallet'
 import {useTxFilter} from './TxFilterProvider'
 import {TxListItem} from './TxListItem'
@@ -44,7 +43,6 @@ export const TxList = (props: Props) => {
     <View style={styles.container}>
       <FlashList
         data={loadedTxs}
-        ListHeaderComponent={<ShowBuyBanner />}
         contentContainerStyle={styles.content}
         renderItem={({item}) => <TxListItem transaction={item} />}
         ItemSeparatorComponent={() => <Space height="lg" />}

--- a/apps/wallet-mobile/src/kernel/navigation.tsx
+++ b/apps/wallet-mobile/src/kernel/navigation.tsx
@@ -5,7 +5,7 @@ import {isKeyOf} from '@yoroi/common'
 import {Atoms, ThemedPalette, useTheme} from '@yoroi/theme'
 import {Chain, Portfolio, Scan} from '@yoroi/types'
 import React from 'react'
-import {Dimensions, Platform, TouchableOpacity, TouchableOpacityProps, View} from 'react-native'
+import {Dimensions, Linking, Platform, TouchableOpacity, TouchableOpacityProps, View} from 'react-native'
 
 import {Icon} from '../components/Icon'
 import {OnConfirm} from '../features/ReviewTx/common/hooks/useOnConfirm'
@@ -700,6 +700,23 @@ export const useWalletNavigation = () => {
           screen: 'history',
           params: {
             screen: 'swap-main',
+          },
+        },
+      })
+    },
+
+    navigateToExchange: () => {
+      if (network === Chain.Network.Preprod) {
+        Linking.openURL('https://docs.cardano.org/cardano-testnets/tools/faucet/')
+        return
+      }
+
+      navigation.navigate('manage-wallets', {
+        screen: 'main-wallet-routes',
+        params: {
+          screen: 'history',
+          params: {
+            screen: 'exchange-create-order',
           },
         },
       })

--- a/packages/notifications/src/notification-manager.test.ts
+++ b/packages/notifications/src/notification-manager.test.ts
@@ -303,6 +303,42 @@ describe('NotificationManager', () => {
     const savedIds = savedEvents.map((event) => event.id)
     expect(savedIds.sort()).toEqual(expectedIds.sort())
   })
+
+  it('should allow to remove an event by id', async () => {
+    const manager = createManager()
+
+    const event1 = createTransactionReceivedEvent({id: 1})
+    const event2 = createTransactionReceivedEvent({id: 2})
+    const event3 = createTransactionReceivedEvent({id: 3})
+    await manager.events.push(event1)
+    await manager.events.push(event2)
+    await manager.events.push(event3)
+
+    // Remove event2
+    await manager.events.remove(2)
+    const savedEvents = await manager.events.read()
+    expect(savedEvents.find((e) => e.id === 2)).toBeUndefined()
+    expect(savedEvents).toHaveLength(2)
+    expect(
+      manager.unreadCounterByGroup$.value.get('transaction-history'),
+    ).toEqual(2)
+  })
+
+  it('should not change events if removing a non-existent id', async () => {
+    const manager = createManager()
+
+    const event1 = createTransactionReceivedEvent({id: 1})
+    const event2 = createTransactionReceivedEvent({id: 2})
+    await manager.events.push(event1)
+    await manager.events.push(event2)
+
+    // Try to remove an event that doesn't exist
+    await manager.events.remove(999)
+    const savedEvents = await manager.events.read()
+    expect(savedEvents).toHaveLength(2)
+    expect(savedEvents.find((e) => e.id === 1)).toBeDefined()
+    expect(savedEvents.find((e) => e.id === 2)).toBeDefined()
+  })
 })
 
 const createTransactionReceivedEvent = (

--- a/packages/notifications/src/notification-manager.test.ts
+++ b/packages/notifications/src/notification-manager.test.ts
@@ -40,6 +40,9 @@ describe('NotificationManager', () => {
       [Notifications.Trigger.RewardsUpdated]: {
         notify: true,
       },
+      [Notifications.Trigger.Banner]: {
+        notify: true,
+      },
       displayDuration: 8,
     })
   })

--- a/packages/notifications/src/notification-manager.ts
+++ b/packages/notifications/src/notification-manager.ts
@@ -72,6 +72,7 @@ const notificationTriggerGroups: Record<
   [Notifications.Trigger.RewardsUpdated]: 'portfolio',
   [Notifications.Trigger.PrimaryTokenPriceChanged]: 'portfolio',
   [Notifications.Trigger.Push]: 'push',
+  [Notifications.Trigger.Banner]: 'portfolio',
 }
 
 const eventsManagerMaker = ({
@@ -125,7 +126,8 @@ const eventsManagerMaker = ({
       if (!shouldNotify(event, await config.read())) {
         return
       }
-      const allEvents = await events.read()
+      const allEvents = (await events.read()).filter(({id}) => id !== event.id)
+
       const newEvents = [event, ...allEvents].slice(0, eventsLimit)
       await storage.setItem('events', newEvents)
       if (!event.isRead) {
@@ -187,6 +189,9 @@ const defaultConfig: Notifications.Config = {
     notify: true,
   },
   [Notifications.Trigger.RewardsUpdated]: {
+    notify: true,
+  },
+  [Notifications.Trigger.Banner]: {
     notify: true,
   },
 }

--- a/packages/notifications/src/notification-manager.ts
+++ b/packages/notifications/src/notification-manager.ts
@@ -139,6 +139,13 @@ const eventsManagerMaker = ({
       await storage.removeItem('events')
       unreadCounterByGroup$.next(buildUnreadCounterDefaultValue())
     },
+    remove: async (id: number) => {
+      const allEvents = await events.read()
+      const filteredEvents = allEvents.filter((event) => event.id !== id)
+      await storage.setItem<EventsStorageData>('events', filteredEvents)
+      await updateUnreadCounter()
+      return filteredEvents
+    },
   }
   return {events, unreadCounterByGroup$, newEvents$}
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -262,6 +262,7 @@ import {
   PortfolioTokenHistoryPeriod,
 } from './portfolio/history'
 import {
+  BannerNotificationEvent,
   NotificationConfig,
   NotificationEvent,
   NotificationGroup,
@@ -701,6 +702,7 @@ export namespace Notifications {
   export type TransactionReceivedEvent = NotificationTransactionReceivedEvent
   export type RewardsUpdatedEvent = NotificationRewardsUpdatedEvent
   export type PushEvent = PushNotificationEvent
+  export type BannerEvent = BannerNotificationEvent
   export type PrimaryTokenPriceChangedEvent =
     NotificationPrimaryTokenPriceChangedEvent
   export const Trigger = NotificationTrigger

--- a/packages/types/src/notifications/manager.ts
+++ b/packages/types/src/notifications/manager.ts
@@ -119,6 +119,7 @@ export type NotificationManager = {
   events: {
     markAllAsRead: () => Promise<void>
     markAsRead(id: NotificationEventId): Promise<void>
+    remove(id: NotificationEventId): Promise<ReadonlyArray<NotificationEvent>>
     read: () => Promise<ReadonlyArray<NotificationEvent>>
     push: (event: Readonly<NotificationEvent>) => Promise<void>
     clear: () => Promise<void>

--- a/packages/types/src/notifications/manager.ts
+++ b/packages/types/src/notifications/manager.ts
@@ -6,6 +6,7 @@ export enum NotificationTrigger {
   'RewardsUpdated' = 'RewardsUpdated',
   'PrimaryTokenPriceChanged' = 'PrimaryTokenPriceChanged',
   'Push' = 'Push',
+  'Banner' = 'Banner',
 }
 
 export type NotificationManagerMakerProps = {
@@ -16,8 +17,18 @@ export type NotificationManagerMakerProps = {
     [NotificationTrigger.RewardsUpdated]: Subject<NotificationRewardsUpdatedEvent>
     [NotificationTrigger.PrimaryTokenPriceChanged]: Subject<NotificationPrimaryTokenPriceChangedEvent>
     [NotificationTrigger.Push]: Subject<PushNotificationEvent>
+    [NotificationTrigger.Banner]: Subject<BannerNotificationEvent>
   }>
   eventsLimit?: number
+}
+
+export interface BannerNotificationEvent extends NotificationEventBase {
+  trigger: NotificationTrigger.Banner
+  metadata: {
+    title: string
+    body: string
+    data?: Record<string, unknown>
+  }
 }
 
 export interface PushNotificationEvent extends NotificationEventBase {
@@ -64,6 +75,7 @@ export type NotificationEvent =
   | NotificationPrimaryTokenPriceChangedEvent
   | NotificationRewardsUpdatedEvent
   | PushNotificationEvent
+  | BannerNotificationEvent
 
 type NotificationEventId = number
 
@@ -87,6 +99,9 @@ export type NotificationConfig = {
     notify: boolean
   }
   [NotificationTrigger.RewardsUpdated]: {
+    notify: boolean
+  }
+  [NotificationTrigger.Banner]: {
     notify: boolean
   }
 }


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

##### Ticket

https://emurgo.atlassian.net/browse/YV-422
https://emurgo.atlassian.net/browse/YV-426
https://emurgo.atlassian.net/browse/YV-427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced banner notifications, including a "Buy Crypto" banner, which may appear based on your wallet balance.
  - Banner notifications now support navigation directly to the exchange screen from the notification popup.
- **Improvements**
  - Banner notifications are now visible in notification history and handled consistently across the app.
  - Notification popups feature improved icon styling and flexible layout.
  - Integrated banner notification triggers into wallet notifications and notification manager.
- **Bug Fixes**
  - Prevented duplicate banner notifications and improved notification removal handling.
- **Chores**
  - Enhanced test coverage for notification event removal and banner triggers.
  - Removed network-specific banner display logic from portfolio and token list screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->