### PR TITLE
fix(swap): types

### DIFF
--- a/mobile/packages/swap/adapters/api/minswap/api-maker.test.ts
+++ b/mobile/packages/swap/adapters/api/minswap/api-maker.test.ts
@@ -103,8 +103,8 @@ describe('minswapApiMaker', () => {
     expect(isRight(result)).toBe(true)
     if (isRight(result)) {
       expect(result.value.data).toHaveLength(1)
-      expect(result.value.data[0].id).toBe('.')
-      expect(result.value.data[0].ticker).toBe('ADA')
+      expect(result.value.data[0]?.id).toBe('.')
+      expect(result.value.data[0]?.ticker).toBe('ADA')
     }
   })
 
@@ -158,9 +158,9 @@ describe('minswapApiMaker', () => {
     expect(isRight(result)).toBe(true)
     if (isRight(result)) {
       expect(result.value.data).toHaveLength(1)
-      expect(result.value.data[0].txHash).toBe('txhash')
-      expect(result.value.data[0].outputIndex).toBe(0)
-      expect(result.value.data[0].aggregator).toBe('minswap')
+      expect(result.value.data[0]?.txHash).toBe('txhash')
+      expect(result.value.data[0]?.outputIndex).toBe(0)
+      expect(result.value.data[0]?.aggregator).toBe('minswap')
     }
   })
 

--- a/mobile/packages/swap/adapters/api/minswap/transformers.test.ts
+++ b/mobile/packages/swap/adapters/api/minswap/transformers.test.ts
@@ -486,7 +486,7 @@ describe('transformersMaker', () => {
       const result = transformers.estimate.response(mockResponse)
 
       // The default case should return Swap.Protocol.Unsupported
-      expect(result.splits[0].protocol).toBe('unsupported')
+      expect(result.splits[0]?.protocol).toBe('unsupported')
     })
 
     it('should handle all Dex protocol mappings in mapDexToProtocol', () => {
@@ -572,7 +572,7 @@ describe('transformersMaker', () => {
         }
 
         const result = transformers.estimate.response(mockResponse)
-        expect(result.splits[0].protocol).toBe(expected)
+        expect(result.splits[0]?.protocol).toBe(expected)
       })
     })
   })
@@ -764,9 +764,9 @@ describe('transformersMaker', () => {
       const result = transformers.tokens.response(mockResponse)
 
       expect(result).toHaveLength(1)
-      expect(result[0].name).toBe('Unknown Token')
-      expect(result[0].ticker).toBe('')
-      expect(result[0].decimals).toBe(0)
+      expect(result[0]?.name).toBe('Unknown Token')
+      expect(result[0]?.ticker).toBe('')
+      expect(result[0]?.decimals).toBe(0)
     })
 
     it('should handle zero amounts in estimate response', () => {
@@ -810,8 +810,8 @@ describe('transformersMaker', () => {
       expect(result.totalInput).toBe(0)
       expect(result.totalOutput).toBe(0)
       expect(result.netPrice).toBe(0)
-      expect(result.splits[0].initialPrice).toBe(0)
-      expect(result.splits[0].finalPrice).toBe(0)
+      expect(result.splits[0]?.initialPrice).toBe(0)
+      expect(result.splits[0]?.finalPrice).toBe(0)
     })
   })
 })

--- a/mobile/packages/swap/adapters/api/minswap/transformers.ts
+++ b/mobile/packages/swap/adapters/api/minswap/transformers.ts
@@ -188,8 +188,8 @@ export const transformersMaker = (config: MinswapApiConfig) => {
                   amountIn: Number(order.amount_in),
                   actualAmountOut: Number(order.min_amount_out),
                   expectedAmountOut: Number(order.min_amount_out),
-                  txHash: order.tx_in.split('#')[0],
-                  outputIndex: parseInt(order.tx_in.split('#')[1], 10),
+                  txHash: order.tx_in.split('#')[0]!,
+                  outputIndex: parseInt(order.tx_in.split('#')[1]!, 10),
                   updateTxHash: undefined, // Minswap only returns pending orders
                   customId: undefined,
                 } satisfies Swap.Order,

--- a/mobile/packages/swap/manager.test.ts
+++ b/mobile/packages/swap/manager.test.ts
@@ -992,7 +992,7 @@ describe('swapManagerMaker', () => {
       expect(result.tag).toBe('right')
       if (result.tag === 'right') {
         expect(result.value.data.options).toHaveLength(1)
-        expect(result.value.data.options[0].protocol).toBe('minswap-v2')
+        expect(result.value.data.options[0]?.protocol).toBe('minswap-v2')
       }
     })
   })

--- a/scripts/packages/types/scripts/flowgen.sh
+++ b/scripts/packages/types/scripts/flowgen.sh
@@ -1,0 +1,3 @@
+for i in $(find lib -type f -name "*.d.ts");
+  do sh -c "npx flowgen $i -o ${i%.*.*}.js.flow";
+done;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds optional chaining in swap tests, asserts non-null parts when parsing `tx_in`, and introduces a `flowgen` script to generate `.js.flow` files.
> 
> - **Swap (tests)**:
>   - Use optional chaining (e.g., `result.data[0]?.…`, `splits[0]?.…`, `options[0]?.…`) to satisfy stricter typings.
> - **Minswap transformers**:
>   - Assert non-null when parsing `tx_in` for `txHash` and `outputIndex` (`split('#')[0]!`, `split('#')[1]!`).
> - **Scripts**:
>   - Add `scripts/packages/types/scripts/flowgen.sh` to generate `.js.flow` from `*.d.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cd4f50adf4b5f5efa2198191ebfc4b42864b916. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->