### PR TITLE
fix(mobile): close withdraw warning modal after tapping CTA

### DIFF
--- a/mobile/src/features/Staking/Governance/useCases/WithdrawGovernanceWarningModal/WithdrawGovernanceWarningModal.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/WithdrawGovernanceWarningModal/WithdrawGovernanceWarningModal.tsx
@@ -6,6 +6,7 @@ import {Text} from 'react-native'
 import {useStrings} from '~/kernel/i18n/useStrings'
 import {useWalletNavigation} from '~/kernel/navigation/hooks/useWalletNavigation'
 import {Button} from '~/ui/Button/Button'
+import {useModal} from '~/ui/Modal/context/ModalContext'
 import {Modal} from '~/ui/Modal/ui/screens/Modal/Modal'
 
 const WithdrawGovernanceWarningModalContent = () => {
@@ -31,8 +32,10 @@ const WithdrawGovernanceWarningModalContent = () => {
 const WithdrawGovernanceWarningModalFooter = () => {
   const walletNavigateTo = useWalletNavigation()
   const strings = useStrings()
+  const {closeModal} = useModal()
   const handleOnPress = () => {
     walletNavigateTo.navigateToGovernanceCentre()
+    closeModal()
   }
 
   return (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Closes the withdraw governance warning modal after navigating from the CTA.
> 
> - **Mobile**:
>   - `WithdrawGovernanceWarningModal.tsx`: Footer now calls `closeModal()` (via `useModal`) after `navigateToGovernanceCentre()` to close the modal post-CTA.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86673adb4406ea2373865fee7cc9a48b3f82c08c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

https://emurgo.atlassian.net/browse/YV-721