### PR TITLE
chore(mobile): restored login with host (former OS)

### DIFF
--- a/apps/mobile/src/features/Auth/ui/screens/LoginWithHostScreen.tsx
+++ b/apps/mobile/src/features/Auth/ui/screens/LoginWithHostScreen.tsx
@@ -16,6 +16,10 @@ export const LoginWithHostScreen = () => {
   const {loginWithHost} = useAuth()
   const {resolve, isPending} = usePromise(loginWithHost)
 
+  React.useEffect(() => {
+    resolve()
+  }, [])
+
   return (
     <View style={[a.flex_1, a.flex_col, a.justify_between]}>
       <Space.Height.lg fill />
@@ -26,7 +30,7 @@ export const LoginWithHostScreen = () => {
 
       <BottomSection>
         <Button
-          title={strings.auth.loginWithHost.title}
+          title={strings.auth.authorize}
           disabled={isPending}
           onPress={resolve}
         />

--- a/apps/mobile/src/features/DevMenu/DevMenu.tsx
+++ b/apps/mobile/src/features/DevMenu/DevMenu.tsx
@@ -22,9 +22,9 @@ import {rootMMKV, rootSyncStorage} from '~/kernel/storage/storages'
 import {Button, ButtonType} from '~/ui/Button/Button'
 import {LoadingOverlay} from '~/ui/LoadingOverlay/LoadingOverlay'
 
-export function DevMenu({visible}: {visible?: boolean}) {
+export function DevMenu() {
   const {isDark, config, basePalette, selectTheme, atoms: ta} = useTheme()
-  const {authWithHost} = useAuth()
+  const {authWithHost, changeAuthSetting} = useAuth()
   const {languageCode, selectLanguage} = useLanguage()
   const strings = useStrings()
   const [isLoading, setIsLoading] = React.useState(false)
@@ -39,10 +39,6 @@ export function DevMenu({visible}: {visible?: boolean}) {
   const metrics = useMetrics()
   const {currency, ptActivity} = usePairing()
   const navigation = useNavigation<any>()
-
-  if (!visible) {
-    return null
-  }
 
   return (
     <SafeAreaView
@@ -96,6 +92,13 @@ export function DevMenu({visible}: {visible?: boolean}) {
         onPress={() => authWithHost().then(console.log).catch(console.error)}
         type={ButtonType.Secondary}
         title="Auth with Host"
+        style={[a.pt_md, a.p_md, a.rounded_md]}
+      />
+
+      <Button
+        onPress={() => changeAuthSetting('os')}
+        type={ButtonType.Secondary}
+        title="Set Auth with Host"
         style={[a.pt_md, a.p_md, a.rounded_md]}
       />
 

--- a/apps/mobile/src/features/DevMenu/index.ts
+++ b/apps/mobile/src/features/DevMenu/index.ts
@@ -1,1 +1,0 @@
-export {DevMenu} from './DevMenu'

--- a/apps/mobile/src/kernel/navigation/AppNavigator.tsx
+++ b/apps/mobile/src/kernel/navigation/AppNavigator.tsx
@@ -5,8 +5,6 @@ import {TransitionPresets, createStackNavigator} from '@react-navigation/stack'
 import * as React from 'react'
 import {Platform} from 'react-native'
 
-
-
 import {AuthSetting, AuthWithHostConfig} from '~/features/Auth/common/types'
 import {useAuth} from '~/features/Auth/context/AuthProvider'
 import {useAuthSetting} from '~/features/Auth/hooks/useAuthSetting'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a secondary button in the developer menu to set authentication with host directly.
  * The login with host screen now automatically triggers the authentication process when opened.

* **Improvements**
  * The login button label has been updated for clarity.
  * The developer menu is now always visible for easier access.

* **Refactor**
  * Simplified developer menu props by removing the visibility toggle.
  * Removed an unused index file for the developer menu.

* **Style**
  * Minor cleanup of blank lines in navigation file imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->