### PR TITLE
Fix(mobile) avoid fetchining non-ada tokens in portfolio

### DIFF
--- a/mobile/src/features/Portfolio/common/hooks/useGetPortfolioTokenChart.ts
+++ b/mobile/src/features/Portfolio/common/hooks/useGetPortfolioTokenChart.ts
@@ -89,8 +89,11 @@ export const useGetPortfolioTokenChart = (
       ]
     >,
     'queryKey' | 'queryFn'
-  > = {},
+  > & {
+    disableNonPrimaryToken?: boolean // disable fetching chart data for non-primary tokens
+  } = {},
 ) => {
+  const {disableNonPrimaryToken = false, ...queryOptions} = options
   const {id: tokenId} = usePortfolioTokenDetailParams()
   const {
     wallet: {balances},
@@ -122,7 +125,7 @@ export const useGetPortfolioTokenChart = (
       isPrimaryToken(tokenInfo.info) &&
       Boolean(ptPriceQuery?.data),
     staleTime: time.oneMinute,
-    ...options,
+    ...queryOptions,
     queryKey: ['useGetPortfolioTokenChart', 'pt', timeInterval, currency],
     queryFn: async () => {
       // force queryFn to be async, otherwise it takes longer and doesn't show isFetching
@@ -158,8 +161,9 @@ export const useGetPortfolioTokenChart = (
   const otherQuery = useQuery({
     throwOnError: true,
     refetchOnMount: false,
-    enabled: tokenInfo && !isPrimaryToken(tokenInfo.info),
-    ...options,
+    ...queryOptions,
+    enabled:
+      !disableNonPrimaryToken && tokenInfo && !isPrimaryToken(tokenInfo.info),
     queryKey: [
       'useGetPortfolioTokenChart',
       tokenInfo?.info.id ?? '',

--- a/mobile/src/features/Portfolio/screens/PortfolioTokenDetails/PortfolioTokenChart/PortfolioTokenChart.tsx
+++ b/mobile/src/features/Portfolio/screens/PortfolioTokenDetails/PortfolioTokenChart/PortfolioTokenChart.tsx
@@ -21,7 +21,9 @@ export const PortfolioTokenChart = () => {
     TokenChartInterval.DAY,
   )
 
-  const {data, isFetching} = useGetPortfolioTokenChart(timeInterval)
+  const {data, isFetching} = useGetPortfolioTokenChart(timeInterval, {
+    disableNonPrimaryToken: true,
+  })
 
   const handleChartSelected = useCallback((index: number) => {
     // We ignore index = -1 cause it used for hide the tooltip.


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YV-618?atlOrigin=eyJpIjoiMDU3YWIyYWFhM2NjNDFjMzg5YzdmOGFjYzRkZTUyMTgiLCJwIjoiaiJ9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `disableNonPrimaryToken` flag to `useGetPortfolioTokenChart` and enables it in `PortfolioTokenChart` to avoid fetching non-primary token data.
> 
> - **Hooks**:
>   - Add `disableNonPrimaryToken` option to `useGetPortfolioTokenChart` and use it to disable the non-primary token query (`enabled` condition updated); spread remaining `queryOptions` into queries.
> - **UI**:
>   - Update `PortfolioTokenChart` to call `useGetPortfolioTokenChart(timeInterval, {disableNonPrimaryToken: true})`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4005cea70e74943c6b3b73cd572302e219bff1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->