### PR TITLE
fix(wallet-mobile): Remove cns from banner

### DIFF
--- a/apps/wallet-mobile/src/features/Send/useCases/StartMultiTokenTx/NotifySupportedNameServers/NotifySupportedNameServers.tsx
+++ b/apps/wallet-mobile/src/features/Send/useCases/StartMultiTokenTx/NotifySupportedNameServers/NotifySupportedNameServers.tsx
@@ -44,8 +44,6 @@ export const NotifySupportedNameServers = () => {
         <NameServer text="ADA Handle" />
 
         <NameServer text="Unstoppable Domains" />
-
-        <NameServer text="Cardano Name Service (CNS)" />
       </LinearGradient>
 
       <Spacer height={16} />


### PR DESCRIPTION
## Remove cns from banner in Send funnel

##### Ticket

[YV-300](https://emurgo.atlassian.net/browse/YV-300)

[YV-300]: https://emurgo.atlassian.net/browse/YV-300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the display of "Cardano Name Service (CNS)" from the list of supported name servers in the send flow. "ADA Handle" and "Unstoppable Domains" remain visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->