### PR TITLE
fix(mobile): AmountCard quantity

### DIFF
--- a/mobile/src/features/Swap/common/AmountCard/AmountCard.tsx
+++ b/mobile/src/features/Swap/common/AmountCard/AmountCard.tsx
@@ -1,4 +1,4 @@
-import {atomicToDecimal, toBigInt} from '@yoroi/common'
+import {atomicToDecimal, parseNumberFromText} from '@yoroi/common'
 import {isPrimaryTokenInfo} from '@yoroi/portfolio'
 import {atoms as a, useTheme} from '@yoroi/theme'
 
@@ -30,7 +30,11 @@ export const AmountCard = ({direction}: {direction: 'in' | 'out'}) => {
   const info = amount.tokenId
     ? swapForm.tokenInfos.get(amount.tokenId)
     : undefined
-  const quantity = amount.value
+  const quantity = parseNumberFromText({
+    text: amount.value,
+    denomination: info?.decimals ?? 0,
+  }).quantity
+
   // Only show errors for input direction (insufficient balance, etc.)
   const error = direction === 'in' ? amount.error : null
   const touched = amount.isTouched
@@ -125,7 +129,7 @@ export const AmountCard = ({direction}: {direction: 'in' | 'out'}) => {
           <TextInput
             keyboardType="numeric"
             autoComplete="off"
-            value={quantity}
+            value={amount.value}
             placeholder="0"
             placeholderTextColor={p.text_gray_medium}
             onChangeText={handleAmountChange}
@@ -176,7 +180,7 @@ export const AmountCard = ({direction}: {direction: 'in' | 'out'}) => {
             <PairedBalance
               amount={{
                 info,
-                quantity: toBigInt(quantity || '0', decimals),
+                quantity: BigInt(quantity || '0'),
               }}
               textStyle={a.body_2_md_regular}
             />

--- a/mobile/src/features/Swap/common/EstimateSummary/EstimateSummary.tsx
+++ b/mobile/src/features/Swap/common/EstimateSummary/EstimateSummary.tsx
@@ -102,11 +102,13 @@ export const EstimateSummary = () => {
 
       <Space.Height.sm />
 
-      <Row
-        label={strings.swap.swapSlippageTitle}
-        description={strings.swap.swapSlippage}
-        value={`${localFormat(swapForm.slippageInput.value)}%`}
-      />
+      {swapForm.orderType === 'market' && (
+        <Row
+          label={strings.swap.swapSlippageTitle}
+          description={strings.swap.swapSlippage}
+          value={`${localFormat(swapForm.slippageInput.value)}%`}
+        />
+      )}
     </View>
   )
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Parse amount input with decimals, display raw input, adjust paired balance quantity, and hide slippage for non‑market orders.
> 
> - **Swap**
>   - **AmountCard (`mobile/src/features/Swap/common/AmountCard/AmountCard.tsx`)**:
>     - Parse `quantity` via `parseNumberFromText` using token `decimals`.
>     - Use `amount.value` as the input field value; update `PairedBalance` to use `BigInt(quantity || '0')`.
>   - **EstimateSummary (`mobile/src/features/Swap/common/EstimateSummary/EstimateSummary.tsx`)**:
>     - Render slippage row only when `orderType === 'market'`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dba9b2d9208e8a69c35b3f464b2c517414f07918. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->