### PR TITLE
fix: fetch all swap orders regardless of the route preferences 

### DIFF
--- a/mobile/packages/swap/manager.test.ts
+++ b/mobile/packages/swap/manager.test.ts
@@ -629,7 +629,7 @@ describe('swapManagerMaker', () => {
       }
     })
 
-    it('returns left if both are left', async () => {
+    it('returns left if all aggregators are left', async () => {
       mockDexhunterApi.orders.mockResolvedValue({
         tag: 'left',
         error: {status: 400, message: 'dh orders error', responseData: {}},
@@ -638,9 +638,12 @@ describe('swapManagerMaker', () => {
         tag: 'left',
         error: {status: 400, message: 'ms orders error', responseData: {}},
       })
+      mockMinswapApi.orders.mockResolvedValue({
+        tag: 'left',
+        error: {status: 400, message: 'mn orders error', responseData: {}},
+      })
 
       const manager = swapManagerMaker(baseConfig)
-      manager.assignSettings({routingPreference: ['dexhunter', 'muesliswap']})
       const result = await manager.api.orders()
       expect(result.tag).toBe('left')
     })

--- a/mobile/packages/swap/manager.ts
+++ b/mobile/packages/swap/manager.ts
@@ -140,7 +140,7 @@ const apiManagerMaker = (
       },
 
       async orders() {
-        const enabledAggregators = getEnabledAggregators()
+        const enabledAggregators = Object.keys(adapters) as Swap.Aggregator[]
 
         const responses: Array<Api.Response<Swap.Order[]>> = await Promise.all(
           enabledAggregators.map((aggregator) => adapters[aggregator].orders()),

--- a/mobile/src/features/Swap/common/SwapProvider.tsx
+++ b/mobile/src/features/Swap/common/SwapProvider.tsx
@@ -156,13 +156,7 @@ export const SwapProvider = ({children}: {children: React.ReactNode}) => {
   ])
 
   const {data: orders = [], refetch: refetchOrders} = useQuery({
-    queryKey: [
-      'persist',
-      'useSwapOrders',
-      network,
-      stakingKey,
-      swapManager.settings.routingPreference,
-    ],
+    queryKey: ['persist', 'useSwapOrders', network, stakingKey],
     queryFn: async () => {
       const res = await swapManager.api.orders()
       if (isRight(res)) return res.value.data


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YV-713

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Orders are now fetched from all aggregators independent of routing preferences, with tests and the React Query key updated accordingly.
> 
> - **Swap Manager (`mobile/packages/swap/manager.ts`)**:
>   - `orders()` now queries all `adapters` (all aggregators) instead of respecting `routingPreference`.
> - **Swap Provider (`mobile/src/features/Swap/common/SwapProvider.tsx`)**:
>   - `useSwapOrders` query key simplified to exclude `routingPreference`.
> - **Tests (`mobile/packages/swap/manager.test.ts`)**:
>   - Update orders tests to include `minswap`; rename to “all aggregators are left”; remove routing preference dependency for orders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6487078e515d8f0c36b719ee85c6e521a99451a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->