### PR TITLE
Fix themes padding

### DIFF
--- a/mobile/src/features/Swap/useCases/CreateOrder/SelectProtocolScreen.tsx
+++ b/mobile/src/features/Swap/useCases/CreateOrder/SelectProtocolScreen.tsx
@@ -20,7 +20,7 @@ export const SelectProtocolScreen = () => {
   const strings = useStrings()
   const {wallet} = useSelectedWallet()
   const {limitOptions, ...swapForm} = useSwap()
-  const {palette: p} = useTheme()
+  const {palette: p, atoms: ta} = useTheme()
   const {numberLocale} = useLanguage()
   if (limitOptions === undefined) return null
 
@@ -51,7 +51,7 @@ export const SelectProtocolScreen = () => {
 
   return (
     <SafeAreaView
-      style={[{backgroundColor: p.bg_color_max, flex: 1}]}
+      style={[ta.bg_color_max, a.flex_1]}
       edges={['left', 'right', 'bottom']}
     >
       <FlatList
@@ -93,7 +93,7 @@ export const SelectProtocolScreen = () => {
               </View>
 
               <View style={[a.flex_row, a.justify_between, a.gap_md]}>
-                <Text style={[a.body_1_lg_regular, {color: p.text_gray_low}]}>
+                <Text style={[a.body_1_lg_regular, ta.text_gray_low]}>
                   {strings.swap.price}
                 </Text>
 
@@ -101,7 +101,7 @@ export const SelectProtocolScreen = () => {
                   style={[
                     a.body_1_lg_regular,
                     a.self_center,
-                    {color: p.text_gray_medium},
+                    ta.text_gray_medium,
                   ]}
                 >
                   {`1 ${tokenInTicker} = ${formatPrice(item.initialPrice)} ${tokenOutTicker}`}
@@ -109,7 +109,7 @@ export const SelectProtocolScreen = () => {
               </View>
 
               <View style={[a.flex_row, a.justify_between, a.gap_md]}>
-                <Text style={[a.body_1_lg_regular, {color: p.text_gray_low}]}>
+                <Text style={[a.body_1_lg_regular, ta.text_gray_low]}>
                   {strings.swap.batcherFee}
                 </Text>
 
@@ -117,7 +117,7 @@ export const SelectProtocolScreen = () => {
                   style={[
                     a.body_1_lg_regular,
                     a.self_center,
-                    {color: p.text_gray_medium},
+                    ta.text_gray_medium,
                   ]}
                 >
                   {`${item.batcherFee} ${wallet.portfolioPrimaryTokenInfo.ticker}`}

--- a/mobile/src/features/Swap/useCases/CreateOrder/SelectProtocolScreen.tsx
+++ b/mobile/src/features/Swap/useCases/CreateOrder/SelectProtocolScreen.tsx
@@ -51,7 +51,7 @@ export const SelectProtocolScreen = () => {
 
   return (
     <SafeAreaView
-      style={[{backgroundColor: p.bg_color_max}]}
+      style={[{backgroundColor: p.bg_color_max, flex: 1}]}
       edges={['left', 'right', 'bottom']}
     >
       <FlatList

--- a/mobile/src/features/Transactions/useCases/TxDetails/TxDetails.tsx
+++ b/mobile/src/features/Transactions/useCases/TxDetails/TxDetails.tsx
@@ -272,7 +272,7 @@ const Fee = ({amount}: {amount: BigNumber}) => {
   const strings = useStrings()
   const {wallet} = useSelectedWallet()
   const {atoms: ta} = useTheme()
-  
+
   const text = `${strings.transactions.txDetailsFee} ${formatTokenWithSymbol(asQuantity(amount), wallet.portfolioPrimaryTokenInfo)}`
   return <Text style={[ta.text_gray_medium, a.body_3_sm_regular]}>{text}</Text>
 }

--- a/mobile/src/features/Transactions/useCases/TxDetails/TxDetails.tsx
+++ b/mobile/src/features/Transactions/useCases/TxDetails/TxDetails.tsx
@@ -271,9 +271,10 @@ const AdaAmount = ({amount}: {amount: BigNumber}) => {
 const Fee = ({amount}: {amount: BigNumber}) => {
   const strings = useStrings()
   const {wallet} = useSelectedWallet()
-
+  const {atoms: ta} = useTheme()
+  
   const text = `${strings.transactions.txDetailsFee} ${formatTokenWithSymbol(asQuantity(amount), wallet.portfolioPrimaryTokenInfo)}`
-  return <Text>{text}</Text>
+  return <Text style={[ta.text_gray_medium, a.body_3_sm_regular]}>{text}</Text>
 }
 
 const ExpandableAssetList: React.FC<{

--- a/mobile/src/kernel/i18n/locales/en-US.json
+++ b/mobile/src/kernel/i18n/locales/en-US.json
@@ -1051,7 +1051,7 @@
   "swap.swapScreen.autoPool": "(auto)",
   "swap.swapScreen.balance": "Balance",
   "swap.swapScreen.batcherFee": "Batcher Fee",
-  "swap.swapScreen.changePool": "change dex",
+  "swap.swapScreen.changePool": "Change DEX",
   "swap.swapScreen.completedOrders": "Completed orders",
   "swap.swapScreen.currentBalance": "Current balance",
   "swap.swapScreen.dex": "dex",


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YV-683

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces palette-based styles with theme atoms in SelectProtocolScreen and TxDetails Fee, and updates the "Change DEX" i18n string capitalization.
> 
> - **UI/Theming**:
>   - `mobile/src/features/Swap/useCases/CreateOrder/SelectProtocolScreen.tsx`:
>     - Use `useTheme().atoms (ta)`; swap `p.bg_color_max` for `ta.bg_color_max` and add `a.flex_1` on `SafeAreaView`.
>     - Replace inline text colors with `ta.text_gray_low`/`ta.text_gray_medium`.
>   - `mobile/src/features/Transactions/useCases/TxDetails/TxDetails.tsx`:
>     - `Fee` now uses `useTheme().atoms`; style fee text with `ta.text_gray_medium` and `a.body_3_sm_regular`.
> - **i18n**:
>   - `mobile/src/kernel/i18n/locales/en-US.json`: change `swap.swapScreen.changePool` to "Change DEX".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4378d59f440c67eb9a501afaf71e1cfc740a31f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->