### PR TITLE
feature(mobile): Add .brave tld to resolver package

### DIFF
--- a/packages/resolver/src/adapters/unstoppable/api.ts
+++ b/packages/resolver/src/adapters/unstoppable/api.ts
@@ -118,6 +118,7 @@ export const unstoppableSupportedTlds = [
   '.888',
   '.wallet',
   '.binanceus',
+  '.brave',
   '.hi',
   '.klever',
   '.kresus',


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

**Change(s):**
- Added `.brave` to the `unstoppableSupportedTlds` array in `packages/resolver/src/adapters/unstoppable/api.ts`.

**Why:**
- To enable resolution of Unstoppable Domains ending with `.brave`, addressing a user report where `diegodamian.brave` failed to resolve. This is a targeted fix while a more dynamic TLD list management is explored.

##### Ticket

YV-YOEXT-2153

---

[Slack Thread](https://emurgo.slack.com/archives/C02M83F3G72/p1753446416546699?thread_ts=1753446416.546699&cid=C02M83F3G72) • [Open in Web](https://www.cursor.com/agents?id=bc-074ba440-cb04-4bde-bbd3-ff7fb3c9253b) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-074ba440-cb04-4bde-bbd3-ff7fb3c9253b)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the ".brave" top-level domain for Unstoppable Domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->