### PR TITLE
Reset send funnel form after transaction

### DIFF
--- a/mobile/src/features/Send/useCases/ListAmountsToSend/ListAmountsToSendScreen.tsx
+++ b/mobile/src/features/Send/useCases/ListAmountsToSend/ListAmountsToSendScreen.tsx
@@ -51,6 +51,7 @@ export const ListAmountsToSendScreen = () => {
     selectedTargetIndex,
     tokenSelectedChanged,
     amountRemoved,
+    reset,
   } = useTransfer()
   const {saveMemo} = useSaveMemo({wallet})
   const {amounts} = targets[selectedTargetIndex].entry
@@ -101,6 +102,8 @@ export const ListAmountsToSendScreen = () => {
       saveMemo({txId: signedTx.signedTx.id, memo: memo.trim()})
     }
 
+    // Reset the send form state after successful transaction
+    reset()
     navigateTo.submittedTx()
   }
 


### PR DESCRIPTION
Reset the Send form state after a successful transaction to ensure a clean form on re-entry.

---
<a href="https://cursor.com/background-agent?bcId=bc-f085e159-e9d1-43aa-a1c1-e597609a2876">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f085e159-e9d1-43aa-a1c1-e597609a2876">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

