### PR TITLE
fix(mobile): fix DApp connection modal flow and clean up disconnected dApp WebViews

### DIFF
--- a/mobile/packages/dapp-connector/connector.js
+++ b/mobile/packages/dapp-connector/connector.js
@@ -155,7 +155,38 @@ const initWallet = ({
   ]
 
   window.addEventListener('message', (event) => {
-    if (!event.data || typeof event.data.id !== 'string') return
+    if (!event.data) return
+
+    if (event.data.type === 'wallet-disconnect') {
+      logMessage('Wallet disconnected, clearing session')
+      try {
+        // eslint-disable-next-line no-undef
+        localStorage.removeItem('yoroi-session-id')
+      } catch {
+        // localStorage not available in some environments
+      }
+      promisesMap.clear()
+      enabling = false
+
+      if (window.cardano && window.cardano[walletName]) {
+        delete window.cardano[walletName]
+      }
+
+      // Notify any listeners about wallet disconnection
+      if (
+        typeof window.dispatchEvent === 'function' &&
+        typeof Event !== 'undefined'
+      ) {
+        try {
+          window.dispatchEvent(new Event('yoroi-wallet-disconnect'))
+        } catch {
+          // Event dispatch not available
+        }
+      }
+      return
+    }
+
+    if (typeof event.data.id !== 'string') return
     logMessage('Received message ' + JSON.stringify(event.data))
 
     const {id, result, error} = event.data

--- a/mobile/src/features/Discover/common/BrowserProvider.tsx
+++ b/mobile/src/features/Discover/common/BrowserProvider.tsx
@@ -2,6 +2,7 @@ import {invalid} from '@yoroi/common'
 
 import {produce} from 'immer'
 import * as React from 'react'
+import WebView from 'react-native-webview'
 
 import {useWalletManager} from '~/features/WalletManager/context/WalletManagerProvider'
 
@@ -12,6 +13,9 @@ const defaultActions: BrowserActions = {
   updateTab: () => invalid('missing init'),
   removeTab: () => invalid('missing init'),
   openTabs: () => invalid('missing init'),
+  registerWebView: () => invalid('missing init'),
+  unregisterWebView: () => invalid('missing init'),
+  sendDisconnectToOrigins: () => invalid('missing init'),
 } as const
 
 const defaultState: BrowserState = {
@@ -19,6 +23,14 @@ const defaultState: BrowserState = {
   tabActiveIndex: -1,
   tabsOpen: false,
 } as const
+
+type WebViewRegistry = Map<
+  string,
+  {
+    webViewRef: React.RefObject<WebView | null>
+    sendDisconnectMessage: () => void
+  }
+>
 
 export type TabItem = {
   id: string
@@ -55,6 +67,8 @@ export const BrowserProvider = ({
     ...defaultState,
     ...initialState,
   })
+
+  const webViewRegistryRef = React.useRef<WebViewRegistry>(new Map())
 
   React.useEffect(() => {
     if (storageId === null) return
@@ -96,6 +110,31 @@ export const BrowserProvider = ({
     },
     openTabs: (isOpen) => {
       dispatch({type: BrowserActionType.OpenTabs, isOpen})
+    },
+    registerWebView: (
+      tabId: string,
+      webViewRef: React.RefObject<WebView | null>,
+      sendDisconnectMessage: () => void,
+    ) => {
+      webViewRegistryRef.current.set(tabId, {webViewRef, sendDisconnectMessage})
+    },
+    unregisterWebView: (tabId: string) => {
+      webViewRegistryRef.current.delete(tabId)
+    },
+    sendDisconnectToOrigins: (origins: string[]) => {
+      browserState.tabs.forEach((tab) => {
+        try {
+          const tabOrigin = new URL(tab.url).origin
+          if (origins.includes(tabOrigin)) {
+            const registration = webViewRegistryRef.current.get(tab.id)
+            if (registration) {
+              registration.sendDisconnectMessage()
+            }
+          }
+        } catch {
+          // Invalid URL, skip
+        }
+      })
     },
   }).current
 
@@ -165,6 +204,13 @@ type BrowserActions = Readonly<{
   updateTab: (tabIndex: number, tabInfo: Partial<Omit<TabItem, 'id'>>) => void
   removeTab: (index: number) => void
   openTabs: (isOpen: boolean) => void
+  registerWebView: (
+    tabId: string,
+    webViewRef: React.RefObject<WebView | null>,
+    sendDisconnectMessage: () => void,
+  ) => void
+  unregisterWebView: (tabId: string) => void
+  sendDisconnectToOrigins: (origins: string[]) => void
 }>
 
 const browserReducer = (

--- a/mobile/src/features/Discover/common/BrowserProvider.tsx
+++ b/mobile/src/features/Discover/common/BrowserProvider.tsx
@@ -122,7 +122,15 @@ export const BrowserProvider = ({
       webViewRegistryRef.current.delete(tabId)
     },
     sendDisconnectToOrigins: (origins: string[]) => {
-      browserState.tabs.forEach((tab) => {
+      // Get current tabs directly from the state via the ref to avoid stale closure
+      const getCurrentTabs = () => {
+        if (storageId === null) return []
+        const currentState = memoryStorage.get(storageId)
+        return currentState?.tabs || []
+      }
+
+      const currentTabs = getCurrentTabs()
+      currentTabs.forEach((tab) => {
         try {
           const tabOrigin = new URL(tab.url).origin
           if (origins.includes(tabOrigin)) {

--- a/mobile/src/features/Discover/common/UnverifiedDappModal.tsx
+++ b/mobile/src/features/Discover/common/UnverifiedDappModal.tsx
@@ -41,7 +41,10 @@ export const useOpenUnverifiedDappModal = () => {
         footer: (
           <Button
             title={strings.discover.understand}
-            onPress={options.onConfirm}
+            onPress={() => {
+              options.onConfirm()
+              closeModal()
+            }}
           />
         ),
         height: 320 + insets.bottom,
@@ -52,6 +55,7 @@ export const useOpenUnverifiedDappModal = () => {
     [
       insets.bottom,
       openModal,
+      closeModal,
       p.gray_900,
       strings.discover.disclaimerModalText,
       strings.discover.disclaimerModalTitle,

--- a/mobile/src/features/Discover/common/helpers.ts
+++ b/mobile/src/features/Discover/common/helpers.ts
@@ -169,3 +169,20 @@ export const getDappFallbackLogo = (website: string) => {
   const withoutProtocol = website.replace(/(^\w+:|^)\/\//, '')
   return `https://${withoutProtocol}/favicon.ico`
 }
+
+export const getTabIndexesByOrigins = (
+  tabs: Array<{url: string}>,
+  origins: string[],
+): number[] => {
+  return tabs.reduce<number[]>((acc, tab, index) => {
+    try {
+      const tabOrigin = new URL(tab.url).origin
+      if (origins.includes(tabOrigin)) {
+        acc.push(index)
+      }
+    } catch {
+      // Invalid URL, skip
+    }
+    return acc
+  }, [])
+}

--- a/mobile/src/features/Discover/common/hooks.tsx
+++ b/mobile/src/features/Discover/common/hooks.tsx
@@ -104,11 +104,20 @@ export const useConnectWalletToWebView = (
     setIsWebViewReady(true)
   }, [])
 
+  const sendDisconnectMessage = React.useCallback(() => {
+    const disconnectMessage = getInjectableMessage({
+      type: 'wallet-disconnect',
+      timestamp: Date.now(),
+    })
+    webViewRef.current?.injectJavaScript(disconnectMessage)
+  }, [webViewRef])
+
   return {
     handleEvent: handleWebViewEvent,
     initScript: getInitScript(sessionId, manager),
     sessionId,
     markWebViewReady,
+    sendDisconnectMessage,
   }
 }
 

--- a/mobile/src/features/Discover/common/useConfirmConnection.ts
+++ b/mobile/src/features/Discover/common/useConfirmConnection.ts
@@ -9,7 +9,7 @@ import {useInvalidateConnectedDapps} from './useDAppsConnected'
 
 export const useConfirmConnection = () => {
   const {openConfirmConnectionModal} = useOpenConfirmConnectionModal()
-  const {openUnverifiedDappModal, closeModal} = useOpenUnverifiedDappModal()
+  const {openUnverifiedDappModal} = useOpenUnverifiedDappModal()
   const invalidateConnectedDapps = useInvalidateConnectedDapps()
 
   return React.useCallback(
@@ -42,18 +42,17 @@ export const useConfirmConnection = () => {
         }
 
         if (!selectedDapp) {
-          let shouldResolveOnClose = true
+          let shouldOpenMainModal = false
           openUnverifiedDappModal({
             onClose: () => {
-              if (shouldResolveOnClose) resolve(false)
+              if (shouldOpenMainModal) {
+                openMainModal()
+              } else {
+                resolve(false)
+              }
             },
             onConfirm: () => {
-              shouldResolveOnClose = false
-              closeModal()
-              // Small delay to ensure modal system is ready for next modal
-              setTimeout(() => {
-                openMainModal()
-              }, 100)
+              shouldOpenMainModal = true
             },
           })
           return
@@ -65,7 +64,6 @@ export const useConfirmConnection = () => {
     [
       openConfirmConnectionModal,
       openUnverifiedDappModal,
-      closeModal,
       invalidateConnectedDapps,
     ],
   )

--- a/mobile/src/features/Discover/common/useDisconnectDapp.ts
+++ b/mobile/src/features/Discover/common/useDisconnectDapp.ts
@@ -4,21 +4,57 @@ import * as React from 'react'
 
 import {useMetrics} from '~/kernel/metrics/metricsManager'
 
+import {useBrowser} from './BrowserProvider'
 import type {DAppItem} from './helpers'
+import {getTabIndexesByOrigins} from './helpers'
 import {useInvalidateConnectedDapps} from './useDAppsConnected'
 
 export const useDisconnectDapp = () => {
   const {manager} = useDappConnector()
   const {track} = useMetrics()
   const invalidateConnectedDapps = useInvalidateConnectedDapps()
+  const {
+    sendDisconnectToOrigins,
+    tabs,
+    removeTab,
+    tabActiveIndex,
+    setTabActive,
+  } = useBrowser()
 
   return React.useCallback(
     async (dApp: DAppItem) => {
       track.discoverConnectedBottomSheetDisconnectClicked()
+
+      const tabIndexesToClose = getTabIndexesByOrigins(tabs, dApp.origins)
+
+      // First send disconnect notification to WebViews
+      sendDisconnectToOrigins(dApp.origins)
+
+      // Close tabs before removing connections to ensure proper cleanup
+      tabIndexesToClose
+        .sort((a: number, b: number) => b - a)
+        .forEach((tabIndex: number) => {
+          if (tabIndex <= tabActiveIndex) {
+            setTabActive(Math.max(0, tabActiveIndex - 1))
+          }
+          removeTab(tabIndex)
+        })
+
+      // Then remove connections from storage
       const connections = dApp.origins.map((origin) => ({dappOrigin: origin}))
       await manager.removeConnections(connections)
+
       await invalidateConnectedDapps()
     },
-    [manager, track, invalidateConnectedDapps],
+    [
+      manager,
+      track,
+      invalidateConnectedDapps,
+      sendDisconnectToOrigins,
+      tabs,
+      removeTab,
+      tabActiveIndex,
+      setTabActive,
+    ],
   )
 }

--- a/mobile/src/features/Discover/common/useDisconnectDapp.ts
+++ b/mobile/src/features/Discover/common/useDisconnectDapp.ts
@@ -31,11 +31,13 @@ export const useDisconnectDapp = () => {
       sendDisconnectToOrigins(dApp.origins)
 
       // Close tabs before removing connections to ensure proper cleanup
+      let currentActiveIndex = tabActiveIndex
       tabIndexesToClose
         .sort((a: number, b: number) => b - a)
         .forEach((tabIndex: number) => {
-          if (tabIndex <= tabActiveIndex) {
-            setTabActive(Math.max(0, tabActiveIndex - 1))
+          if (tabIndex <= currentActiveIndex) {
+            currentActiveIndex = Math.max(0, currentActiveIndex - 1)
+            setTabActive(currentActiveIndex)
           }
           removeTab(tabIndex)
         })

--- a/mobile/src/features/Discover/useCases/BrowseDapp/WebViewItem.tsx
+++ b/mobile/src/features/Discover/useCases/BrowseDapp/WebViewItem.tsx
@@ -52,6 +52,8 @@ export const WebViewItem = ({tab, index}: Props) => {
     setTabActive,
     removeTab,
     tabActiveIndex,
+    registerWebView,
+    unregisterWebView,
   } = useBrowser()
   const webURL = tab?.url
   const {domainName} = getDomainFromUrl(webURL)
@@ -62,11 +64,12 @@ export const WebViewItem = ({tab, index}: Props) => {
   const scaleXWebview = useSharedValue(1)
   const opacityValue = useSharedValue(0)
 
-  const {initScript, handleEvent, markWebViewReady} = useConnectWalletToWebView(
-    wallet,
-    webViewRef,
-    webURL, // Pass the tab URL as fallback
-  )
+  const {initScript, handleEvent, markWebViewReady, sendDisconnectMessage} =
+    useConnectWalletToWebView(
+      wallet,
+      webViewRef,
+      webURL, // Pass the tab URL as fallback
+    )
 
   const containerStyleAnimated = useAnimatedStyle(() => {
     return {transform: [{scaleX: scaleXWebview.value}]}
@@ -115,6 +118,14 @@ export const WebViewItem = ({tab, index}: Props) => {
 
     removeTab(index)
   }
+
+  React.useEffect(() => {
+    registerWebView(tab.id, webViewRef, sendDisconnectMessage)
+
+    return () => {
+      unregisterWebView(tab.id)
+    }
+  }, [tab.id, registerWebView, unregisterWebView, sendDisconnectMessage])
 
   React.useEffect(() => {
     const scaleXRatio = 1 - 16 / SCREEN_WIDTH

--- a/mobile/src/features/Links/hooks/useLinksRequestAction.tsx
+++ b/mobile/src/features/Links/hooks/useLinksRequestAction.tsx
@@ -272,6 +272,7 @@ export const useLinksRequestAction = () => {
           )
           break
         case 'launch':
+          console.log('openRequestedBrowserLaunchDappUrl')
           openRequestedBrowserLaunchDappUrl({
             params: action.info.params,
             isTrusted: action.isTrusted,

--- a/mobile/src/features/Links/hooks/useLinksRequestAction.tsx
+++ b/mobile/src/features/Links/hooks/useLinksRequestAction.tsx
@@ -272,7 +272,6 @@ export const useLinksRequestAction = () => {
           )
           break
         case 'launch':
-          console.log('openRequestedBrowserLaunchDappUrl')
           openRequestedBrowserLaunchDappUrl({
             params: action.info.params,
             isTrusted: action.isTrusted,

--- a/mobile/src/ui/Modal/ModalContext.tsx
+++ b/mobile/src/ui/Modal/ModalContext.tsx
@@ -88,14 +88,10 @@ export const ModalProvider = ({children, initialState}: Props) => {
   }, [state.isOpen, state.queue])
 
   const closeModal = React.useCallback(() => {
-    if (state.onClose) {
-      state.onClose()
-    }
-
     dispatch({
       type: 'closeAndProcessQueue',
     })
-  }, [state])
+  }, [])
 
   const openModal = React.useCallback(
     ({
@@ -316,6 +312,14 @@ const modalReducer = (state: ModalState, action: ModalAction) => {
       }
 
     case 'closeAndProcessQueue':
+      if (state.onClose) {
+        try {
+          state.onClose()
+        } catch (error) {
+          console.error('[ModalReducer] Error calling onClose:', error)
+        }
+      }
+
       if (state.queue.length > 0) {
         const nextModal = state.queue[0]
         return {
@@ -391,5 +395,6 @@ const defaultState: ModalState = Object.freeze({
   canContinue: false,
   full: false,
   withFeedback: false,
+  onClose: undefined,
   queue: [],
 })


### PR DESCRIPTION
**Fixes included:**

- Resolved a blocking issue in the DApp connection flow where the disclaimer modal didn’t close after clicking “Understand”, preventing the confirmation modal from appearing.

- Additionally, while addressing this, a parallel bug was found and fixed: disconnected dApps kept active WebView tabs that continued making API calls, causing repeated connection errors. A proper disconnect flow was added to cleanly notify, close tabs, and remove connections.

Related prs: https://emurgo.atlassian.net/browse/YV-651