### PR TITLE
fix screen share crash

### DIFF
--- a/mobile/src/features/Settings/useCases/changeAppSettings/ApplicationSettingsScreen.tsx
+++ b/mobile/src/features/Settings/useCases/changeAppSettings/ApplicationSettingsScreen.tsx
@@ -16,7 +16,7 @@ import {
 } from '~/features/Settings/SettingsItems'
 import {useNavigateTo} from '~/features/Settings/common/navigation'
 import {useSelectedNetwork} from '~/features/WalletManager/hooks/useSelectedNetwork'
-import {isAndroid} from '~/kernel/constants'
+import {isAndroid, isDev} from '~/kernel/constants'
 import {useLanguage} from '~/kernel/i18n/LanguageProvider'
 import {LanguageRecord, supportedLanguages} from '~/kernel/i18n/localization'
 import {useStrings} from '~/kernel/i18n/useStrings'
@@ -170,7 +170,7 @@ export const ApplicationSettingsScreen = () => {
             <CrashReportsSwitch />
           </SettingsItem>
 
-          {isAndroid && (
+          {isAndroid && isDev && (
             <SettingsItem
               icon={<Icon.Share {...iconProps} />}
               label={strings.settings.applicationSettings.screenSharing}

--- a/mobile/src/features/Settings/useCases/changeAppSettings/ScreenShare/ScreenShare.ts
+++ b/mobile/src/features/Settings/useCases/changeAppSettings/ScreenShare/ScreenShare.ts
@@ -42,6 +42,10 @@ export const useInitScreenShare = () => {
 export const changeScreenShareNativeSettingOnAndroid = (
   screenShareEnabled: boolean,
 ) => {
+  if (!FlagSecure) {
+    return
+  }
+
   if (screenShareEnabled) {
     FlagSecure.deactivate()
   } else {


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YV-593

Screen sharing enable/disable, which was only in Android, seems to be broken.
This will at least prevent the crash, and disable it for non dev. 
Making it work will need more work down the line.