### PR TITLE
Investigate red navigator display

### DIFF
--- a/apps/mobile/src/features/SetupWallet/SetupWalletNavigator.tsx
+++ b/apps/mobile/src/features/SetupWallet/SetupWalletNavigator.tsx
@@ -1,11 +1,11 @@
 import {createStackNavigator} from '@react-navigation/stack'
-// import {useTheme} from '@yoroi/theme'
+import {useTheme} from '@yoroi/theme'
 import * as React from 'react'
 
-/* import {
+import {
   defaultStackNavigationOptions,
   WalletInitRoutes,
-} from '~/kernel/navigation' */
+} from '~/kernel/navigation'
 // import {NetworkTag} from '../Settings/useCases/changeAppSettings/ChangeNetwork/NetworkTag'
 import {PreparingWalletScreen} from './common/PreparingWalletScreen/PreparingWalletScreen'
 import {ImportReadOnlyWalletScreen} from './legacy/ImportReadOnlyWallet/ImportReadOnlyWalletScreen'
@@ -21,21 +21,21 @@ import {useStrings} from '~/kernel/i18n/useStrings'
 import {RestoreWalletDetailsScreen} from './useCases/RestoreWallet/RestoreWalletDetailsScreen'
 import {RestoreWalletScreen} from './useCases/RestoreWallet/RestoreWalletScreen'
 
-const Stack = createStackNavigator<any /* WalletInitRoutes */>()
+const Stack = createStackNavigator<WalletInitRoutes>()
 export const SetupWalletNavigator = () => {
   const strings = useStrings()
-  // const {atoms: ta, palette: p} = useTheme()
+  const {atoms: ta, palette: p} = useTheme()
 
-  /* const navigationOptions = React.useMemo(
+  const navigationOptions = React.useMemo(
     () => defaultStackNavigationOptions(ta, p),
     [ta, p],
   )
- */
+
   return (
     <Stack.Navigator
       screenOptions={
         {
-          // ...navigationOptions,
+          ...navigationOptions,
           // headerTitle: ({children}) => <NetworkTag>{children}</NetworkTag>,
         }
       }

--- a/apps/mobile/src/features/SetupWallet/useCases/ChooseMnemonicType/ChooseMnemonicTypeScreen.tsx
+++ b/apps/mobile/src/features/SetupWallet/useCases/ChooseMnemonicType/ChooseMnemonicTypeScreen.tsx
@@ -6,6 +6,7 @@ import {View} from 'react-native'
 import {SafeAreaView} from 'react-native-safe-area-context'
 
 import {useMetrics} from '~/kernel/metrics/metricsManager'
+import {SetupWalletRouteNavigation} from '~/kernel/navigation'
 import {LogoBanner} from '~/ui/LogoBanner/LogoBanner'
 import {Space} from '~/ui/Space/Space'
 import {ButtonCard} from '../../common/ButtonCard/ButtonCard'
@@ -19,7 +20,7 @@ export const ChooseMnemonicTypeScreen = () => {
   const {track} = useMetrics()
   const {palette: p} = useTheme()
 
-  const navigation = useNavigation<any>()
+  const navigation = useNavigation<SetupWalletRouteNavigation>()
 
   const handle15Words = () => {
     mnemonicTypeChanged(15)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "yoroi",
+  "name": "workspace",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {}


### PR DESCRIPTION
## Description / Change(s) / Related issue(s)

Resolved TypeScript errors that caused the `SetupWalletNavigator` to appear in red.

*   **Enabled proper type safety**: Replaced `any` with specific types (`WalletInitRoutes`, `SetupWalletRouteNavigation`) for navigators and hooks.
*   **Restored theme integration**: Uncommented `useTheme` and applied `defaultStackNavigationOptions` to ensure correct styling.
*   **Uncommented critical imports**: Restored necessary navigation-related imports.

##### Ticket

YV-

---
<a href="https://cursor.com/background-agent?bcId=bc-a79a8042-3eb5-4e93-94aa-f599513ba949">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a79a8042-3eb5-4e93-94aa-f599513ba949">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>