### PR TITLE
fix(common, mobile): decimal edge cases

### DIFF
--- a/mobile/packages/common/utils/parse-number-from-text.ts
+++ b/mobile/packages/common/utils/parse-number-from-text.ts
@@ -155,7 +155,7 @@ export const parseNumberFromText = ({
 
     return {
       sanitizedInput,
-      formattedValue,
+      formattedValue: formattedValue?.replace(/[,|.]$/, ''),
       numericValue: bnValue.toNumber(),
       quantity,
     }
@@ -204,7 +204,7 @@ export const parseNumberFromText = ({
 
   return {
     sanitizedInput: finalSanitizedInput,
-    formattedValue,
+    formattedValue: formattedValue?.replace(/[,|.]$/, ''),
     numericValue: bnValue.toNumber(),
     quantity,
   }

--- a/mobile/src/features/Swap/common/EstimateSummary/EstimateSummary.tsx
+++ b/mobile/src/features/Swap/common/EstimateSummary/EstimateSummary.tsx
@@ -25,8 +25,9 @@ export const EstimateSummary = () => {
   const {openModal} = useModal()
   const navigateTo = useNavigateTo()
   const {numberLocale} = useLanguage()
-  const localFormat = (v: number | string) =>
-    parseNumberFromText({text: String(v), format: numberLocale}).formattedValue
+  const localFormat = (v: number | string, precision?: number) =>
+    parseNumberFromText({text: String(v), format: numberLocale, precision})
+      .formattedValue
   const tokenInInfo = swapForm.tokenInfos.get(
     swapForm.tokenInInput.tokenId ?? undefinedToken,
   )
@@ -40,12 +41,6 @@ export const EstimateSummary = () => {
   const protocol = swapForm.estimate?.splits[0]?.protocol
 
   if (swapForm.estimate === undefined) return null
-
-  const netPrice = swapForm.estimate.netPrice
-  const roundedPrice = netPrice
-    .toFixed(tokenOutInfo?.decimals ?? 0)
-    .replace(/\.0+$/, '')
-  const price = roundedPrice !== '0' ? roundedPrice : netPrice.toFixed(6)
 
   const expand = () =>
     openModal({
@@ -86,7 +81,7 @@ export const EstimateSummary = () => {
             ? strings.swap.limitPriceInfo
             : strings.swap.marketPriceInfo
         }
-        value={`1 ${tokenInTicker} = ${localFormat(price)} ${tokenOutTicker}`}
+        value={`1 ${tokenInTicker} = ${localFormat(swapForm.estimate?.netPrice ?? 0, Math.max(tokenOutInfo?.decimals ?? 0, tokenInInfo?.decimals ?? 0, 3))} ${tokenOutTicker}`}
       />
 
       <Space.Height.sm />

--- a/mobile/src/features/Swap/useCases/CreateOrder/SelectProtocolScreen.tsx
+++ b/mobile/src/features/Swap/useCases/CreateOrder/SelectProtocolScreen.tsx
@@ -1,3 +1,4 @@
+import {parseNumberFromText} from '@yoroi/common'
 import {atoms as a, useTheme} from '@yoroi/theme'
 
 import {useNavigation} from '@react-navigation/native'
@@ -9,6 +10,7 @@ import {SafeAreaView} from 'react-native-safe-area-context'
 import {undefinedToken} from '~/features/Swap/common/constants'
 import {useSwap} from '~/features/Swap/common/useSwap'
 import {useSelectedWallet} from '~/features/WalletManager/hooks/useSelectedWallet'
+import {useLanguage} from '~/kernel/i18n/LanguageProvider'
 import {useStrings} from '~/kernel/i18n/useStrings'
 import {Counter} from '~/ui/Counter/Counter'
 import {ProtocolAvatar} from '~/ui/ProtocolAvatar/ProtocolAvatar'
@@ -19,7 +21,7 @@ export const SelectProtocolScreen = () => {
   const {wallet} = useSelectedWallet()
   const {limitOptions, ...swapForm} = useSwap()
   const {palette: p} = useTheme()
-
+  const {numberLocale} = useLanguage()
   if (limitOptions === undefined) return null
 
   const tokenInInfo = swapForm.tokenInfos.get(
@@ -33,10 +35,15 @@ export const SelectProtocolScreen = () => {
   const tokenOutTicker = tokenOutInfo?.ticker ?? tokenOutInfo?.name ?? '-'
 
   const formatPrice = (price: number) => {
-    const roundedPrice = price
-      .toFixed(tokenOutInfo?.decimals ?? 0)
-      .replace(/\.0+$/, '')
-    return roundedPrice !== '0' ? roundedPrice : price.toFixed(6)
+    return parseNumberFromText({
+      text: String(price),
+      format: numberLocale,
+      precision: Math.max(
+        tokenOutInfo?.decimals ?? 0,
+        tokenInInfo?.decimals ?? 0,
+        3,
+      ),
+    }).formattedValue
   }
 
   const data = limitOptions.options

--- a/mobile/src/features/Swap/useCases/ListOrders/ListOrders.tsx
+++ b/mobile/src/features/Swap/useCases/ListOrders/ListOrders.tsx
@@ -1,5 +1,5 @@
 import {primaryTokenInfoMainnet} from '@yoroi/blockchains'
-import {isLeft, truncateString} from '@yoroi/common'
+import {isLeft, parseNumberFromText, truncateString} from '@yoroi/common'
 import {infoExtractName} from '@yoroi/portfolio'
 import {atoms as a, useTheme} from '@yoroi/theme'
 import {Api, Portfolio, Swap} from '@yoroi/types'
@@ -18,6 +18,7 @@ import {useSearch, useSearchOnNavBar} from '~/features/Search/SearchContext'
 import {useSwap} from '~/features/Swap/common/useSwap'
 import {useWalletManager} from '~/features/WalletManager/context/WalletManagerProvider'
 import {useSelectedWallet} from '~/features/WalletManager/hooks/useSelectedWallet'
+import {useLanguage} from '~/kernel/i18n/LanguageProvider'
 import {useStrings} from '~/kernel/i18n/useStrings'
 import {useWalletNavigation} from '~/kernel/navigation/hooks/useWalletNavigation'
 import {Boundary} from '~/ui/Boundary/Boundary'
@@ -174,6 +175,7 @@ const Order = ({order}: {order: Swap.Order}) => {
   const {palette: p} = useTheme()
   const [expanded, setExpanded] = React.useState<boolean>(false)
   const swapForm = useSwap()
+  const {numberLocale} = useLanguage()
   const tokenInInfo = swapForm.tokenInfos.get(order.tokenIn)
   const tokenOutInfo = swapForm.tokenInfos.get(order.tokenOut)
 
@@ -182,14 +184,20 @@ const Order = ({order}: {order: Swap.Order}) => {
       ? order.expectedAmountOut
       : order.actualAmountOut
   const priceCalc = amountOut === 0 ? 0 : order.amountIn / amountOut
-  const roundedPrice = priceCalc
-    .toFixed(tokenOutInfo?.decimals ?? 0)
-    .replace(/\.0+$/, '')
-  const price = roundedPrice !== '0' ? roundedPrice : priceCalc.toFixed(6)
 
-  const priceStr = `1 ${tokenName(tokenInInfo)} = ${price} ${tokenName(tokenOutInfo)}`
+  const roundedPrice = parseNumberFromText({
+    text: String(priceCalc),
+    precision: Math.max(
+      tokenOutInfo?.decimals ?? 0,
+      tokenInInfo?.decimals ?? 0,
+      3,
+    ),
+    format: numberLocale,
+  }).formattedValue
 
-  const amountOutStr = `${Number(amountOut.toFixed(tokenOutInfo?.decimals ?? 0))} ${tokenName(tokenOutInfo)}`
+  const priceStr = `1 ${tokenName(tokenInInfo)} = ${roundedPrice} ${tokenName(tokenOutInfo)}`
+
+  const amountOutStr = `${parseNumberFromText({text: String(amountOut), precision: tokenOutInfo?.decimals ?? 0, format: numberLocale}).formattedValue} ${tokenName(tokenOutInfo)}`
 
   const lastTxHash = order.updateTxHash ?? order.txHash ?? ''
   const shortenedTxHash = `${truncateString({value: lastTxHash, maxLength: 22})}#${order.outputIndex ?? 0}`
@@ -559,7 +567,7 @@ const Details = ({
 }: CancellationProps & {response: Api.Response<Swap.CancelResponse>}) => {
   const strings = useStrings()
   const {wallet} = useSelectedWallet()
-
+  const {numberLocale} = useLanguage()
   const portfolioTokenInfos = usePortfolioTokenInfosSuspense({
     wallet,
     tokenIds: [order.tokenIn, order.tokenOut],
@@ -578,7 +586,7 @@ const Details = ({
       ? order.expectedAmountOut
       : order.actualAmountOut
 
-  const amountOutStr = `${Number(amountOut.toFixed(tokenOutInfo?.decimals ?? 0))} ${tokenName(tokenOutInfo)}`
+  const amountOutStr = `${parseNumberFromText({text: String(amountOut), precision: tokenOutInfo?.decimals ?? 0, format: numberLocale}).formattedValue} ${tokenName(tokenOutInfo)}`
 
   const isFromPrimary = tokenOutInfo?.nature === Portfolio.Token.Nature.Primary
   const fromDetail = isFromPrimary
@@ -591,7 +599,7 @@ const Details = ({
     ? tokenOutInfo?.description
     : tokenOutInfo?.fingerprint
   const toName = infoExtractName(tokenOutInfo)
-  const amountInStr = `${Number(order.amountIn.toFixed(tokenInInfo?.decimals ?? 0))} ${tokenName(tokenOutInfo)}`
+  const amountInStr = `${parseNumberFromText({text: String(order.amountIn), precision: tokenInInfo?.decimals ?? 0, format: numberLocale}).formattedValue} ${tokenName(tokenOutInfo)}`
 
   return (
     <View>

--- a/mobile/src/features/Swap/useCases/ReviewSwap/TransactionSummary.tsx
+++ b/mobile/src/features/Swap/useCases/ReviewSwap/TransactionSummary.tsx
@@ -35,8 +35,9 @@ export const TransactionSummary = ({
   const {orderType} = swapForm
   const [showSplits, setShowSplits] = React.useState(false)
   const {numberLocale} = useLanguage()
-  const localFormat = (v: number | string) =>
-    parseNumberFromText({text: String(v), format: numberLocale}).formattedValue
+  const localFormat = (v: number | string, precision?: number) =>
+    parseNumberFromText({text: String(v), format: numberLocale, precision})
+      .formattedValue
   const tokenInInfo = swapForm.tokenInfos.get(
     swapForm.tokenInInput.tokenId ?? undefinedToken,
   )
@@ -78,11 +79,8 @@ export const TransactionSummary = ({
     swapForm.createTx?.netPrice ??
     swapForm.createTx?.splits[0].initialPrice ??
     0
-  const roundedPrice = netPrice
-    .toFixed(tokenOutInfo?.decimals ?? 0)
-    .replace(/\.0+$/, '')
-  const price = roundedPrice !== '0' ? roundedPrice : netPrice.toFixed(6)
-  const priceInfoValue = `1 ${tokenInTicker} = ${localFormat(price)} ${tokenOutTicker}`
+
+  const priceInfoValue = `1 ${tokenInTicker} = ${localFormat(netPrice, Math.max(tokenOutInfo?.decimals ?? 0, tokenInInfo?.decimals ?? 0, 3))} ${tokenOutTicker}`
   const minAdaInfoValue = `${swapForm.createTx?.deposits} ${wallet.portfolioPrimaryTokenInfo.ticker}`
   const totalFee = `${localFormat(swapForm.createTx?.totalFee ?? 0)} ${wallet.portfolioPrimaryTokenInfo.ticker}`
   const minReceivedInfoValue = `${localFormat(swapForm.createTx?.totalOutputWithoutSlippage ?? 0)} ${tokenOutTicker}`


### PR DESCRIPTION
- Fix formatted value for precision 0 leaving trailing decimal separator.
- Refactor some toFixed calls to format
- Format order values


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes trailing decimal separators in `parseNumberFromText` and replaces ad-hoc rounding with locale-aware precision formatting across Swap price/amount displays.
> 
> - **Common Utils**:
>   - `utils/parse-number-from-text.ts`: `formattedValue` now strips trailing `,` or `.`; preserves locale while avoiding dangling separators.
> - **Mobile – Swap UI**:
>   - Standardize price/amount formatting via `parseNumberFromText({format: numberLocale, precision})`:
>     - `EstimateSummary`: price uses max token decimals (≥3); removes manual `toFixed` logic.
>     - `CreateOrder/SelectProtocolScreen`: price formatting switched to locale-aware precision.
>     - `ListOrders`: price and amounts use locale-aware formatting; adds `useLanguage`.
>     - `ReviewSwap/TransactionSummary`: price display uses locale-aware precision; refactors `localFormat` to accept precision.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8c7618d3e96e16d6030c99ad8b22d4414babebb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->