### PR TITLE
fix(mobile): vsc config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,6 +31,6 @@
   "prettier.resolveGlobalModules": false,
   "prettier.prettierPath": "./mobile/node_modules/prettier",
   "eslint.workingDirectories": ["./mobile"],
-  "eslint.workingDirectory": "./mobile",
-  "files.autoSave": "onFocusChange"
+  "files.autoSave": "onFocusChange",
+  "typescript.tsdk": "./mobile/node_modules/typescript/lib"
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Points VS Code to the mobile TypeScript SDK, relies on `eslint.workingDirectories` (removes singular setting), and sets autosave on focus change.
> 
> - **VS Code settings** (`.vscode/settings.json`):
>   - Configure `typescript.tsdk` to `./mobile/node_modules/typescript/lib`.
>   - Remove `eslint.workingDirectory` in favor of `eslint.workingDirectories`.
>   - Set `files.autoSave` to `onFocusChange`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49ad4038820072d2defada9b73827b0f9578b258. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->