### PR TITLE
fix(mobile): Fix dapps welcome ready and wallet remove transition

### DIFF
--- a/mobile/src/features/Discover/common/useShowWelcomeDApp.tsx
+++ b/mobile/src/features/Discover/common/useShowWelcomeDApp.tsx
@@ -14,8 +14,9 @@ export const useShowWelcomeDApp = () => {
     `wallet/${wallet.id}/${storageRootDAppExplorer}/`,
   )
 
-  const [localValue, setLocalValue] = React.useState<boolean>(false)
-  const [isLoaded, setIsLoaded] = React.useState<boolean>(false)
+  const [localValue, setLocalValue] = React.useState<boolean | undefined>(
+    undefined,
+  )
 
   React.useEffect(() => {
     const asyncEffect = async () => {
@@ -23,7 +24,6 @@ export const useShowWelcomeDApp = () => {
       const parsed = parseSafe(storedStorage)
       const value = isBoolean(parsed) ? parsed : false
       setLocalValue(value)
-      setIsLoaded(true)
     }
     asyncEffect()
   }, [walletStorage])
@@ -36,5 +36,5 @@ export const useShowWelcomeDApp = () => {
     [walletStorage],
   )
 
-  return [localValue, updateValue, isLoaded] as const
+  return [localValue, updateValue] as const
 }

--- a/mobile/src/features/Discover/common/useShowWelcomeDApp.tsx
+++ b/mobile/src/features/Discover/common/useShowWelcomeDApp.tsx
@@ -15,6 +15,7 @@ export const useShowWelcomeDApp = () => {
   )
 
   const [localValue, setLocalValue] = React.useState<boolean>(false)
+  const [isLoaded, setIsLoaded] = React.useState<boolean>(false)
 
   React.useEffect(() => {
     const asyncEffect = async () => {
@@ -22,6 +23,7 @@ export const useShowWelcomeDApp = () => {
       const parsed = parseSafe(storedStorage)
       const value = isBoolean(parsed) ? parsed : false
       setLocalValue(value)
+      setIsLoaded(true)
     }
     asyncEffect()
   }, [walletStorage])
@@ -34,5 +36,5 @@ export const useShowWelcomeDApp = () => {
     [walletStorage],
   )
 
-  return [localValue, updateValue] as const
+  return [localValue, updateValue, isLoaded] as const
 }

--- a/mobile/src/features/Discover/useCases/BrowseDapp/WebViewItem.tsx
+++ b/mobile/src/features/Discover/useCases/BrowseDapp/WebViewItem.tsx
@@ -83,12 +83,15 @@ export const WebViewItem = ({tab, index}: Props) => {
     setWebViewState(event)
   }
 
+  const handleLoadStart = () => {
+    // Mark WebView as ready when it starts loading, before the dapp-connector script runs
+    markWebViewReady()
+  }
+
   const handleEventLoadWebView = (event: WebViewNavigationEvent) => {
     const url = event.nativeEvent.url
     if (url !== 'about:blank') {
       updateTab(+index, {url})
-      // Mark WebView as ready after successful load
-      markWebViewReady()
     }
   }
 
@@ -161,6 +164,7 @@ export const WebViewItem = ({tab, index}: Props) => {
             androidLayerType="hardware"
             source={{uri: webURL}}
             onNavigationStateChange={handleNavigationStateChange}
+            onLoadStart={handleLoadStart}
             onLoad={handleEventLoadWebView}
             javaScriptEnabled
             scalesPageToFit

--- a/mobile/src/features/Discover/useCases/SelectDappFromList/SelectDappFromListScreen.tsx
+++ b/mobile/src/features/Discover/useCases/SelectDappFromList/SelectDappFromListScreen.tsx
@@ -41,7 +41,7 @@ export const SelectDappFromListScreen = () => {
     [],
   )
   const {track} = useMetrics()
-  const [isShowedWelcomeDApp, , isWelcomeLoaded] = useShowWelcomeDApp()
+  const [isShowedWelcomeDApp] = useShowWelcomeDApp()
 
   React.useEffect(() => {
     if (currentTab === 'recommended') {
@@ -87,11 +87,13 @@ export const SelectDappFromListScreen = () => {
 
   return (
     <>
-      <WelcomeDAppModal disabled={!isWelcomeLoaded || isShowedWelcomeDApp} />
+      <WelcomeDAppModal
+        disabled={isShowedWelcomeDApp === undefined || isShowedWelcomeDApp}
+      />
 
       <ShowDisclaimer
         type="dapps"
-        disabled={!isWelcomeLoaded || !isShowedWelcomeDApp}
+        disabled={isShowedWelcomeDApp === undefined || !isShowedWelcomeDApp}
       />
 
       <View style={[a.flex_1, ta.bg_color_max, a.px_lg, a.gap_lg]}>

--- a/mobile/src/features/Discover/useCases/SelectDappFromList/SelectDappFromListScreen.tsx
+++ b/mobile/src/features/Discover/useCases/SelectDappFromList/SelectDappFromListScreen.tsx
@@ -41,7 +41,7 @@ export const SelectDappFromListScreen = () => {
     [],
   )
   const {track} = useMetrics()
-  const [isShowedWelcomeDApp] = useShowWelcomeDApp()
+  const [isShowedWelcomeDApp, , isWelcomeLoaded] = useShowWelcomeDApp()
 
   React.useEffect(() => {
     if (currentTab === 'recommended') {
@@ -87,9 +87,12 @@ export const SelectDappFromListScreen = () => {
 
   return (
     <>
-      <WelcomeDAppModal disabled={isShowedWelcomeDApp} />
+      <WelcomeDAppModal disabled={!isWelcomeLoaded || isShowedWelcomeDApp} />
 
-      <ShowDisclaimer type="dapps" disabled={!isShowedWelcomeDApp} />
+      <ShowDisclaimer
+        type="dapps"
+        disabled={!isWelcomeLoaded || !isShowedWelcomeDApp}
+      />
 
       <View style={[a.flex_1, ta.bg_color_max, a.px_lg, a.gap_lg]}>
         <ChainDAppsWarning />

--- a/mobile/src/features/Discover/useCases/SelectDappFromList/WelcomeDAppModal.tsx
+++ b/mobile/src/features/Discover/useCases/SelectDappFromList/WelcomeDAppModal.tsx
@@ -15,11 +15,11 @@ export const WelcomeDAppModal = ({disabled}: {disabled?: boolean}) => {
   const {palette: p} = useTheme()
   const insets = useSafeAreaInsets()
   const {openModal, closeModal} = useModal()
-  const [seen, setSeen, isLoaded] = useShowWelcomeDApp()
+  const [seen, setSeen] = useShowWelcomeDApp()
   const [showing, setShowing] = React.useState(false)
 
   React.useEffect(() => {
-    if (disabled || seen || showing || !isLoaded) return
+    if (disabled || seen || showing || seen === undefined) return
 
     openModal({
       title: strings.discover.welcomeToYoroiDAppExplorer,
@@ -54,7 +54,6 @@ export const WelcomeDAppModal = ({disabled}: {disabled?: boolean}) => {
     closeModal,
     disabled,
     insets.bottom,
-    isLoaded,
     openModal,
     seen,
     setSeen,

--- a/mobile/src/features/Discover/useCases/SelectDappFromList/WelcomeDAppModal.tsx
+++ b/mobile/src/features/Discover/useCases/SelectDappFromList/WelcomeDAppModal.tsx
@@ -15,11 +15,11 @@ export const WelcomeDAppModal = ({disabled}: {disabled?: boolean}) => {
   const {palette: p} = useTheme()
   const insets = useSafeAreaInsets()
   const {openModal, closeModal} = useModal()
-  const [seen, setSeen] = useShowWelcomeDApp()
+  const [seen, setSeen, isLoaded] = useShowWelcomeDApp()
   const [showing, setShowing] = React.useState(false)
 
   React.useEffect(() => {
-    if (disabled || seen || showing) return
+    if (disabled || seen || showing || !isLoaded) return
 
     openModal({
       title: strings.discover.welcomeToYoroiDAppExplorer,
@@ -54,6 +54,7 @@ export const WelcomeDAppModal = ({disabled}: {disabled?: boolean}) => {
     closeModal,
     disabled,
     insets.bottom,
+    isLoaded,
     openModal,
     seen,
     setSeen,

--- a/mobile/src/features/Settings/useCases/changeWalletSettings/RemoveWallet/RemoveWalletScreen.tsx
+++ b/mobile/src/features/Settings/useCases/changeWalletSettings/RemoveWallet/RemoveWalletScreen.tsx
@@ -31,7 +31,11 @@ export const RemoveWalletScreen = () => {
 
   const handleOnRemoveWallet = () => {
     walletManager.removeWallet(wallet.id)
-    navigation.goBack()
+    // Navigate to wallet selection screen since the current wallet is being removed
+    // Navigate to the manage-wallets screen with wallet-selection as the initial route
+    navigation.navigate('manage-wallets', {
+      screen: 'wallet-selection',
+    })
   }
 
   return (

--- a/mobile/src/features/WalletManager/wallet-manager.ts
+++ b/mobile/src/features/WalletManager/wallet-manager.ts
@@ -625,6 +625,11 @@ export class WalletManager {
       id,
     ])
 
+    // If the removed wallet is the currently selected one, clear the selection
+    if (this.#selectedWalletId$.value === id) {
+      this.#selectedWalletId$.next(null)
+    }
+
     // can't update the walletInfo here cuz it might be in the middle of wallet syncing
     this.#wallets.delete(id)
     const metas = new Map(this.#walletMetas$.value)


### PR DESCRIPTION
- Welcome dapp was opening while storage was still loading
- After removing a wallet, have to go to wallet selection to not get an error