### PR TITLE
fix(mobile): governance banner

### DIFF
--- a/mobile/jest.setup.js
+++ b/mobile/jest.setup.js
@@ -149,10 +149,3 @@ jest.mock('react-native-ble-plx', () => ({
     BleError: class BleError {
     },
 }))
-
-jest.mock('@yoroi/blockchains', () => ({
-    cardanoConfig: {
-      denominations: {lovelace: 1n, ada: 1_000_000n},
-      params: {minUtxoValue: 1_000_000n},
-    },
-  }));

--- a/mobile/jest.setup.js
+++ b/mobile/jest.setup.js
@@ -149,3 +149,10 @@ jest.mock('react-native-ble-plx', () => ({
     BleError: class BleError {
     },
 }))
+
+jest.mock('@yoroi/blockchains', () => ({
+    cardanoConfig: {
+      denominations: {lovelace: 1n, ada: 1_000_000n},
+      params: {minUtxoValue: 1_000_000n},
+    },
+  }));

--- a/mobile/src/features/Dashboard/Dashboard.tsx
+++ b/mobile/src/features/Dashboard/Dashboard.tsx
@@ -98,6 +98,10 @@ export const Dashboard = () => {
   const createOnWithdraw =
     ({shouldDeregister}: {shouldDeregister: boolean}) =>
     () => {
+      if (isParticipatingInGovernance === undefined) {
+        // status still loading → avoid showing warning;
+        return
+      }
       if (!isParticipatingInGovernance) {
         openModal({
           title: strings.staking.withdrawWarningTitle,

--- a/mobile/src/features/Dashboard/Dashboard.tsx
+++ b/mobile/src/features/Dashboard/Dashboard.tsx
@@ -16,7 +16,7 @@ import {SafeAreaView} from 'react-native-safe-area-context'
 import {useBalances} from '~/features/Portfolio/common/hooks/useBalances'
 import {useReviewTx} from '~/features/ReviewTx/common/ReviewTxProvider'
 import {StakeRewardsWithdrawalOperation} from '~/features/ReviewTx/common/operations'
-import {useIsParticipatingInGovernance} from '~/features/Staking/Governance/common/helpers'
+import {useGovernanceParticipation} from '~/features/Staking/Governance/common/helpers'
 import {WithdrawGovernanceWarningModal} from '~/features/Staking/Governance/useCases/WithdrawGovernanceWarningModal/WithdrawGovernanceWarningModal'
 import {PoolTransitionNotice} from '~/features/Staking/Staking/PoolTransition/PoolTransitionNotice'
 import {usePoolTransition} from '~/features/Staking/Staking/PoolTransition/usePoolTransition'
@@ -71,11 +71,12 @@ export const Dashboard = () => {
     stakingInfo,
     refetch: refetchStakingInfo,
     error,
-    isLoading,
+    isLoading: isStakingInfoLoading,
   } = useStakingInfo(wallet)
 
-  const isParticipatingInGovernance = useIsParticipatingInGovernance()
   const walletNavigateTo = useWalletNavigation()
+  const {isParticipating, isLoading: isGovernanceParticipationLoading} =
+    useGovernanceParticipation()
 
   React.useEffect(() => {
     if (unsignedTx) {
@@ -98,11 +99,11 @@ export const Dashboard = () => {
   const createOnWithdraw =
     ({shouldDeregister}: {shouldDeregister: boolean}) =>
     () => {
-      if (isParticipatingInGovernance === undefined) {
+      if (isGovernanceParticipationLoading) {
         // status still loading → avoid showing warning;
         return
       }
-      if (!isParticipatingInGovernance) {
+      if (!isParticipating) {
         openModal({
           title: strings.staking.withdrawWarningTitle,
           content: (
@@ -127,7 +128,7 @@ export const Dashboard = () => {
     >
       <View style={[a.flex_1]}>
         {isOnline && error && (
-          <SyncErrorBanner showRefresh={!(isLoading || isSyncing)} />
+          <SyncErrorBanner showRefresh={!(isStakingInfoLoading || isSyncing)} />
         )}
 
         <ScrollView

--- a/mobile/src/features/Notifications/useCases/ViewNotificationHistory/ViewNotificationHistoryScreen.tsx
+++ b/mobile/src/features/Notifications/useCases/ViewNotificationHistory/ViewNotificationHistoryScreen.tsx
@@ -22,6 +22,7 @@ import {useStrings} from '~/kernel/i18n/useStrings'
 import {useWalletNavigation} from '~/kernel/navigation/hooks/useWalletNavigation'
 import {Button, ButtonType} from '~/ui/Button/Button'
 import {ScrollView} from '~/ui/ScrollView/ScrollView'
+import {Space} from '~/ui/Space/Space'
 import {Text} from '~/ui/Text/Text'
 
 import {EmptyNotificationsIllustration} from '../../illustrations/EmptyNotifications'
@@ -70,7 +71,7 @@ export const ViewNotificationHistoryScreen = () => {
 
   return (
     <SafeAreaView
-      style={[a.px_lg, a.flex, {flex: 1, position: 'relative'}]}
+      style={[a.flex_1, a.px_lg]}
       edges={['right', 'left', 'bottom']}
     >
       <ScrollView contentContainerStyle={{paddingBottom: 60}}>
@@ -88,6 +89,7 @@ export const ViewNotificationHistoryScreen = () => {
       <View
         style={[
           a.absolute,
+          a.pb_lg,
           {bottom: 0, left: 0, right: 0, height: 60},
           a.align_center,
           a.justify_center,
@@ -100,6 +102,7 @@ export const ViewNotificationHistoryScreen = () => {
           onPress={handleMarkAllAsRead}
           type={ButtonType.Text}
         />
+        <Space.Height.xl />
       </View>
     </SafeAreaView>
   )

--- a/mobile/src/features/Notifications/useCases/ViewNotificationHistory/ViewNotificationHistoryScreen.tsx
+++ b/mobile/src/features/Notifications/useCases/ViewNotificationHistory/ViewNotificationHistoryScreen.tsx
@@ -22,7 +22,6 @@ import {useStrings} from '~/kernel/i18n/useStrings'
 import {useWalletNavigation} from '~/kernel/navigation/hooks/useWalletNavigation'
 import {Button, ButtonType} from '~/ui/Button/Button'
 import {ScrollView} from '~/ui/ScrollView/ScrollView'
-import {Space} from '~/ui/Space/Space'
 import {Text} from '~/ui/Text/Text'
 
 import {EmptyNotificationsIllustration} from '../../illustrations/EmptyNotifications'
@@ -102,7 +101,6 @@ export const ViewNotificationHistoryScreen = () => {
           onPress={handleMarkAllAsRead}
           type={ButtonType.Text}
         />
-        <Space.Height.xl />
       </View>
     </SafeAreaView>
   )

--- a/mobile/src/features/Notifications/useCases/ViewNotificationHistory/ViewNotificationHistoryScreen.tsx
+++ b/mobile/src/features/Notifications/useCases/ViewNotificationHistory/ViewNotificationHistoryScreen.tsx
@@ -69,11 +69,8 @@ export const ViewNotificationHistoryScreen = () => {
   }
 
   return (
-    <SafeAreaView
-      style={[a.flex_1, a.px_lg]}
-      edges={['right', 'left', 'bottom']}
-    >
-      <ScrollView contentContainerStyle={{paddingBottom: 60}}>
+    <SafeAreaView style={[a.flex_1]} edges={['right', 'left', 'bottom']}>
+      <ScrollView contentContainerStyle={[a.px_lg, a.pb_2xl]}>
         <View style={[a.gap_lg, a.flex]}>
           {walletNotifications.map((notification) => (
             <NotificationItem
@@ -88,8 +85,8 @@ export const ViewNotificationHistoryScreen = () => {
       <View
         style={[
           a.absolute,
-          a.pb_lg,
-          {bottom: 0, left: 0, right: 0, height: 60},
+          a.pb_2xl,
+          {bottom: 0, left: 0, right: 0, height: 70},
           a.align_center,
           a.justify_center,
           {zIndex: 10, backgroundColor: p.bg_color_max},

--- a/mobile/src/features/Staking/Governance/common/helpers.tsx
+++ b/mobile/src/features/Staking/Governance/common/helpers.tsx
@@ -22,12 +22,12 @@ import {CardanoMobile} from '~/wallets/wallets'
 import {GovernanceVote} from '../types'
 import {useNavigateTo} from './navigation'
 
-export const useIsParticipatingInGovernance = (): boolean | undefined => {
+export const useGovernanceParticipation = () => {
   const {wallet} = useSelectedWallet()
   const stakingKeyHash = useStakingKey(wallet)
   const {data: stakingStatus, isLoading} = useStakingKeyState(stakingKeyHash)
-  if (isLoading) return undefined
-  return stakingStatus?.drepDelegation != null
+  const isParticipating = stakingStatus?.drepDelegation != null
+  return {isParticipating, isLoading} as const
 }
 
 export const useGovernanceStatus = () => {

--- a/mobile/src/features/Staking/Governance/common/helpers.tsx
+++ b/mobile/src/features/Staking/Governance/common/helpers.tsx
@@ -22,9 +22,12 @@ import {CardanoMobile} from '~/wallets/wallets'
 import {GovernanceVote} from '../types'
 import {useNavigateTo} from './navigation'
 
-export const useIsParticipatingInGovernance = () => {
-  const status = useGovernanceStatus()
-  return status !== null
+export const useIsParticipatingInGovernance = (): boolean | undefined => {
+  const {wallet} = useSelectedWallet()
+  const stakingKeyHash = useStakingKey(wallet)
+  const {data: stakingStatus, isLoading} = useStakingKeyState(stakingKeyHash)
+  if (isLoading) return undefined
+  return stakingStatus?.drepDelegation != null
 }
 
 export const useGovernanceStatus = () => {

--- a/mobile/src/features/Staking/Governance/common/helpers.tsx
+++ b/mobile/src/features/Staking/Governance/common/helpers.tsx
@@ -25,7 +25,15 @@ import {useNavigateTo} from './navigation'
 export const useGovernanceParticipation = () => {
   const {wallet} = useSelectedWallet()
   const stakingKeyHash = useStakingKey(wallet)
-  const {data: stakingStatus, isLoading} = useStakingKeyState(stakingKeyHash)
+  const {
+    data: stakingStatus,
+    isLoading,
+    refetch,
+  } = useStakingKeyState(stakingKeyHash)
+
+  // Refresh governance status when UTXOs change
+  useWalletEvent(wallet, 'utxos', refetch)
+
   const isParticipating = stakingStatus?.drepDelegation != null
   return {isParticipating, isLoading} as const
 }

--- a/mobile/src/features/Staking/Governance/useCases/useGovernanceBanner.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/useGovernanceBanner.tsx
@@ -44,34 +44,39 @@ export const useGovernanceBanner = () => {
         balanceLovelace: adaLovelace.toString(),
       })
       // show banner only if NOT participating and balance > 5 ADA
-      if (!isParticipating && network === Chain.Network.Mainnet) {
-        if (!hasEnoughAda) return false
+      const onMainnet = network === Chain.Network.Mainnet
+      if (!onMainnet) return false
 
-        const last = (await manager.events.read()).find(
-          (ev) =>
-            ev.trigger === Notifications.Trigger.Banner &&
-            ev.id === BannerIds.GovernanceParticipation,
-        )
-
-        if (
-          !last ||
-          new Date(last.date).getTime() + time.oneMonth < Date.now()
-        ) {
-          showBanner({
-            id: BannerIds.GovernanceParticipation,
-            title: strings.staking.newToGovernanceTitle,
-            body: strings.staking.newToGovernanceText,
-            isRead: !!last,
-          })
-        }
-        return true
-      } else {
+      if (isParticipating) {
         await manager.events.remove(BannerIds.GovernanceParticipation)
         queryClient.invalidateQueries({
           queryKey: ['receivedNotificationEvents'],
         })
         return false
       }
+
+      if (!hasEnoughAda) {
+        await manager.events.remove(BannerIds.GovernanceParticipation)
+        queryClient.invalidateQueries({
+          queryKey: ['receivedNotificationEvents'],
+        })
+        return false
+      }
+
+      const last = (await manager.events.read()).find(
+        (ev) =>
+          ev.trigger === Notifications.Trigger.Banner &&
+          ev.id === BannerIds.GovernanceParticipation,
+      )
+      if (!last || new Date(last.date).getTime() + time.oneMonth < Date.now()) {
+        showBanner({
+          id: BannerIds.GovernanceParticipation,
+          title: strings.staking.newToGovernanceTitle,
+          body: strings.staking.newToGovernanceText,
+          isRead: !!last,
+        })
+      }
+      return true
     },
   })
 }

--- a/mobile/src/features/Staking/Governance/useCases/useGovernanceBanner.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/useGovernanceBanner.tsx
@@ -8,7 +8,9 @@ import {BannerIds, showBanner} from '~/features/Notifications/common/banners'
 import {useWalletManager} from '~/features/WalletManager/context/WalletManagerProvider'
 import {useSelectedWallet} from '~/features/WalletManager/hooks/useSelectedWallet'
 import {useWalletEvent} from '~/features/WalletManager/hooks/useWalletEvent'
+import {MIN_ADA_GOVERNANCE_BANNER} from '~/kernel/constants'
 import {useStrings} from '~/kernel/i18n/useStrings'
+import {logger} from '~/kernel/logger/logger'
 
 import {useIsParticipatingInGovernance} from '../common/helpers'
 
@@ -29,28 +31,38 @@ export const useGovernanceBanner = () => {
   )
 
   useQuery({
-    queryKey,
+    queryKey: [...queryKey, isParticipating],
+    enabled: isParticipating !== undefined,
     staleTime: time.fiveMinutes,
     queryFn: async () => {
-      if (!isParticipating) {
-        if (network === Chain.Network.Mainnet) {
-          const last = (await manager.events.read()).find(
-            (ev) =>
-              ev.trigger === Notifications.Trigger.Banner &&
-              ev.id === BannerIds.GovernanceParticipation,
-          )
+      const balance = wallet?.balanceManager.getPrimaryBalance()
+      const adaLovelace = balance?.quantity ?? 0n
+      const hasEnoughAda = adaLovelace > MIN_ADA_GOVERNANCE_BANNER
+      logger.info('Governance banner prerequisites ', {
+        walletId: wallet?.id,
+        isParticipating,
+        balanceLovelace: adaLovelace.toString(),
+      })
+      // show banner only if NOT participating and balance > 5 ADA
+      if (!isParticipating && network === Chain.Network.Mainnet) {
+        if (!hasEnoughAda) return false
 
-          if (
-            !last ||
-            new Date(last.date).getTime() + time.oneMonth < Date.now()
-          ) {
-            showBanner({
-              id: BannerIds.GovernanceParticipation,
-              title: strings.staking.newToGovernanceTitle,
-              body: strings.staking.newToGovernanceText,
-              isRead: !!last,
-            })
-          }
+        const last = (await manager.events.read()).find(
+          (ev) =>
+            ev.trigger === Notifications.Trigger.Banner &&
+            ev.id === BannerIds.GovernanceParticipation,
+        )
+
+        if (
+          !last ||
+          new Date(last.date).getTime() + time.oneMonth < Date.now()
+        ) {
+          showBanner({
+            id: BannerIds.GovernanceParticipation,
+            title: strings.staking.newToGovernanceTitle,
+            body: strings.staking.newToGovernanceText,
+            isRead: !!last,
+          })
         }
         return true
       } else {

--- a/mobile/src/features/Staking/Governance/useCases/useGovernanceBanner.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/useGovernanceBanner.tsx
@@ -36,7 +36,7 @@ export const useGovernanceBanner = () => {
     staleTime: time.fiveMinutes,
     queryFn: async () => {
       const balance = wallet?.balanceManager.getPrimaryBalance()
-      const adaLovelace = balance?.quantity ?? 0n
+      const adaLovelace = BigInt(balance?.quantity ?? '0')
       const hasEnoughAda = adaLovelace > MIN_ADA_GOVERNANCE_BANNER
       logger.info('Governance banner prerequisites ', {
         walletId: wallet?.id,

--- a/mobile/src/features/Staking/Governance/useCases/useGovernanceBanner.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/useGovernanceBanner.tsx
@@ -8,7 +8,7 @@ import {BannerIds, showBanner} from '~/features/Notifications/common/banners'
 import {useWalletManager} from '~/features/WalletManager/context/WalletManagerProvider'
 import {useSelectedWallet} from '~/features/WalletManager/hooks/useSelectedWallet'
 import {useWalletEvent} from '~/features/WalletManager/hooks/useWalletEvent'
-import {MIN_ADA_GOVERNANCE_BANNER} from '~/kernel/constants'
+import {minAdaForGovernanceBanner} from '~/kernel/constants'
 import {useStrings} from '~/kernel/i18n/useStrings'
 import {logger} from '~/kernel/logger/logger'
 
@@ -37,7 +37,7 @@ export const useGovernanceBanner = () => {
     queryFn: async () => {
       const balance = wallet?.balanceManager.getPrimaryBalance()
       const adaLovelace = BigInt(balance?.quantity ?? '0')
-      const hasEnoughAda = adaLovelace > MIN_ADA_GOVERNANCE_BANNER
+      const hasEnoughAda = adaLovelace > minAdaForGovernanceBanner
       logger.info('Governance banner prerequisites ', {
         walletId: wallet?.id,
         isParticipating,

--- a/mobile/src/features/Staking/Governance/useCases/useGovernanceBanner.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/useGovernanceBanner.tsx
@@ -12,7 +12,7 @@ import {MIN_ADA_GOVERNANCE_BANNER} from '~/kernel/constants'
 import {useStrings} from '~/kernel/i18n/useStrings'
 import {logger} from '~/kernel/logger/logger'
 
-import {useIsParticipatingInGovernance} from '../common/helpers'
+import {useGovernanceParticipation} from '../common/helpers'
 
 export const useGovernanceBanner = () => {
   const strings = useStrings()
@@ -21,8 +21,8 @@ export const useGovernanceBanner = () => {
   const {
     selected: {network},
   } = useWalletManager()
+  const {isParticipating, isLoading} = useGovernanceParticipation()
 
-  const isParticipating = useIsParticipatingInGovernance()
   const queryKey = ['governanceBanner', wallet?.id, network]
   const queryClient = useQueryClient()
 
@@ -32,7 +32,7 @@ export const useGovernanceBanner = () => {
 
   useQuery({
     queryKey: [...queryKey, isParticipating],
-    enabled: isParticipating !== undefined,
+    enabled: !isLoading,
     staleTime: time.fiveMinutes,
     queryFn: async () => {
       const balance = wallet?.balanceManager.getPrimaryBalance()

--- a/mobile/src/features/Staking/Governance/useCases/useGovernanceBanner.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/useGovernanceBanner.tsx
@@ -1,6 +1,6 @@
 import {time} from '@yoroi/common'
 import {useNotificationManager} from '@yoroi/notifications'
-import {Chain, Notifications} from '@yoroi/types'
+import {Notifications} from '@yoroi/types'
 
 import {useQuery, useQueryClient} from '@tanstack/react-query'
 
@@ -44,7 +44,7 @@ export const useGovernanceBanner = () => {
         balanceLovelace: adaLovelace.toString(),
       })
       // show banner only if NOT participating and balance > 5 ADA
-      const onMainnet = network === Chain.Network.Mainnet
+      const onMainnet = wallet?.isMainnet === true
       if (!onMainnet) return false
 
       if (isParticipating) {

--- a/mobile/src/kernel/constants.ts
+++ b/mobile/src/kernel/constants.ts
@@ -6,6 +6,7 @@ import Constants from 'expo-constants'
 import * as Device from 'expo-device'
 import {freeze} from 'immer'
 import {Platform} from 'react-native'
+import {cardanoConfig} from '@yoroi/blockchains'
 
 // Resolvers API Keys
 export const unstoppableApiKey = process.env.EXPO_PUBLIC_UNSTOPPABLE_API_KEY
@@ -79,5 +80,4 @@ export const agreementDate = 1691967600000
 export const appVersion = Constants.expoConfig?.version ?? ''
 export const requiredPasswordLength = 10
 
-export const LOVELACE_PER_ADA = 1_000_000n
-export const MIN_ADA_GOVERNANCE_BANNER = 5n * LOVELACE_PER_ADA
+export const minAdaForGovernanceBanner = 5n * cardanoConfig.denominations.ada

--- a/mobile/src/kernel/constants.ts
+++ b/mobile/src/kernel/constants.ts
@@ -78,3 +78,6 @@ export const agreementDate = 1691967600000
 // Others
 export const appVersion = Constants.expoConfig?.version ?? ''
 export const requiredPasswordLength = 10
+
+export const LOVELACE_PER_ADA = 1_000_000n
+export const MIN_ADA_GOVERNANCE_BANNER = 5n * LOVELACE_PER_ADA

--- a/mobile/src/kernel/constants.ts
+++ b/mobile/src/kernel/constants.ts
@@ -1,4 +1,3 @@
-import {cardanoConfig} from '@yoroi/blockchains'
 import {configCurrencies} from '@yoroi/portfolio'
 import {ThemeName} from '@yoroi/theme'
 import {App, Portfolio} from '@yoroi/types'
@@ -80,4 +79,4 @@ export const agreementDate = 1691967600000
 export const appVersion = Constants.expoConfig?.version ?? ''
 export const requiredPasswordLength = 10
 
-export const minAdaForGovernanceBanner = 5n * cardanoConfig.denominations.ada
+export const minAdaForGovernanceBanner = 5n * 1_000_000n

--- a/mobile/src/kernel/constants.ts
+++ b/mobile/src/kernel/constants.ts
@@ -1,3 +1,4 @@
+import {cardanoConfig} from '@yoroi/blockchains'
 import {configCurrencies} from '@yoroi/portfolio'
 import {ThemeName} from '@yoroi/theme'
 import {App, Portfolio} from '@yoroi/types'
@@ -6,7 +7,6 @@ import Constants from 'expo-constants'
 import * as Device from 'expo-device'
 import {freeze} from 'immer'
 import {Platform} from 'react-native'
-import {cardanoConfig} from '@yoroi/blockchains'
 
 // Resolvers API Keys
 export const unstoppableApiKey = process.env.EXPO_PUBLIC_UNSTOPPABLE_API_KEY


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YV-666

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors governance participation check into a hook and updates banner to show only on mainnet when not participating with >5 ADA; adjusts Dashboard flow and notification history UI.
> 
> - **Governance**:
>   - Introduce `useGovernanceParticipation` returning `{isParticipating, isLoading}` and refreshing on `utxos`.
>   - Update `useGovernanceBanner` to depend on participation status, enable only when not loading, and show banner only on mainnet with balance > `5 ADA`; removes banner otherwise and invalidates notifications.
> - **Dashboard**:
>   - Replace `useIsParticipatingInGovernance` with `useGovernanceParticipation`; prevent withdraw warning while participation status is loading; wire staking info loading to `SyncErrorBanner`.
> - **Notifications**:
>   - Tweak `ViewNotificationHistoryScreen` layout: SafeArea/ScrollView padding and bottom action area sizing.
> - **Constants**:
>   - Add `minAdaForGovernanceBanner` constant (`5n * 1_000_000n`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd3e7e5d2faaf1b59a957599fae639bf2e2b7db1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->