### PR TITLE
fix: swap navigation

### DIFF
--- a/mobile/src/features/Swap/useCases/CreateOrder/SelectTokenScreen.tsx
+++ b/mobile/src/features/Swap/useCases/CreateOrder/SelectTokenScreen.tsx
@@ -3,6 +3,7 @@ import {amountBreakdown, isPrimaryToken, sortTokenInfos} from '@yoroi/portfolio'
 import {atoms as a, useTheme} from '@yoroi/theme'
 import {Portfolio} from '@yoroi/types'
 
+import {useNavigation} from '@react-navigation/native'
 import {FlashList} from '@shopify/flash-list'
 import BigNumber from 'bignumber.js'
 import * as React from 'react'
@@ -30,8 +31,6 @@ import {
   AmountItemPlaceholder,
   TokenAmountItem,
 } from '~/ui/TokenAmountItem/TokenAmountItem'
-
-import {useNavigateTo} from '../../common/navigation'
 
 type Direction = SwapTokenRoutes['select-token']
 
@@ -241,8 +240,8 @@ const SelectableToken = React.memo(
     const {id, name, ticker} = tokenInfo
     const {closeSearch} = useSearch()
     const swapForm = useSwap()
-    const navigateTo = useNavigateTo()
     const {track} = useMetrics()
+    const navigation = useNavigation()
 
     const shouldUpdateToken =
       direction === 'in'
@@ -289,7 +288,7 @@ const SelectableToken = React.memo(
             direction === 'in' ? 'TokenInInputTouched' : 'TokenOutInputTouched',
         })
       }
-      navigateTo.startSwap()
+      navigation.goBack()
       closeSearch()
     }, [
       id,
@@ -300,7 +299,7 @@ const SelectableToken = React.memo(
       shouldSwitchTokens,
       shouldUpdateToken,
       swapForm,
-      navigateTo,
+      navigation,
       closeSearch,
     ])
 


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YV-709

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use React Navigation’s `goBack()` in `SelectTokenScreen` and remove `useNavigateTo` to fix swap token selection flow.
> 
> - **Swap Create Order** (`mobile/src/features/Swap/useCases/CreateOrder/SelectTokenScreen.tsx`):
>   - Replace `useNavigateTo` with `useNavigation` from React Navigation.
>   - On token selection, call `navigation.goBack()` instead of `navigateTo.startSwap()`.
>   - Update callback dependencies accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d72d5f16924adda347ca3284e87a53d840e1ff4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->