### PR TITLE
fix(mobile): hide modal push notifications and fix padding on few screens

### DIFF
--- a/mobile/src/features/Initialization/ui/screens/AnalyticsChangedScreen.tsx
+++ b/mobile/src/features/Initialization/ui/screens/AnalyticsChangedScreen.tsx
@@ -1,22 +1,14 @@
-import {atoms as a, useTheme} from '@yoroi/theme'
-
 import * as React from 'react'
-import {SafeAreaView} from 'react-native-safe-area-context'
 
 import {useLegalAgreement} from '~/features/Legal/hooks/useLegalAgreement'
 import {Analytics} from '~/features/Legal/ui/shared/Analytics/Analytics'
 
 export const AnalyticsChangedScreen = () => {
   const {agree} = useLegalAgreement()
-  const {atoms: ta} = useTheme()
 
   const handleOnNext = () => {
     agree()
   }
 
-  return (
-    <SafeAreaView style={[a.flex_1, ta.bg_color_max]}>
-      <Analytics type="notice" onNext={handleOnNext} />
-    </SafeAreaView>
-  )
+  return <Analytics type="notice" onNext={handleOnNext} />
 }

--- a/mobile/src/features/Initialization/ui/screens/AnalyticsNoticeScreen.tsx
+++ b/mobile/src/features/Initialization/ui/screens/AnalyticsNoticeScreen.tsx
@@ -1,7 +1,4 @@
-import {atoms as a, useTheme} from '@yoroi/theme'
-
 import * as React from 'react'
-import {SafeAreaView} from 'react-native-safe-area-context'
 
 import {useLegalAgreement} from '~/features/Legal/hooks/useLegalAgreement'
 import {Analytics} from '~/features/Legal/ui/shared/Analytics/Analytics'
@@ -13,7 +10,6 @@ export const AnalyticsNoticeScreen = () => {
   const navigateTo = useNavigateTo()
   const {track} = useMetrics()
   const {agree} = useLegalAgreement()
-  const {atoms: ta} = useTheme()
 
   const handleOnNext = () => {
     agree()
@@ -21,9 +17,5 @@ export const AnalyticsNoticeScreen = () => {
     navigateTo.enableLogingWithPin()
   }
 
-  return (
-    <SafeAreaView style={[a.flex_1, ta.bg_color_max]}>
-      <Analytics type="notice" onNext={handleOnNext} />
-    </SafeAreaView>
-  )
+  return <Analytics type="notice" onNext={handleOnNext} />
 }

--- a/mobile/src/features/Legal/ui/shared/Analytics/Analytics.tsx
+++ b/mobile/src/features/Legal/ui/shared/Analytics/Analytics.tsx
@@ -2,19 +2,14 @@ import {time} from '@yoroi/common'
 import {atoms as a, useTheme} from '@yoroi/theme'
 
 import * as React from 'react'
-import {
-  Linking,
-  Text,
-  TouchableOpacity,
-  View,
-  useWindowDimensions,
-} from 'react-native'
+import {Linking, Text, TouchableOpacity, View} from 'react-native'
 import {ScrollView} from 'react-native-gesture-handler'
 
 import {useBold} from '~/hooks/useBold'
 import {useStrings} from '~/kernel/i18n/useStrings'
 import {useMetrics} from '~/kernel/metrics/metricsManager'
 import {Button, ButtonType} from '~/ui/Button/Button'
+import {SafeArea} from '~/ui/SafeArea/SafeArea'
 import {SettingsSwitch} from '~/ui/SettingsSwitch/SettingsSwitch'
 import {Space} from '~/ui/Space/Space'
 import {YoroiLogo} from '~/ui/YoroiLogo/YoroiLogo'
@@ -38,9 +33,6 @@ export const Analytics = (props: Props) => {
 const Notice = ({onNext}: {onNext?: () => void}) => {
   const strings = useStrings()
   const metrics = useMetrics()
-  const {height: deviceHeight} = useWindowDimensions()
-  const [contentHeight, setContentHeight] = React.useState(0)
-  const {palette: p, atoms: ta} = useTheme()
 
   const scrollViewRef = React.useRef<ScrollView | null>(null)
 
@@ -53,60 +45,33 @@ const Notice = ({onNext}: {onNext?: () => void}) => {
   }, [])
 
   return (
-    <View style={[a.flex_1]}>
+    <SafeArea style={a.pt_2xl}>
       <ScrollView
         bounces={false}
         style={a.flex_1}
         contentContainerStyle={[a.px_lg, {paddingBottom: buttonHeight + 16}]}
         ref={scrollViewRef}
         persistentScrollbar
-        showsVerticalScrollIndicator
+        showsVerticalScrollIndicator={false}
       >
-        <View
-          onLayout={(event) => {
-            const {height} = event.nativeEvent.layout
-            setContentHeight(height + buttonHeight)
-          }}
-        >
+        <View>
           <Info showLogo />
-
-          <Space.Height.lg />
-
-          <Button
-            size="S"
-            type={ButtonType.Text}
-            onPress={() => {
-              metrics.disable()
-              onNext?.()
-            }}
-            title={strings.ui.skip}
-          />
-
-          <Space.Height.lg />
         </View>
       </ScrollView>
 
-      <View
-        style={[
-          a.absolute,
-          a.w_full,
-          ta.bg_color_max,
-          a.px_lg,
-          a.justify_center,
-          {
-            bottom: 0,
-            height: buttonHeight,
-          },
-          {
-            // only show border top if the content is scrollable
-            ...(deviceHeight < contentHeight && {
-              borderTopWidth: 1,
-              borderTopColor: p.gray_500,
-            }),
-          },
-        ]}
-        pointerEvents="box-none"
-      >
+      <SafeArea.Footer>
+        <Button
+          size="S"
+          type={ButtonType.Text}
+          onPress={() => {
+            metrics.disable()
+            onNext?.()
+          }}
+          title={strings.ui.skip}
+        />
+
+        <Space.Height.lg />
+
         <Button
           type={ButtonType.Primary}
           onPress={() => {
@@ -115,8 +80,8 @@ const Notice = ({onNext}: {onNext?: () => void}) => {
           }}
           title={strings.ui.accept}
         />
-      </View>
-    </View>
+      </SafeArea.Footer>
+    </SafeArea>
   )
 }
 
@@ -134,7 +99,7 @@ const Settings = () => {
   }
 
   return (
-    <View style={[a.px_lg, a.gap_lg]}>
+    <SafeArea style={[a.px_lg, a.gap_lg]}>
       <Info />
 
       <View style={[a.flex_row, a.align_center, a.justify_between]}>
@@ -147,7 +112,7 @@ const Settings = () => {
           onValueChange={handleOnValueChange}
         />
       </View>
-    </View>
+    </SafeArea>
   )
 }
 

--- a/mobile/src/features/Receive/useCases/RequestSpecificAmountScreen.tsx
+++ b/mobile/src/features/Receive/useCases/RequestSpecificAmountScreen.tsx
@@ -84,7 +84,7 @@ export const RequestSpecificAmountScreen = () => {
 
   return (
     <SafeArea>
-      <ScrollView ref={scrollViewRef} style={[a.flex_1]}>
+      <ScrollView ref={scrollViewRef} style={[a.flex_1, a.px_lg]}>
         <View style={[a.gap_lg]}>
           <Text style={[a.body_1_lg_regular, ta.text_gray_medium]}>
             {strings.receive.specificAmountDescription}

--- a/mobile/src/features/Settings/ui/screens/ChangeApplicationSettingsScreen/ToggleAnalyticsSettings/ToggleAnalyticsSettingsScreen.tsx
+++ b/mobile/src/features/Settings/ui/screens/ChangeApplicationSettingsScreen/ToggleAnalyticsSettings/ToggleAnalyticsSettingsScreen.tsx
@@ -1,19 +1,7 @@
-import {atoms as a, useTheme} from '@yoroi/theme'
-
 import * as React from 'react'
-import {SafeAreaView} from 'react-native-safe-area-context'
 
 import {Analytics} from '~/features/Legal/ui/shared/Analytics/Analytics'
 
 export const ToggleAnalyticsSettingsScreen = () => {
-  const {atoms: ta} = useTheme()
-
-  return (
-    <SafeAreaView
-      edges={['left', 'right', 'bottom']}
-      style={[a.flex_1, a.pt_lg, ta.bg_color_max]}
-    >
-      <Analytics type="settings" />
-    </SafeAreaView>
-  )
+  return <Analytics type="settings" />
 }

--- a/mobile/src/features/Transactions/useCases/TxHistory/TxHistory.tsx
+++ b/mobile/src/features/Transactions/useCases/TxHistory/TxHistory.tsx
@@ -12,6 +12,7 @@ import {useGovernanceBanner} from '~/features/Staking/Governance/useCases/useGov
 import {usePoolTransitionModal} from '~/features/Staking/Staking/PoolTransition/usePoolTransitionModal'
 import {useSelectedWallet} from '~/features/WalletManager/hooks/useSelectedWallet'
 import {useSync} from '~/features/WalletManager/hooks/useSync'
+import {features} from '~/kernel/features'
 import {useStrings} from '~/kernel/i18n/useStrings'
 import {useMetrics} from '~/kernel/metrics/metricsManager'
 import {Space, SpaceHeight} from '~/ui/Space/Space'
@@ -34,7 +35,7 @@ export const TxHistory = () => {
   const {atoms: ta, palette: p, isDark} = useTheme()
 
   const {track} = useMetrics()
-  useGetImportantAlertsModal({enabled: true})
+  useGetImportantAlertsModal({enabled: features.pushNotifications})
 
   useFocusEffect(
     React.useCallback(() => {


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YV-716

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gates the Important Alerts modal by a push notifications feature flag and refactors Analytics screens to use SafeArea with adjusted layout/padding; adds padding to the Request Specific Amount screen.
> 
> - **Notifications**:
>   - Gate Important Alerts modal in `Transactions/useCases/TxHistory/TxHistory.tsx` with `features.pushNotifications`.
> - **Analytics UI**:
>   - Replace external `SafeAreaView` wrappers with internal `SafeArea` in `AnalyticsChangedScreen.tsx`, `AnalyticsNoticeScreen.tsx`, and `ToggleAnalyticsSettingsScreen.tsx` by returning `<Analytics />` directly.
>   - In `Legal/ui/shared/Analytics/Analytics.tsx`:
>     - Use `SafeArea` and `SafeArea.Footer`; move actions (Skip/Accept) to footer and simplify layout (remove dynamic height/border logic).
>     - Hide vertical scroll indicator and add top padding (`a.pt_2xl`).
>     - Wrap Settings view with `SafeArea`.
> - **Receive**:
>   - Add horizontal padding (`a.px_lg`) to `RequestSpecificAmountScreen` `ScrollView`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 746b271c715bf2d43744d4745253a402a14de4a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->