### PR TITLE
fix(mobile): initial wallet load crash

### DIFF
--- a/mobile/src/features/Notifications/common/GetImportantAlertsModal.tsx
+++ b/mobile/src/features/Notifications/common/GetImportantAlertsModal.tsx
@@ -1,23 +1,23 @@
-import {atoms as a, useTheme} from '@yoroi/theme'
+import { atoms as a, useTheme } from '@yoroi/theme'
 
 import * as React from 'react'
-import {InteractionManager, View, useWindowDimensions} from 'react-native'
+import { InteractionManager, View, useWindowDimensions } from 'react-native'
 
-import {useStrings} from '~/kernel/i18n/useStrings'
-import {Button, ButtonType} from '~/ui/Button/Button'
-import {useModal} from '~/ui/Modal/ModalContext'
-import {PhoneBell} from '~/ui/PhoneBellIllustration/PhoneBellIllustration'
-import {Space} from '~/ui/Space/Space'
-import {Text} from '~/ui/Text/Text'
+import { useStrings } from '~/kernel/i18n/useStrings'
+import { Button, ButtonType } from '~/ui/Button/Button'
+import { useModal } from '~/ui/Modal/ModalContext'
+import { PhoneBell } from '~/ui/PhoneBellIllustration/PhoneBellIllustration'
+import { Space } from '~/ui/Space/Space'
+import { Text } from '~/ui/Text/Text'
 
-import {uiStorage} from './storage'
-import {triggerNotificationsPermissionModal} from './tools'
+import { uiStorage } from './storage'
+import { triggerNotificationsPermissionModal } from './tools'
 
 const timeToShowModalInMs = 1000
 const modalStorageKey = 'hasShownGetImportantAlertsModal'
 
 export const useGetImportantAlertsModal = ({enabled}: {enabled: boolean}) => {
-  const {openModal} = useModal()
+  const {openModal, closeModal} = useModal()
   const {height: windowHeight} = useWindowDimensions()
   const strings = useStrings()
 
@@ -30,25 +30,30 @@ export const useGetImportantAlertsModal = ({enabled}: {enabled: boolean}) => {
 
       openModal({
         title: strings.notifications.getImportantAlerts,
-        content: <GetImportantAlertsModal />,
+        content: <GetImportantAlertsModal onClose={closeModal} />,
         height: 520,
       })
       await uiStorage.setItem(modalStorageKey, true)
     }, timeToShowModalInMs)
 
     return () => clearTimeout(timeout)
-  }, [openModal, strings, windowHeight, enabled])
+  }, [openModal, strings, windowHeight, enabled, closeModal])
 }
 
-export const GetImportantAlertsModal = () => {
+type GetImportantAlertsModalProps = {
+  onClose: () => void
+}
+
+export const GetImportantAlertsModal = ({
+  onClose,
+}: GetImportantAlertsModalProps) => {
   const strings = useStrings()
-  const {closeModal} = useModal()
   const {palette: p} = useTheme()
 
   const handleTurnOnPress = async () => {
     await triggerNotificationsPermissionModal()
 
-    InteractionManager.runAfterInteractions(() => closeModal())
+    InteractionManager.runAfterInteractions(() => onClose())
   }
 
   return (
@@ -74,7 +79,7 @@ export const GetImportantAlertsModal = () => {
       <Button
         size="M"
         title={strings.notifications.skip}
-        onPress={closeModal}
+        onPress={onClose}
         type={ButtonType.Text}
         style={[a.flex_1, a.self_stretch, {flexGrow: 0}]}
       />

--- a/mobile/src/features/Notifications/common/GetImportantAlertsModal.tsx
+++ b/mobile/src/features/Notifications/common/GetImportantAlertsModal.tsx
@@ -1,17 +1,17 @@
-import { atoms as a, useTheme } from '@yoroi/theme'
+import {atoms as a, useTheme} from '@yoroi/theme'
 
 import * as React from 'react'
-import { InteractionManager, View, useWindowDimensions } from 'react-native'
+import {InteractionManager, View, useWindowDimensions} from 'react-native'
 
-import { useStrings } from '~/kernel/i18n/useStrings'
-import { Button, ButtonType } from '~/ui/Button/Button'
-import { useModal } from '~/ui/Modal/ModalContext'
-import { PhoneBell } from '~/ui/PhoneBellIllustration/PhoneBellIllustration'
-import { Space } from '~/ui/Space/Space'
-import { Text } from '~/ui/Text/Text'
+import {useStrings} from '~/kernel/i18n/useStrings'
+import {Button, ButtonType} from '~/ui/Button/Button'
+import {useModal} from '~/ui/Modal/ModalContext'
+import {PhoneBell} from '~/ui/PhoneBellIllustration/PhoneBellIllustration'
+import {Space} from '~/ui/Space/Space'
+import {Text} from '~/ui/Text/Text'
 
-import { uiStorage } from './storage'
-import { triggerNotificationsPermissionModal } from './tools'
+import {uiStorage} from './storage'
+import {triggerNotificationsPermissionModal} from './tools'
 
 const timeToShowModalInMs = 1000
 const modalStorageKey = 'hasShownGetImportantAlertsModal'


### PR DESCRIPTION
`useModal` cannot be used inside modal at the moment