### PR TITLE
fix(wallet-mobile): invalidate banners on utxo change

### DIFF
--- a/apps/wallet-mobile/src/features/Exchange/common/useBuyCryptoBanner.tsx
+++ b/apps/wallet-mobile/src/features/Exchange/common/useBuyCryptoBanner.tsx
@@ -1,10 +1,9 @@
 import {time} from '@yoroi/common'
 import {useNotificationManager} from '@yoroi/notifications'
 import {Chain, Notifications} from '@yoroi/types'
-import _ from 'lodash'
-import {useQuery} from 'react-query'
+import {useQuery, useQueryClient} from 'react-query'
 
-import {useBalances} from '../../../yoroi-wallets/hooks'
+import {useBalances, useWalletEvent} from '../../../yoroi-wallets/hooks'
 import {Amounts, Quantities} from '../../../yoroi-wallets/utils/utils'
 import {BannerIds, showBanner} from '../../Notifications/common/banners'
 import {useSelectedWallet} from '../../WalletManager/common/hooks/useSelectedWallet'
@@ -24,9 +23,14 @@ export const useBuyCryptoBanner = () => {
   const primaryAmount = Amounts.getAmount(balances, wallet.portfolioPrimaryTokenInfo.id)
   const hasZeroPt = Quantities.isZero(primaryAmount.quantity)
 
+  const queryKey = ['buyCryptoBanner', wallet?.id, network]
+  const queryClient = useQueryClient()
+
+  useWalletEvent(wallet, 'utxos', () => queryClient.invalidateQueries(queryKey))
+
   useQuery({
-    queryKey: ['buyCryptoBanner', wallet?.id, network],
-    staleTime: time.oneHour,
+    queryKey,
+    staleTime: time.fiveMinutes,
     queryFn: async () => {
       if (hasZeroPt) {
         const last = (await manager.events.read()).find(

--- a/apps/wallet-mobile/src/features/Exchange/common/useBuyCryptoBanner.tsx
+++ b/apps/wallet-mobile/src/features/Exchange/common/useBuyCryptoBanner.tsx
@@ -1,6 +1,7 @@
 import {time} from '@yoroi/common'
 import {useNotificationManager} from '@yoroi/notifications'
 import {Chain, Notifications} from '@yoroi/types'
+import * as React from 'react'
 import {useQuery, useQueryClient} from 'react-query'
 
 import {useBalances, useWalletEvent} from '../../../yoroi-wallets/hooks'
@@ -28,28 +29,37 @@ export const useBuyCryptoBanner = () => {
 
   useWalletEvent(wallet, 'utxos', () => queryClient.invalidateQueries(queryKey))
 
+  React.useEffect(() => {
+    queryClient.invalidateQueries(queryKey)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [network])
+
   useQuery({
     queryKey,
     staleTime: time.fiveMinutes,
     queryFn: async () => {
       if (hasZeroPt) {
         const last = (await manager.events.read()).find(
-          (ev) =>
-            ev.trigger === Notifications.Trigger.Banner &&
-            (ev.id === BannerIds.BuyCrypto || ev.id === BannerIds.TestAda),
+          (ev) => ev.trigger === Notifications.Trigger.Banner && ev.id === BannerIds.BuyCrypto,
         )
 
-        if (!last || new Date(last.date).getTime() + time.oneMonth < Date.now()) {
-          if (network === Chain.Network.Preprod) {
-            manager.events.remove(BannerIds.BuyCrypto)
+        const lastPreprod = (await manager.events.read()).find(
+          (ev) => ev.trigger === Notifications.Trigger.Banner && ev.id === BannerIds.TestAda,
+        )
+
+        if (network === Chain.Network.Preprod) {
+          manager.events.remove(BannerIds.BuyCrypto)
+          if (!lastPreprod || new Date(lastPreprod.date).getTime() + time.oneMonth < Date.now()) {
             showBanner({
               id: BannerIds.TestAda,
               title: strings.preprodFaucetBannerTitle,
               body: strings.preprodFaucetBannerText,
-              isRead: !!last,
+              isRead: !!lastPreprod,
             })
-          } else {
-            manager.events.remove(BannerIds.TestAda)
+          }
+        } else {
+          manager.events.remove(BannerIds.TestAda)
+          if (!last || new Date(last.date).getTime() + time.oneMonth < Date.now()) {
             showBanner({
               id: BannerIds.BuyCrypto,
               title: strings.needMoreCrypto,

--- a/apps/wallet-mobile/src/features/Staking/Governance/useCases/useGovernanceBanner.tsx
+++ b/apps/wallet-mobile/src/features/Staking/Governance/useCases/useGovernanceBanner.tsx
@@ -1,8 +1,9 @@
 import {time} from '@yoroi/common'
 import {useNotificationManager} from '@yoroi/notifications'
 import {Chain, Notifications} from '@yoroi/types'
-import {useQuery} from 'react-query'
+import {useQuery, useQueryClient} from 'react-query'
 
+import {useWalletEvent} from '../../../../yoroi-wallets/hooks'
 import {BannerIds, showBanner} from '../../../Notifications/common/banners'
 import {useSelectedWallet} from '../../../WalletManager/common/hooks/useSelectedWallet'
 import {useWalletManager} from '../../../WalletManager/context/WalletManagerProvider'
@@ -10,6 +11,7 @@ import {useIsParticipatingInGovernance} from '../common/helpers'
 import {useStrings} from '../common/strings'
 
 export const useGovernanceBanner = () => {
+  const strings = useStrings()
   const {wallet} = useSelectedWallet()
   const manager = useNotificationManager()
   const {
@@ -17,12 +19,14 @@ export const useGovernanceBanner = () => {
   } = useWalletManager()
 
   const isParticipating = useIsParticipatingInGovernance()
+  const queryKey = ['governanceBanner', wallet?.id, network]
+  const queryClient = useQueryClient()
 
-  const strings = useStrings()
+  useWalletEvent(wallet, 'utxos', () => queryClient.invalidateQueries(queryKey))
 
   useQuery({
-    queryKey: ['governanceBanner', wallet?.id, network],
-    staleTime: time.oneHour,
+    queryKey,
+    staleTime: time.fiveMinutes,
     queryFn: async () => {
       if (!isParticipating) {
         if (network === Chain.Network.Mainnet) {


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

##### Ticket

https://emurgo.atlassian.net/browse/YV-431?focusedCommentId=37537
https://emurgo.atlassian.net/browse/YV-498

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced responsiveness of banner updates in the Exchange and Governance sections, ensuring information refreshes more quickly when wallet activity occurs.
  * Reduced banner data refresh intervals from one hour to five minutes for more timely updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->