### PR TITLE
fix(mobile): modals - receive/send sav

### DIFF
--- a/mobile/src/features/Receive/useCases/DescribeSelectedAddressScreen.tsx
+++ b/mobile/src/features/Receive/useCases/DescribeSelectedAddressScreen.tsx
@@ -1,10 +1,9 @@
-import {atoms as a, useTheme} from '@yoroi/theme'
+import {atoms as a} from '@yoroi/theme'
 import {Wallet} from '@yoroi/types'
 
 import {useFocusEffect} from '@react-navigation/native'
 import * as React from 'react'
-import {GestureResponderEvent, ScrollView, View} from 'react-native'
-import {SafeAreaView} from 'react-native-safe-area-context'
+import {GestureResponderEvent, ScrollView} from 'react-native'
 
 import {useCopy} from '~/features/Copy/context/CopyProvider'
 import {useAddressMode} from '~/features/WalletManager/hooks/useAddressMode'
@@ -14,6 +13,7 @@ import {AddressDetailCard} from '~/ui/AddressDetailCard/AddressDetailCard'
 import {Button, ButtonType} from '~/ui/Button/Button'
 import {Icon} from '~/ui/Icon'
 import {useModal} from '~/ui/Modal/context/ModalContext'
+import {SafeArea} from '~/ui/SafeArea/SafeArea'
 import {
   SingleOrMultipleAddressesModal,
   singleOrMultipleAddressesModalHeight,
@@ -27,7 +27,6 @@ import {useNavigateTo} from '../common/useNavigateTo'
 
 export const DescribeSelectedAddressScreen = () => {
   const strings = useStrings()
-  const {palette: p} = useTheme()
   const navigateTo = useNavigateTo()
   const {selectedAddress} = useReceive()
   const {
@@ -67,13 +66,15 @@ export const DescribeSelectedAddressScreen = () => {
     const timeout = setTimeout(() => {
       openModal({
         title: strings.receive.singleOrMultiple,
-        content: (
-          <SingleOrMultipleAddressesModal
+        content: <SingleOrMultipleAddressesModal.Content />,
+        footer: (
+          <SingleOrMultipleAddressesModal.Footer
             onConfirm={handleOnModalConfirm}
             onClose={closeModal}
           />
         ),
         height: singleOrMultipleAddressesModalHeight,
+        canDiscard: false,
       })
     }, 300)
     return () => clearTimeout(timeout)
@@ -92,21 +93,19 @@ export const DescribeSelectedAddressScreen = () => {
   )
 
   return (
-    <SafeAreaView
-      style={[a.p_lg, a.flex_1, {backgroundColor: p.bg_color_max}]}
-      edges={['left', 'right', 'bottom']}
-    >
-      <ScrollView style={[a.flex_1]}>
-        <View style={[a.align_center, a.flex_1]}>
-          {hasAddress ? (
-            <AddressDetailCard title={strings.receive.addresscardTitle} />
-          ) : (
-            <SkeletonAdressDetail />
-          )}
-        </View>
+    <SafeArea>
+      <ScrollView
+        contentContainerStyle={[a.px_lg, a.align_center]}
+        style={[a.pt_lg]}
+      >
+        {hasAddress ? (
+          <AddressDetailCard title={strings.receive.addresscardTitle} />
+        ) : (
+          <SkeletonAdressDetail />
+        )}
       </ScrollView>
 
-      <View style={[a.flex_col, a.gap_sm]}>
+      <SafeArea.Footer style={[a.gap_lg]}>
         <Button
           type={ButtonType.Text}
           title={strings.receive.requestSpecificAmountButton}
@@ -121,7 +120,7 @@ export const DescribeSelectedAddressScreen = () => {
           title={strings.receive.copyAddressButton}
           icon={Icon.Copy}
         />
-      </View>
-    </SafeAreaView>
+      </SafeArea.Footer>
+    </SafeArea>
   )
 }

--- a/mobile/src/features/Receive/useCases/RequestSpecificAmountScreen.tsx
+++ b/mobile/src/features/Receive/useCases/RequestSpecificAmountScreen.tsx
@@ -9,7 +9,6 @@ import {useFocusEffect} from '@react-navigation/native'
 import * as React from 'react'
 import {
   GestureResponderEvent,
-  ScrollView as RNScrollView,
   Text,
   View,
   useWindowDimensions,
@@ -22,6 +21,7 @@ import {useMetrics} from '~/kernel/metrics/metricsManager'
 import {Button} from '~/ui/Button/Button'
 import {Icon} from '~/ui/Icon'
 import {useModal} from '~/ui/Modal/context/ModalContext'
+import {Modal} from '~/ui/Modal/ui/screens/Modal/Modal'
 import {SafeArea} from '~/ui/SafeArea/SafeArea'
 import {ScrollView} from '~/ui/ScrollView/ScrollView'
 import {useScrollView} from '~/ui/ScrollView/useScrollView'
@@ -53,7 +53,8 @@ export const RequestSpecificAmountScreen = () => {
     track.receiveAmountGeneratedPageViewed({ada_amount: Number(amount)})
     openModal({
       title: strings.receive.amountToReceive,
-      content: <Modal amount={amount} address={selectedAddress} />,
+      content: <ModalContent amount={amount} address={selectedAddress} />,
+      footer: <ModalFooter amount={amount} address={selectedAddress} />,
       height: modalHeight,
     })
   }, [
@@ -84,7 +85,11 @@ export const RequestSpecificAmountScreen = () => {
 
   return (
     <SafeArea>
-      <ScrollView ref={scrollViewRef} style={[a.flex_1, a.px_lg]}>
+      <ScrollView
+        ref={scrollViewRef}
+        style={[a.pt_lg]}
+        contentContainerStyle={[a.px_lg]}
+      >
         <View style={[a.gap_lg]}>
           <Text style={[a.body_1_lg_regular, ta.text_gray_medium]}>
             {strings.receive.specificAmountDescription}
@@ -123,8 +128,9 @@ export const RequestSpecificAmountScreen = () => {
   )
 }
 
-const Modal = ({amount, address}: {amount: string; address: string}) => {
+const ModalContent = ({amount, address}: {amount: string; address: string}) => {
   const strings = useStrings()
+  const {copy} = useCopy()
   const {track} = useMetrics()
 
   const cardanoLinks = linksCardanoModuleMaker()
@@ -150,47 +156,70 @@ const Modal = ({amount, address}: {amount: string; address: string}) => {
     ? `${amount} ${portfolioPrimaryTokenInfo.ticker.toLocaleUpperCase()}`
     : ''
 
+  return (
+    <Modal.Content
+      contentContainerStyle={[
+        a.flex_grow,
+        a.justify_between,
+        a.gap_lg,
+        a.px_lg,
+      ]}
+    >
+      {hasAddress ? (
+        <ShareQRCodeCard
+          title={title}
+          shareContent={content}
+          qrContent={content}
+          onLongPress={(event: GestureResponderEvent) =>
+            copy({
+              text: content,
+              feedback: strings.receive.addressCopiedMsg,
+              event,
+            })
+          }
+          testID="receive:specific-amount"
+          onShare={() => track.receiveShareAddressClicked()}
+          shareLabel={strings.receive.shareLabel}
+        />
+      ) : (
+        <View style={[a.flex_1]}>
+          <SkeletonAdressDetail />
+        </View>
+      )}
+    </Modal.Content>
+  )
+}
+
+const ModalFooter = ({amount, address}: {amount: string; address: string}) => {
+  const strings = useStrings()
   const {copy} = useCopy()
 
-  return (
-    <View style={[a.p_lg, a.flex_1]}>
-      <RNScrollView
-        contentContainerStyle={[a.flex_grow, a.justify_between, a.gap_lg]}
-      >
-        {hasAddress ? (
-          <ShareQRCodeCard
-            title={title}
-            shareContent={content}
-            qrContent={content}
-            onLongPress={(event: GestureResponderEvent) =>
-              copy({
-                text: content,
-                feedback: strings.receive.addressCopiedMsg,
-                event,
-              })
-            }
-            testID="receive:specific-amount"
-            onShare={() => track.receiveShareAddressClicked()}
-            shareLabel={strings.receive.shareLabel}
-          />
-        ) : (
-          <View style={[{flex: 1}]}>
-            <SkeletonAdressDetail />
-          </View>
-        )}
-      </RNScrollView>
+  const cardanoLinks = linksCardanoModuleMaker()
+  const cardanoRequestLink = cardanoLinks.create({
+    config: configCardanoLegacyTransfer,
+    params: {
+      address: address,
+      amount: Number(amount),
+    },
+  })
+  const yoroiLinks = linksYoroiModuleMaker('yoroi')
+  const yoroiPaymentRequestLink = yoroiLinks.transfer.request.adaWithLink({
+    link: cardanoRequestLink.link,
+  })
 
-      <View style={[a.pt_lg]}>
-        <Button
-          onPress={(event: GestureResponderEvent) =>
-            copy({text: content, feedback: strings.receive.copyLinkMsg, event})
-          }
-          disabled={!hasAmount}
-          title={strings.receive.copyLinkBtn}
-          icon={Icon.Copy}
-          testID="receive:request-specific-amount:copy-link-button"
-        />
-      </View>
-    </View>
+  const hasAmount = !isEmptyString(amount)
+  const content = hasAmount ? yoroiPaymentRequestLink : address
+
+  return (
+    <Modal.Footer>
+      <Button
+        onPress={(event: GestureResponderEvent) =>
+          copy({text: content, feedback: strings.receive.copyLinkMsg, event})
+        }
+        title={strings.receive.copyLinkBtn}
+        icon={Icon.Copy}
+        testID="receive:request-specific-amount:copy-link-button"
+      />
+    </Modal.Footer>
   )
 }

--- a/mobile/src/features/Send/useCases/ListAmountsToSend/ListAmountsToSendScreen.tsx
+++ b/mobile/src/features/Send/useCases/ListAmountsToSend/ListAmountsToSendScreen.tsx
@@ -7,7 +7,6 @@ import {useNavigation} from '@react-navigation/native'
 import * as React from 'react'
 import {TouchableOpacity, View} from 'react-native'
 import {FlatList} from 'react-native-gesture-handler'
-import {SafeAreaView} from 'react-native-safe-area-context'
 
 import {useReviewTx} from '~/features/ReviewTx/common/ReviewTxProvider'
 import {useSearch} from '~/features/Search/SearchContext'
@@ -25,7 +24,7 @@ import {Boundary} from '~/ui/Boundary/Boundary'
 import {Button} from '~/ui/Button/Button'
 import {Icon} from '~/ui/Icon'
 import {RemoveAmountButton} from '~/ui/RemoveAmountButton/RemoveAmountButton'
-import {Space} from '~/ui/Space/Space'
+import {SafeArea} from '~/ui/SafeArea/SafeArea'
 import {TokenAmountItem} from '~/ui/TokenAmountItem/TokenAmountItem'
 import {YoroiEntry, YoroiSignedTx, YoroiUnsignedTx} from '~/wallets/types/yoroi'
 
@@ -38,7 +37,6 @@ export const ListAmountsToSendScreen = () => {
   const {track} = useMetrics()
   const {wallet} = useSelectedWallet()
   const {unsignedTxChanged} = useReviewTx()
-  const {atoms: ta} = useTheme()
   const {
     memo,
     targets,
@@ -137,10 +135,7 @@ export const ListAmountsToSendScreen = () => {
     createUnsignedTx([toYoroiEntry(targets[selectedTargetIndex].entry)])
   }
   return (
-    <SafeAreaView
-      edges={['left', 'right', 'bottom']}
-      style={[a.flex_1, a.px_lg, a.pb_lg, a.gap_xl, ta.bg_color_max]}
-    >
+    <SafeArea>
       <AmountsList
         data={Object.values(amounts)}
         renderItem={({item: amount}) => (
@@ -155,16 +150,12 @@ export const ListAmountsToSendScreen = () => {
         bounces={false}
         keyExtractor={(item) => item.info.id}
         testID="selectedTokens"
+        contentContainerStyle={[a.px_lg]}
+        style={[a.pt_lg]}
       />
 
-      <Actions style={[a.bg_transparent]}>
-        <Row>
-          <Space.Height._2xs fill />
-
-          <AddTokenButton onPress={handleOnAdd} />
-        </Row>
-
-        <Space.Height.xl />
+      <SafeArea.Footer style={[a.bg_transparent, a.gap_lg]}>
+        <AddTokenButton onPress={handleOnAdd} />
 
         <NextButton
           onPress={handleOnNext}
@@ -172,8 +163,8 @@ export const ListAmountsToSendScreen = () => {
           disabled={selectedTokensCounter === 0}
           isLoading={isPending}
         />
-      </Actions>
-    </SafeAreaView>
+      </SafeArea.Footer>
+    </SafeArea>
   )
 }
 
@@ -241,7 +232,6 @@ const ListAmountsNavigateBackButton = () => {
 
 const Left = View
 const Right = View
-const Actions = View
 const Row = View
 const NextButton = Button
 const AmountsList = FlatList

--- a/mobile/src/features/Send/useCases/ListAmountsToSend/ListAmountsToSendScreen.tsx
+++ b/mobile/src/features/Send/useCases/ListAmountsToSend/ListAmountsToSendScreen.tsx
@@ -232,6 +232,5 @@ const ListAmountsNavigateBackButton = () => {
 
 const Left = View
 const Right = View
-const Row = View
 const NextButton = Button
 const AmountsList = FlatList

--- a/mobile/src/features/Send/useCases/StartMultiTokenTx/StartMultiTokenTxScreen.tsx
+++ b/mobile/src/features/Send/useCases/StartMultiTokenTx/StartMultiTokenTxScreen.tsx
@@ -96,7 +96,8 @@ export const StartMultiTokenTxScreen = () => {
     <SafeArea>
       <ScrollView
         ref={scrollViewRef}
-        style={[a.flex_1, a.px_lg]}
+        style={[a.pt_lg]}
+        contentContainerStyle={[a.px_lg]}
         bounces={false}
       >
         <ShowErrors />

--- a/mobile/src/kernel/i18n/messages/receive.ts
+++ b/mobile/src/kernel/i18n/messages/receive.ts
@@ -99,7 +99,7 @@ export const receiveMessages = defineMessages({
     defaultMessage: '!!!Single or multiple',
   },
   singleOrMultipleDetails: {
-    id: 'nft.detail.title',
+    id: 'components.receive.receivescreen.singleOrMultipleDetails',
     defaultMessage: '!!!Single or multiple details',
   },
   selectMultiple: {

--- a/mobile/src/ui/SingleOrMultipleAddressesModal/SingleOrMultipleAddressesModal.tsx
+++ b/mobile/src/ui/SingleOrMultipleAddressesModal/SingleOrMultipleAddressesModal.tsx
@@ -8,21 +8,38 @@ import {useMultipleAddressesInfo} from '~/features/Receive/common/useMultipleAdd
 import {useAddressMode} from '~/features/WalletManager/hooks/useAddressMode'
 import {useStrings} from '~/kernel/i18n/useStrings'
 import {Button, ButtonType} from '~/ui/Button/Button'
+import {Modal} from '~/ui/Modal/ui/screens/Modal/Modal'
 
 export const singleOrMultipleAddressesModalHeight = 580
 
-type Props = {
-  onConfirm: (addressMode: Wallet.AddressMode) => void
-  onClose: () => void
+const SingleOrMultipleAddressesModalContent = () => {
+  const strings = useStrings()
+  const {atoms: ta} = useTheme()
+
+  return (
+    <View style={[a.flex_1, a.align_center, a.justify_between, a.py_lg]}>
+      {/* @bankless TODO: maybe rexport the component from Figma, it's blowing the UI */}
+      {/* <QRs /> */}
+
+      <Text
+        style={[
+          a.body_1_lg_regular,
+          a.justify_center,
+          a.text_center,
+          ta.text_gray_medium,
+        ]}
+      >
+        {strings.receive.singleOrMultipleDetails}
+      </Text>
+    </View>
+  )
 }
 
-export const SingleOrMultipleAddressesModal = ({onConfirm, onClose}: Props) => {
+const SingleOrMultipleAddressesModalFooter = ({onConfirm, onClose}: Props) => {
   const strings = useStrings()
   const {enableMultipleMode, enableSingleMode} = useAddressMode()
 
   const {hideMultipleAddressesInfo} = useMultipleAddressesInfo()
-
-  const {palette: p} = useTheme()
 
   const handleOnMultiple = () => {
     enableMultipleMode()
@@ -45,35 +62,27 @@ export const SingleOrMultipleAddressesModal = ({onConfirm, onClose}: Props) => {
   }
 
   return (
-    <View style={[a.flex_1, a.align_center, a.justify_between, a.py_lg]}>
-      {/* TODO: REVISIT, this breaks the app. investigate why */}
-      {/*  <QRs /> */}
+    <Modal.Footer>
+      <Button
+        type={ButtonType.Text}
+        title={strings.receive.selectMultiple}
+        onPress={handleOnMultiple}
+      />
 
-      <Text
-        style={[
-          a.body_1_lg_regular,
-          a.justify_center,
-          a.text_center,
-          {color: p.text_gray_medium},
-        ]}
-      >
-        {strings.receive.singleOrMultipleDetails}
-      </Text>
-
-      <View style={[{flex: 1}]} />
-
-      <View style={[a.flex_col, a.gap_sm, a.w_full, {height: 120}]}>
-        <Button
-          type={ButtonType.Text}
-          title={strings.receive.selectMultiple}
-          onPress={handleOnMultiple}
-        />
-
-        <Button
-          title={strings.receive.singleAddressWallet}
-          onPress={handleOnSingle}
-        />
-      </View>
-    </View>
+      <Button
+        title={strings.receive.singleAddressWallet}
+        onPress={handleOnSingle}
+      />
+    </Modal.Footer>
   )
+}
+
+export const SingleOrMultipleAddressesModal = {
+  Content: SingleOrMultipleAddressesModalContent,
+  Footer: SingleOrMultipleAddressesModalFooter,
+}
+
+type Props = {
+  onConfirm: (addressMode: Wallet.AddressMode) => void
+  onClose: () => void
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors receive/send modals into header/content/footer API and updates multiple screens to use SafeArea with adjusted ScrollView padding and footer actions.
> 
> - **UI/Layout**:
>   - Migrate screens to `SafeArea` with footer actions and consistent padding: `Receive/DescribeSelectedAddressScreen`, `Receive/RequestSpecificAmountScreen`, `Send/ListAmountsToSendScreen`, `Send/StartMultiTokenTxScreen`.
>   - Adjust `ScrollView` usage to `style={[a.pt_lg]}` and `contentContainerStyle` with `a.px_lg`.
> - **Receive Modals**:
>   - Split modal content/controls:
>     - `SingleOrMultipleAddressesModal` now exports `Content` and `Footer` (uses `Modal.Footer`), and updated consumer to pass `content`, `footer`, `height`, and `canDiscard:false`.
>     - `RequestSpecificAmountScreen` modal split into `ModalContent` and `ModalFooter` (uses `Modal.Content`/`Modal.Footer`); moves copy action to footer and keeps QR/share in content.
> - **Send - Select Assets**:
>   - Replace `SafeAreaView`/custom wrappers with `SafeArea` and `SafeArea.Footer`; remove extra layout wrappers (`Actions`, `Row`, `Space`) and set list padding via `contentContainerStyle`.
> - **i18n**:
>   - Fix `receive.singleOrMultipleDetails` message `id` to `components.receive.receivescreen.singleOrMultipleDetails`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e6c2e9502bc394d5e60a5d2f3eb677a8e6a4a2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->