### PR TITLE
fix(mobile): invalidation loop when 404

### DIFF
--- a/mobile/src/features/Portfolio/common/hooks/usePortfolioImage.ts
+++ b/mobile/src/features/Portfolio/common/hooks/usePortfolioImage.ts
@@ -23,7 +23,7 @@ export const usePortfolioImageInvalidate = () => {
       )
 
       if (idsToInvalidate.length === 0) {
-        logger.log(
+        logger.debug(
           `Skipping invalidation - all images already invalidated this session: ${ids}`,
         )
         return

--- a/mobile/src/features/Portfolio/common/hooks/usePortfolioImage.ts
+++ b/mobile/src/features/Portfolio/common/hooks/usePortfolioImage.ts
@@ -10,14 +10,31 @@ import {useSelectedNetwork} from '~/features/WalletManager/hooks/useSelectedNetw
 import {isDev} from '~/kernel/constants'
 import {logger} from '~/kernel/logger/logger'
 
+export const sessionInvalidatedImages = new Set<string>()
+
 export const usePortfolioImageInvalidate = () => {
   const {
     networkManager: {tokenManager},
   } = useSelectedNetwork()
   const mutation = useMutation({
     mutationFn: async (ids: Array<Portfolio.Token.Id>) => {
-      logger.log(`Invalidating images ${ids}`)
-      await tokenManager.api.tokenImageInvalidate(ids)
+      const idsToInvalidate = ids.filter(
+        (id) => !sessionInvalidatedImages.has(id),
+      )
+
+      if (idsToInvalidate.length === 0) {
+        logger.log(
+          `Skipping invalidation - all images already invalidated this session: ${ids}`,
+        )
+        return
+      }
+
+      logger.log(`Invalidating images ${idsToInvalidate}`)
+
+      // Mark these images as invalidated for this session
+      idsToInvalidate.forEach((id) => sessionInvalidatedImages.add(id))
+
+      await tokenManager.api.tokenImageInvalidate(idsToInvalidate)
       await Image.clearDiskCache()
       await Image.clearMemoryCache()
     },
@@ -26,6 +43,10 @@ export const usePortfolioImageInvalidate = () => {
   return {
     ...mutation,
     invalidate: mutation.mutate,
+    forceInvalidate: (id: Portfolio.Token.Id) => {
+      sessionInvalidatedImages.delete(id)
+      mutation.mutate([id])
+    },
   }
 }
 
@@ -115,7 +136,11 @@ export const usePortfolioImage = ({
       timerRef.current = setTimeout(() => query.refetch(), count * 300)
     } else {
       if (isDev) {
-        invalidate([`${policy}.${name}`])
+        const imageId = `${policy}.${name}` as Portfolio.Token.Id
+        // Only invalidate if not already invalidated this session
+        if (!sessionInvalidatedImages.has(imageId)) {
+          invalidate([imageId])
+        }
         queryClient.invalidateQueries({queryKey})
       }
       setError(true)

--- a/mobile/src/features/Portfolio/common/hooks/usePortfolioImage.ts
+++ b/mobile/src/features/Portfolio/common/hooks/usePortfolioImage.ts
@@ -29,7 +29,7 @@ export const usePortfolioImageInvalidate = () => {
         return
       }
 
-      logger.log(`Invalidating images ${idsToInvalidate}`)
+      logger.debug(`Invalidating images ${idsToInvalidate}`)
 
       // Mark these images as invalidated for this session
       idsToInvalidate.forEach((id) => sessionInvalidatedImages.add(id))

--- a/mobile/src/features/Portfolio/screens/PortfolioDashboard/PortfolioDashboardScreen.tsx
+++ b/mobile/src/features/Portfolio/screens/PortfolioDashboard/PortfolioDashboardScreen.tsx
@@ -1,20 +1,18 @@
-import {atoms as a, useTheme} from '@yoroi/theme'
+import {atoms as a} from '@yoroi/theme'
 
 import {useFocusEffect} from '@react-navigation/native'
 import * as React from 'react'
 import {ScrollView} from 'react-native'
-import {SafeAreaView} from 'react-native-safe-area-context'
 
 import {usePortfolio} from '~/features/Portfolio/context/PortfolioProvider'
 import {useMetrics} from '~/kernel/metrics/metricsManager'
 import {BalanceCard} from '~/ui/BalanceCard/BalanceCard'
-import {Space} from '~/ui/Space/Space'
+import {SafeArea} from '~/ui/SafeArea/SafeArea'
 
 import {DashboardNFTsList} from './DashboardNFTsList/DashboardNFTsList'
 import {DashboardTokensList} from './DashboardTokensList/DashboardTokensList'
 
 export const PortfolioDashboardScreen = () => {
-  const {palette: p} = useTheme()
   const {track} = useMetrics()
   const {resetTabs} = usePortfolio()
 
@@ -26,21 +24,14 @@ export const PortfolioDashboardScreen = () => {
   )
 
   return (
-    <SafeAreaView
-      style={[a.flex_1, {backgroundColor: p.bg_color_max}]}
-      edges={['left', 'right', 'bottom']}
-    >
-      <ScrollView style={[a.flex_1, {backgroundColor: p.bg_color_max}]}>
+    <SafeArea>
+      <ScrollView contentContainerStyle={[a.gap_lg]}>
         <BalanceCard />
-
-        <Space.Height.md />
 
         <DashboardTokensList />
 
-        <Space.Height.md />
-
         <DashboardNFTsList />
       </ScrollView>
-    </SafeAreaView>
+    </SafeArea>
   )
 }

--- a/mobile/src/features/Portfolio/ui/MediaDetailsScreen/MediaDetailsScreen.tsx
+++ b/mobile/src/features/Portfolio/ui/MediaDetailsScreen/MediaDetailsScreen.tsx
@@ -12,7 +12,6 @@ import React, {ReactNode, useState} from 'react'
 import {
   Linking,
   RefreshControl,
-  SafeAreaView,
   ScrollView,
   TouchableOpacity,
   View,
@@ -26,9 +25,9 @@ import {useMetrics} from '~/kernel/metrics/metricsManager'
 import {NftRoutes} from '~/kernel/navigation/types'
 import {Boundary} from '~/ui/Boundary/Boundary'
 import {Copiable} from '~/ui/Copiable/Copiable'
-import {FadeIn} from '~/ui/FadeIn/FadeIn'
 import {Hr} from '~/ui/Hr/Hr'
 import {MediaPreview} from '~/ui/MediaPreview/MediaPreview'
+import {SafeArea} from '~/ui/SafeArea/SafeArea'
 import {Space} from '~/ui/Space/Space'
 import {Tab, TabPanel, TabPanels, Tabs} from '~/ui/Tabs'
 import {Text} from '~/ui/Text/Text'
@@ -36,10 +35,9 @@ import {Text} from '~/ui/Text/Text'
 import {useNavigateTo} from '../../common/navigation'
 
 export const MediaDetailsScreen = () => {
-  const {palette: p} = useTheme()
   const strings = useStrings()
   const {track} = useMetrics()
-  const {invalidate, isPending} = usePortfolioImageInvalidate()
+  const {forceInvalidate, isPending} = usePortfolioImageInvalidate()
 
   const [activeTab, setActiveTab] = useState<ActiveTab>('overview')
 
@@ -54,55 +52,53 @@ export const MediaDetailsScreen = () => {
   // TODO: revisit + product definition (missing is gone state)
   if (!amount) return null
 
-  const onRefresh = () => invalidate([amount.info.id])
+  const handleRefresh = () => forceInvalidate(amount.info.id)
 
   return (
-    <FadeIn style={{flex: 1, backgroundColor: p.bg_color_max}}>
-      <SafeAreaView>
-        <ScrollView
-          contentContainerStyle={[{paddingHorizontal: imagePadding}]}
-          refreshControl={
-            <RefreshControl onRefresh={onRefresh} refreshing={isPending} />
-          }
-        >
-          <SelectableMedia info={amount.info} />
+    <SafeArea>
+      <ScrollView
+        contentContainerStyle={[{paddingHorizontal: imagePadding}]}
+        refreshControl={
+          <RefreshControl onRefresh={handleRefresh} refreshing={isPending} />
+        }
+      >
+        <SelectableMedia info={amount.info} />
 
-          <Tabs>
-            <Tab
-              onPress={() => {
-                if (activeTab !== 'overview') {
-                  setActiveTab('overview')
-                  track.nftGalleryDetailsTab({nft_tab: 'Overview'})
-                }
-              }}
-              label={strings.portfolio.overview}
-              active={activeTab === 'overview'}
-              testID="overview"
-            />
+        <Tabs>
+          <Tab
+            onPress={() => {
+              if (activeTab !== 'overview') {
+                setActiveTab('overview')
+                track.nftGalleryDetailsTab({nft_tab: 'Overview'})
+              }
+            }}
+            label={strings.portfolio.overview}
+            active={activeTab === 'overview'}
+            testID="overview"
+          />
 
-            <Tab
-              onPress={() => {
-                if (activeTab !== 'metadata') {
-                  setActiveTab('metadata')
-                  track.nftGalleryDetailsTab({nft_tab: 'Metadata'})
-                }
-              }}
-              label={strings.portfolio.info}
-              active={activeTab === 'metadata'}
-              testID="metadata"
-            />
-          </Tabs>
+          <Tab
+            onPress={() => {
+              if (activeTab !== 'metadata') {
+                setActiveTab('metadata')
+                track.nftGalleryDetailsTab({nft_tab: 'Metadata'})
+              }
+            }}
+            label={strings.portfolio.info}
+            active={activeTab === 'metadata'}
+            testID="metadata"
+          />
+        </Tabs>
 
-          <Boundary loading={{enabled: true}}>
-            <Details
-              info={amount.info}
-              activeTab={activeTab}
-              networkManager={networkManager}
-            />
-          </Boundary>
-        </ScrollView>
-      </SafeAreaView>
-    </FadeIn>
+        <Boundary loading={{enabled: true}}>
+          <Details
+            info={amount.info}
+            activeTab={activeTab}
+            networkManager={networkManager}
+          />
+        </Boundary>
+      </ScrollView>
+    </SafeArea>
   )
 }
 


### PR DESCRIPTION
- Fix for the FTs/NFTs that don't have have actually the right metadata/image, otherwise the app stays in the loop of requesting the invalidation, this will happen per session now, yet, can still be forced by the user when on the media details.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Session-scope portfolio image invalidations to stop 404 retry loops, add a force refresh path, and refactor portfolio screens to use SafeArea.
> 
> - **Portfolio image handling (`usePortfolioImage.ts`)**:
>   - Add `sessionInvalidatedImages` to skip re-invalidating the same `Portfolio.Token.Id` within a session.
>   - Update `usePortfolioImageInvalidate` to filter already invalidated IDs, mark new ones, and expose `forceInvalidate(id)`.
>   - In `onError`, invalidate only if the image wasn't invalidated this session; keep cache clearing; switch to debug logs.
> - **UI refactor**:
>   - Replace `SafeAreaView`/`FadeIn` with `SafeArea` in `PortfolioDashboardScreen.tsx` and `MediaDetailsScreen.tsx`; simplify layout (use `contentContainerStyle` gap) and remove theme-based background/spacers.
> - **Behavior**:
>   - `MediaDetailsScreen` refresh now uses `forceInvalidate` to allow user-triggered re-fetch despite session skip.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93d9fda85a50880d9efa5135f43c73c8e4a6e8cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->