### PR TITLE
chore: merge develop to preview

### DIFF
--- a/mobile/src/features/Staking/Governance/useCases/WithdrawGovernanceWarningModal/WithdrawGovernanceWarningModal.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/WithdrawGovernanceWarningModal/WithdrawGovernanceWarningModal.tsx
@@ -6,6 +6,7 @@ import {Text} from 'react-native'
 import {useStrings} from '~/kernel/i18n/useStrings'
 import {useWalletNavigation} from '~/kernel/navigation/hooks/useWalletNavigation'
 import {Button} from '~/ui/Button/Button'
+import {useModal} from '~/ui/Modal/context/ModalContext'
 import {Modal} from '~/ui/Modal/ui/screens/Modal/Modal'
 
 const WithdrawGovernanceWarningModalContent = () => {
@@ -31,8 +32,10 @@ const WithdrawGovernanceWarningModalContent = () => {
 const WithdrawGovernanceWarningModalFooter = () => {
   const walletNavigateTo = useWalletNavigation()
   const strings = useStrings()
+  const {closeModal} = useModal()
   const handleOnPress = () => {
     walletNavigateTo.navigateToGovernanceCentre()
+    closeModal()
   }
 
   return (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Closes the withdraw governance warning modal when the action button navigates to the Governance Centre.
> 
> - **Governance UI**:
>   - **WithdrawGovernanceWarningModal** (`mobile/src/features/Staking/Governance/useCases/WithdrawGovernanceWarningModal/WithdrawGovernanceWarningModal.tsx`):
>     - Integrates `useModal` to call `closeModal()` after `navigateToGovernanceCentre()` on button press.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53c7bcee821fa08eafc9feac3778cff9b39a0a94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->