### PR TITLE
feat(swap): adapt Muesliswap adapter to API v2 changes

### DIFF
--- a/packages/swap/src/adapters/api/muesliswap/api.mocks.ts
+++ b/packages/swap/src/adapters/api/muesliswap/api.mocks.ts
@@ -5,6 +5,8 @@ import {
   CancelResponse,
   CreateOrderRequest,
   CreateOrderResponse,
+  LimitOrderRequest,
+  LimitQuoteRequest,
   OrdersHistoryResponse,
   QuoteRequest,
   QuoteResponse,
@@ -257,8 +259,9 @@ const cancelInput: Array<Swap.CancelRequest> = [
 ]
 
 const cancelRequest: CancelRequest = {
-  output_idx: 0,
-  tx_hash: '8751fbef1ebec0d2da9218a69493ef36070012ce24fdbc44ec6df519377b92bf',
+  order_ids: [
+    '8751fbef1ebec0d2da9218a69493ef36070012ce24fdbc44ec6df519377b92bf#0',
+  ],
 }
 
 const cancelResponse: CancelResponse = {
@@ -277,10 +280,10 @@ const quoteLimitInput: Swap.EstimateRequest = {
   protocol: 'minswap-v1',
 }
 
-const quoteLimitRequest: QuoteRequest = {
+const quoteLimitRequest: LimitQuoteRequest = {
   buy_amount: '0',
   buy_token: quoteLimitInput.tokenOut,
-  dex: 'minswap-v1',
+  order_contract: 'minswap-v1',
   numbers_have_decimals: true,
   sell_amount: '0',
   sell_token: quoteLimitInput.tokenIn,
@@ -302,7 +305,19 @@ const quoteRequest: QuoteRequest = {
   sell_amount: String(quoteInput.amountIn),
   slippage: quoteInput.slippage / 100,
   numbers_have_decimals: true,
-  dex: ['minswap-v1'],
+  excluded_sources: [
+    'muesliswap-v2',
+    'muesliswap-clp',
+    'minswap-v2',
+    'minswap-stable',
+    'spectrum-v1',
+    'teddy-v1',
+    'wingriders-v1',
+    'wingriders-v2',
+    'vyfi-v1',
+    'sundaeswap-v1',
+    'sundaeswap-v3',
+  ],
   partner: 'somePartnerId',
 }
 
@@ -316,7 +331,7 @@ const quoteResponse: QuoteResponse = {
   sell_token_decimals: 6,
   net_price: 0.00113,
   net_price_impact: 1.258404559451805,
-  frontend_fee: '0.000000',
+  service_fee: '0.000000',
   numbers_have_decimals: true,
   total_output_without_slippage: '1130',
   splits: [
@@ -349,7 +364,7 @@ const quoteNoOutResponse: QuoteResponse = {
   sell_token_decimals: 6,
   net_price: 0.00113,
   net_price_impact: 1.258404559451805,
-  frontend_fee: '0.000000',
+  service_fee: '0.000000',
   numbers_have_decimals: true,
   splits: [
     {
@@ -449,14 +464,14 @@ const createLimitInput: Array<Swap.CreateRequest> = [
   },
 ]
 
-const createLimitRequest = (address: string): CreateOrderRequest => ({
+const createLimitRequest = (address: string): LimitOrderRequest => ({
   sell_token: '.',
   sell_amount: '1',
   user_address: address,
   buy_token:
     'cdaaee586376139ee8c3cc4061623968810d177ca5c300afb890b48a.43415354',
   buy_amount: '1',
-  dex: 'minswap-v1',
+  order_contract: 'minswap-v1',
   numbers_have_decimals: true,
 })
 
@@ -488,7 +503,7 @@ const createLimitResponse: CreateOrderResponse = {
     sell_token_decimals: 6,
     net_price: 0.00113,
     net_price_impact: 1.258404559451805,
-    frontend_fee: '0.000000',
+    service_fee: '0.000000',
     numbers_have_decimals: true,
     total_output_without_slippage: '1130',
     splits: [
@@ -554,20 +569,7 @@ const createRequest = (address: string): Array<CreateOrderRequest> => [
     user_address: address,
     buy_token:
       'cdaaee586376139ee8c3cc4061623968810d177ca5c300afb890b48a.43415354',
-    dex: [
-      'muesliswap-v2',
-      'muesliswap-clp',
-      'minswap-v1',
-      'minswap-v2',
-      'minswap-stable',
-      'spectrum-v1',
-      'teddy-v1',
-      'wingriders-v1',
-      'wingriders-v2',
-      'vyfi-v1',
-      'sundaeswap-v1',
-      'sundaeswap-v3',
-    ],
+    excluded_sources: [],
     numbers_have_decimals: true,
     slippage: 0,
     partner: 'somePartnerId',
@@ -578,7 +580,19 @@ const createRequest = (address: string): Array<CreateOrderRequest> => [
     user_address: address,
     buy_token:
       'cdaaee586376139ee8c3cc4061623968810d177ca5c300afb890b48a.43415354',
-    dex: ['minswap-v1'],
+    excluded_sources: [
+      'muesliswap-v2',
+      'muesliswap-clp',
+      'minswap-v2',
+      'minswap-stable',
+      'spectrum-v1',
+      'teddy-v1',
+      'wingriders-v1',
+      'wingriders-v2',
+      'vyfi-v1',
+      'sundaeswap-v1',
+      'sundaeswap-v3',
+    ],
     numbers_have_decimals: true,
     slippage: 0.02,
     partner: 'somePartnerId',
@@ -596,7 +610,7 @@ const createResponse: CreateOrderResponse = {
     sell_token_decimals: 6,
     net_price: 0.00113,
     net_price_impact: 1.258404559451805,
-    frontend_fee: '0.000000',
+    service_fee: '0.000000',
     numbers_have_decimals: true,
     total_output_without_slippage: '1130',
     splits: [

--- a/packages/swap/src/adapters/api/muesliswap/helpers.test.ts
+++ b/packages/swap/src/adapters/api/muesliswap/helpers.test.ts
@@ -1,4 +1,4 @@
-import {getAllowedDexes, resolveDexes} from './helpers'
+import {getAllowedDexes} from './helpers'
 import {Dex} from './types'
 
 const allDexes: Array<Dex> = [
@@ -35,29 +35,6 @@ describe('getAllowedDexes', () => {
 
   it('should return an empty array if all DEXes are blocked', () => {
     const result = getAllowedDexes({blocked: allDexes})
-    expect(result).toEqual([])
-  })
-})
-
-describe('resolveDexes', () => {
-  it('should return the protocol if provided', () => {
-    const result = resolveDexes({protocol: Dex.Minswap_v1})
-    expect(result).toEqual([Dex.Minswap_v1])
-  })
-
-  it('should return allowed DEXes if protocol is not provided', () => {
-    const result = resolveDexes({blockedProtocols: [Dex.Minswap_stable]})
-    const expected = allDexes.filter((dex) => dex !== Dex.Minswap_stable)
-    expect(result).toEqual(expected)
-  })
-
-  it('should return all DEXes if no protocol and no blocked protocols are provided', () => {
-    const result = resolveDexes({})
-    expect(result).toEqual(allDexes)
-  })
-
-  it('should return an empty array if all DEXes are blocked and no protocol is provided', () => {
-    const result = resolveDexes({blockedProtocols: allDexes})
     expect(result).toEqual([])
   })
 })

--- a/packages/swap/src/adapters/api/muesliswap/helpers.ts
+++ b/packages/swap/src/adapters/api/muesliswap/helpers.ts
@@ -12,13 +12,3 @@ export function getAllowedDexes({
   )
   return difference(dexesWithoutUnsupported, blocked)
 }
-
-export function resolveDexes({
-  protocol,
-  blockedProtocols,
-}: {
-  protocol?: Dex
-  blockedProtocols?: ReadonlyArray<Dex>
-}) {
-  return protocol ? [protocol] : getAllowedDexes({blocked: blockedProtocols})
-}

--- a/packages/swap/src/adapters/api/muesliswap/transformers.test.ts
+++ b/packages/swap/src/adapters/api/muesliswap/transformers.test.ts
@@ -7,7 +7,7 @@ import {
   transformersMaker,
 } from './transformers'
 import {api, primaryTokenInfo} from './api.mocks'
-import {CreateOrderRequest, Dex} from './types'
+import {Dex, LimitOrderRequest} from './types'
 
 const address =
   'addr1q9qhyvkm5fytm5ckgshny0zz08a3urhhh7ckdqxcm27av40eafn3v5lr2w2n2er9uj7c743mt42gpe8tgek6394z9t7qn4yjzl'
@@ -76,7 +76,19 @@ describe('transformers', () => {
         buy_amount: '10',
         buy_token:
           'af2e27f580f7f08e93190a81f72462f153026d06450924726645891b.44524950',
-        dex: ['minswap-v1'],
+        excluded_sources: [
+          'muesliswap-v2',
+          'muesliswap-clp',
+          'minswap-v2',
+          'minswap-stable',
+          'spectrum-v1',
+          'teddy-v1',
+          'wingriders-v1',
+          'wingriders-v2',
+          'vyfi-v1',
+          'sundaeswap-v1',
+          'sundaeswap-v3',
+        ],
         numbers_have_decimals: true,
         partner: 'somePartnerId',
         sell_token: '.',
@@ -86,19 +98,7 @@ describe('transformers', () => {
       const input = {...api.inputs.quote, protocol: undefined}
       const request = {
         ...api.requests.quote,
-        dex: [
-          'muesliswap-v2',
-          'muesliswap-clp',
-          'minswap-v1',
-          'minswap-v2',
-          'minswap-stable',
-          'spectrum-v1',
-          'teddy-v1',
-          'wingriders-v2',
-          'vyfi-v1',
-          'sundaeswap-v1',
-          'sundaeswap-v3',
-        ],
+        excluded_sources: ['wingriders-v1'],
       }
       expect(transformers.quote.request(input)).toEqual(request)
     })
@@ -123,7 +123,7 @@ describe('transformers', () => {
       )
 
       const input = {...api.inputs.quoteLimit, protocol: undefined}
-      const request = {...api.requests.quoteLimit, dex: undefined}
+      const request = {...api.requests.quoteLimit, order_contract: undefined}
       expect(transformers.limitQuote.request(input)).toEqual(request)
     })
   })
@@ -152,10 +152,10 @@ describe('transformers', () => {
       ).toEqual(api.requests.createLimit(address))
       expect(
         transformers.createLimit.request(api.inputs.createLimit[1]!),
-      ).toEqual<CreateOrderRequest>({
+      ).toEqual<LimitOrderRequest>({
         ...api.requests.createLimit(address),
         buy_amount: '0',
-        dex: Dex.Unsupported,
+        order_contract: Dex.Unsupported,
       })
     })
 

--- a/packages/swap/src/adapters/api/muesliswap/transformers.ts
+++ b/packages/swap/src/adapters/api/muesliswap/transformers.ts
@@ -16,7 +16,6 @@ import {
   TokensResponse,
   MuesliswapApiConfig,
 } from './types'
-import {resolveDexes} from './helpers'
 
 export const transformersMaker = ({
   primaryTokenInfo,
@@ -97,8 +96,7 @@ export const transformersMaker = ({
 
     cancel: {
       request: ({order}: Swap.CancelRequest): CancelRequest => ({
-        tx_hash: order.txHash,
-        output_idx: order.outputIndex ?? 0,
+        order_ids: [`${order.txHash}#${order.outputIndex ?? 0}`],
       }),
       response: ({tx_cbor}: CancelResponse): Swap.CancelResponse => ({
         cbor: tx_cbor,
@@ -120,7 +118,7 @@ export const transformersMaker = ({
         sell_amount: String(amountIn),
 
         buy_amount: String(amountIn * wantedPrice),
-        dex: protocol ? fromSwapProtocol(protocol) : undefined,
+        order_contract: protocol ? fromSwapProtocol(protocol) : undefined,
       }),
     },
 
@@ -142,10 +140,12 @@ export const transformersMaker = ({
         ...(partner !== undefined && {partner}),
         // muesli expects slippage as a percentage
         slippage: slippage / 100,
-        dex: resolveDexes({
-          protocol: protocol ? fromSwapProtocol(protocol) : undefined,
-          blockedProtocols: blockedProtocols?.map(fromSwapProtocol),
-        }),
+        excluded_sources: protocol
+          ? Object.values(Dex).filter(
+              (dex) =>
+                dex !== Dex.Unsupported && dex !== fromSwapProtocol(protocol),
+            )
+          : (blockedProtocols?.map(fromSwapProtocol) ?? []),
       }),
       response: ({
         buy_token_decimals,
@@ -156,7 +156,7 @@ export const transformersMaker = ({
         total_batcher_fee,
         total_deposit,
         total_input,
-        frontend_fee,
+        service_fee,
         total_output,
         total_output_without_slippage,
       }: QuoteResponse): Swap.EstimateResponse => ({
@@ -167,7 +167,7 @@ export const transformersMaker = ({
         batcherFee: Number(total_batcher_fee),
         deposits: Number(total_deposit),
         totalFee: Number(
-          (Number(total_batcher_fee) + Number(frontend_fee)).toFixed(
+          (Number(total_batcher_fee) + Number(service_fee)).toFixed(
             primaryTokenInfo.decimals,
           ),
         ),
@@ -198,10 +198,12 @@ export const transformersMaker = ({
         user_address: address,
         ...(partner !== undefined && {partner}),
         slippage: slippage / 100,
-        dex: resolveDexes({
-          protocol: protocol ? fromSwapProtocol(protocol) : undefined,
-          blockedProtocols: blockedProtocols?.map(fromSwapProtocol),
-        }),
+        excluded_sources: protocol
+          ? Object.values(Dex).filter(
+              (dex) =>
+                dex !== Dex.Unsupported && dex !== fromSwapProtocol(protocol),
+            )
+          : (blockedProtocols?.map(fromSwapProtocol) ?? []),
         utxos: inputs,
       }),
       response: ({
@@ -211,7 +213,7 @@ export const transformersMaker = ({
           net_price,
           net_price_impact,
           splits,
-          frontend_fee,
+          service_fee,
           total_batcher_fee,
           total_deposit,
           total_input,
@@ -222,14 +224,14 @@ export const transformersMaker = ({
       }: CreateOrderResponse): Swap.CreateResponse => ({
         aggregator: Swap.Aggregator.Muesliswap,
         aggregatorFee: 0,
-        frontendFee: Number(frontend_fee),
+        frontendFee: Number(service_fee),
         cbor: tx_cbor,
         netPrice: net_price * 10 ** (sell_token_decimals - buy_token_decimals),
         priceImpact: net_price_impact,
         batcherFee: Number(total_batcher_fee),
         deposits: Number(total_deposit),
         totalFee: Number(
-          (Number(total_batcher_fee) + Number(frontend_fee)).toFixed(
+          (Number(total_batcher_fee) + Number(service_fee)).toFixed(
             primaryTokenInfo.decimals,
           ),
         ),
@@ -250,7 +252,7 @@ export const transformersMaker = ({
         amountIn,
         inputs,
       }: Swap.CreateRequest): LimitOrderRequest => ({
-        dex: fromSwapProtocol(protocol),
+        order_contract: fromSwapProtocol(protocol),
         buy_amount: String(amountIn * wantedPrice),
 
         numbers_have_decimals: true,
@@ -267,7 +269,7 @@ export const transformersMaker = ({
           net_price,
           net_price_impact,
           splits,
-          frontend_fee,
+          service_fee,
           total_batcher_fee,
           total_deposit,
           total_input,
@@ -280,13 +282,13 @@ export const transformersMaker = ({
         aggregator: Swap.Aggregator.Muesliswap,
 
         aggregatorFee: 0,
-        frontendFee: Number(frontend_fee),
+        frontendFee: Number(service_fee),
         netPrice: net_price * 10 ** (sell_token_decimals - buy_token_decimals),
         priceImpact: net_price_impact,
         batcherFee: Number(total_batcher_fee),
         deposits: Number(total_deposit),
         totalFee: Number(
-          (Number(total_batcher_fee) + Number(frontend_fee)).toFixed(
+          (Number(total_batcher_fee) + Number(service_fee)).toFixed(
             primaryTokenInfo.decimals,
           ),
         ),

--- a/packages/swap/src/adapters/api/muesliswap/types.ts
+++ b/packages/swap/src/adapters/api/muesliswap/types.ts
@@ -107,8 +107,7 @@ export type OrdersHistoryResponse = {
 }
 
 export type CancelRequest = {
-  tx_hash: string
-  output_idx: number
+  order_ids: string[]
 }
 
 export type CancelResponse = {
@@ -121,7 +120,8 @@ export type LimitOrderRequest = {
   buy_amount: string
   sell_amount: string
   user_address: string
-  dex: Dex
+  // Changed from dex to order_contract
+  order_contract?: Dex
   partner?: string
   numbers_have_decimals?: boolean
   utxos?: string[]
@@ -134,7 +134,8 @@ export type CreateOrderRequest = {
   sell_amount?: string
   user_address: string
   slippage?: number
-  dex?: ReadonlyArray<Dex> | Dex
+  // Changed from dex to excluded_sources
+  excluded_sources?: ReadonlyArray<Dex> | Dex
   partner?: string
   numbers_have_decimals?: boolean
   utxos?: string[]
@@ -146,8 +147,8 @@ export type QuoteRequest = {
   buy_amount?: string
   sell_amount?: string
   slippage?: number
-  // TODO: @jorbuedo it looks to accept string/array of strings
-  dex?: ReadonlyArray<Dex> | Dex
+  // Changed from dex to excluded_sources
+  excluded_sources?: ReadonlyArray<Dex> | Dex
   partner?: string
   numbers_have_decimals?: boolean
 }
@@ -157,7 +158,8 @@ export type LimitQuoteRequest = {
   sell_token: string
   buy_amount: string
   sell_amount: string
-  dex?: Dex
+  // Changed from dex to order_contract
+  order_contract?: Dex
   partner?: string
   numbers_have_decimals?: boolean
 }
@@ -188,7 +190,8 @@ export type QuoteResponse = {
   sell_token_decimals: number
   net_price: number
   net_price_impact: number
-  frontend_fee: number | string
+  // Changed from frontend_fee to service_fee
+  service_fee: number | string
   total_output_without_slippage?: number | string
   splits: Array<Split>
   numbers_have_decimals: boolean


### PR DESCRIPTION
- Update types to use excluded_sources instead of dex
- Change frontend_fee to service_fee in response types
- Update cancel request to use order_ids array
- Simplify transformers to directly map blockedProtocols to excluded_sources
- Remove unnecessary resolveDexes function
- Update all tests and mocks to reflect new API structure

The new API uses excluded_sources (exclusion list) instead of dex (selection list), which maps directly to our existing blockedProtocols concept.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated naming conventions for order and quote requests, replacing previous fields with clearer identifiers for order contracts and excluded sources.
  * Enhanced request structures to support more flexible filtering and identification of decentralized exchanges (DEXes).

* **Bug Fixes**
  * Standardized fee naming in responses, ensuring consistent terminology across the platform.

* **Refactor**
  * Streamlined data structures for order cancellations and requests, improving clarity and maintainability.
  * Removed deprecated helper functions and updated related tests accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->