### PR TITLE
fix(mobile): dapp welcome modals display

### DIFF
--- a/mobile/src/features/Discover/useCases/SelectDappFromList/SelectDappFromListScreen.tsx
+++ b/mobile/src/features/Discover/useCases/SelectDappFromList/SelectDappFromListScreen.tsx
@@ -87,13 +87,11 @@ export const SelectDappFromListScreen = () => {
 
   return (
     <>
-      <WelcomeDAppModal
-        disabled={isShowedWelcomeDApp === undefined || isShowedWelcomeDApp}
-      />
+      <WelcomeDAppModal disabled={isShowedWelcomeDApp !== false} />
 
       <ShowDisclaimer
         type="dapps"
-        disabled={isShowedWelcomeDApp === undefined || !isShowedWelcomeDApp}
+        disabled={isShowedWelcomeDApp === undefined}
       />
 
       <View style={[a.flex_1, ta.bg_color_max, a.px_lg, a.gap_lg]}>

--- a/mobile/src/features/Discover/useCases/SelectDappFromList/WelcomeDAppModal.tsx
+++ b/mobile/src/features/Discover/useCases/SelectDappFromList/WelcomeDAppModal.tsx
@@ -20,8 +20,10 @@ export const WelcomeDAppModal = ({disabled}: {disabled?: boolean}) => {
   const [showing, setShowing] = React.useState(false)
 
   React.useEffect(() => {
+    console.log('[WelcomeDAppModal] Effect', {disabled, seen, showing})
     if (disabled || seen || showing || seen === undefined) return
 
+    console.log('[WelcomeDAppModal] Opening modal')
     openModal({
       title: strings.discover.welcomeToYoroiDAppExplorer,
       content: (
@@ -43,7 +45,7 @@ export const WelcomeDAppModal = ({disabled}: {disabled?: boolean}) => {
           <Button
             onPress={() => {
               setSeen(true)
-              closeModal(false)
+              closeModal()
             }}
             title={strings.discover.next}
           />

--- a/mobile/src/features/Discover/useCases/SelectDappFromList/WelcomeDAppModal.tsx
+++ b/mobile/src/features/Discover/useCases/SelectDappFromList/WelcomeDAppModal.tsx
@@ -20,10 +20,8 @@ export const WelcomeDAppModal = ({disabled}: {disabled?: boolean}) => {
   const [showing, setShowing] = React.useState(false)
 
   React.useEffect(() => {
-    console.log('[WelcomeDAppModal] Effect', {disabled, seen, showing})
     if (disabled || seen || showing || seen === undefined) return
 
-    console.log('[WelcomeDAppModal] Opening modal')
     openModal({
       title: strings.discover.welcomeToYoroiDAppExplorer,
       content: (

--- a/mobile/src/features/Legal/ui/shared/Disclaimer/ShowDisclaimer.tsx
+++ b/mobile/src/features/Legal/ui/shared/Disclaimer/ShowDisclaimer.tsx
@@ -131,13 +131,6 @@ export const ShowDisclaimer = ({type, disabled}: Props) => {
   ])
 
   React.useEffect(() => {
-    console.log('[ShowDisclaimer] Effect', {
-      disabled,
-      accepted,
-      showed,
-      isLoading,
-      hasText: !!disclaimerText,
-    })
     if (
       !disabled &&
       !accepted &&
@@ -145,7 +138,6 @@ export const ShowDisclaimer = ({type, disabled}: Props) => {
       !isLoading &&
       disclaimerText
     ) {
-      console.log('[ShowDisclaimer] Opening modal')
       openDisclaimerModal()
     }
   }, [

--- a/mobile/src/features/Legal/ui/shared/Disclaimer/ShowDisclaimer.tsx
+++ b/mobile/src/features/Legal/ui/shared/Disclaimer/ShowDisclaimer.tsx
@@ -45,6 +45,11 @@ export const ShowDisclaimer = ({type, disabled}: Props) => {
   const {resetToTxHistory} = useWalletNavigation()
   const [showed, setShowed] = React.useState(false)
   const [accepted, setAccepted] = useDisclaimerState(type)
+
+  // Reset showed when the disclaimer type changes
+  React.useEffect(() => {
+    setShowed(false)
+  }, [type])
   const {atoms: ta, palette: p, basePalette} = useTheme()
   const {data: disclaimerText, isLoading} = useDisclaimerText({
     type,

--- a/mobile/src/features/Legal/ui/shared/Disclaimer/ShowDisclaimer.tsx
+++ b/mobile/src/features/Legal/ui/shared/Disclaimer/ShowDisclaimer.tsx
@@ -51,6 +51,87 @@ export const ShowDisclaimer = ({type, disabled}: Props) => {
     languageCode,
   })
 
+  const openDisclaimerModal = React.useCallback(() => {
+    if (accepted || !disclaimerText) return
+    openModal({
+      title: strings.global.disclaimer,
+      content: (
+        <Modal.Content>
+          <View style={{height: 600}}>
+            <Markdown
+              colorScheme={basePalette}
+              backgroundColor={ta.bg_color_max.backgroundColor}
+              value={disclaimerText || ''}
+              flatListProps={{
+                style: {
+                  backgroundColor: p.bg_color_max,
+                },
+              }}
+              styles={{
+                text: {
+                  ...a.body_1_lg_regular,
+                  ...ta.text_gray_max,
+                  ...a.py_sm,
+                },
+                h2: {
+                  ...a.body_1_lg_medium,
+                  ...ta.text_gray_max,
+                  ...a.py_sm,
+                },
+                h1: {
+                  ...ta.text_gray_max,
+                  ...a.heading_3_medium,
+                  ...a.py_sm,
+                },
+              }}
+            />
+          </View>
+        </Modal.Content>
+      ),
+      footer: (
+        <Modal.Footer>
+          <View style={[a.py_lg]}>
+            <Check text={strings.global.accept} />
+          </View>
+
+          <Button
+            type={ButtonType.Secondary}
+            title={strings.global.cancel}
+            onPress={() => {
+              resetToTxHistory()
+              closeModal()
+            }}
+          />
+          <Proceed
+            title={strings.global.proceed}
+            onPress={() => {
+              setAccepted(true)
+              closeModal()
+            }}
+          />
+        </Modal.Footer>
+      ),
+      withFeedback: true,
+      height: 600,
+      canDiscard: false,
+    })
+    setShowed(true)
+  }, [
+    accepted,
+    disclaimerText,
+    openModal,
+    strings.global.disclaimer,
+    strings.global.accept,
+    strings.global.cancel,
+    strings.global.proceed,
+    basePalette,
+    ta,
+    p.bg_color_max,
+    resetToTxHistory,
+    closeModal,
+    setAccepted,
+  ])
+
   React.useEffect(() => {
     if (
       !disabled &&
@@ -59,80 +140,17 @@ export const ShowDisclaimer = ({type, disabled}: Props) => {
       !isLoading &&
       disclaimerText
     ) {
-      openModal({
-        title: strings.global.disclaimer,
-        content: (
-          <Modal.Content>
-            <View style={{height: 600}}>
-              <Markdown
-                colorScheme={basePalette}
-                backgroundColor={ta.bg_color_max.backgroundColor}
-                value={disclaimerText || ''}
-                flatListProps={{
-                  style: {
-                    backgroundColor: p.bg_color_max,
-                  },
-                }}
-                styles={{
-                  text: {
-                    ...a.body_1_lg_regular,
-                    ...ta.text_gray_max,
-                    ...a.py_sm,
-                  },
-                  h2: {
-                    ...a.body_1_lg_medium,
-                    ...ta.text_gray_max,
-                    ...a.py_sm,
-                  },
-                  h1: {
-                    ...ta.text_gray_max,
-                    ...a.heading_3_medium,
-                    ...a.py_sm,
-                  },
-                }}
-              />
-            </View>
-          </Modal.Content>
-        ),
-        footer: (
-          <Modal.Footer>
-            <View style={[a.py_lg]}>
-              <Check text={strings.global.accept} />
-            </View>
-
-            <Button
-              type={ButtonType.Secondary}
-              title={strings.global.cancel}
-              onPress={() => {
-                resetToTxHistory()
-                closeModal()
-              }}
-            />
-            <Proceed
-              title={strings.global.proceed}
-              onPress={() => {
-                setAccepted(true)
-                closeModal()
-              }}
-            />
-          </Modal.Footer>
-        ),
-        withFeedback: true,
-        height: 600,
-        canDiscard: false,
-      })
-      setShowed(true)
+      openDisclaimerModal()
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     disabled,
     accepted,
     showed,
     isLoading,
     disclaimerText,
-    openModal,
-    setShowed,
+    openDisclaimerModal,
   ])
+
   return null
 }
 

--- a/mobile/src/features/Legal/ui/shared/Disclaimer/ShowDisclaimer.tsx
+++ b/mobile/src/features/Legal/ui/shared/Disclaimer/ShowDisclaimer.tsx
@@ -56,6 +56,8 @@ export const ShowDisclaimer = ({type, disabled}: Props) => {
     openModal({
       title: strings.global.disclaimer,
       content: (
+        // Not using Modal.Content here to avoid nested VirtualizedLists warning
+        // Markdown component uses FlatList internally, which conflicts with Modal.Content's ScrollView
         <View style={{height: 600}}>
           <Markdown
             colorScheme={basePalette}

--- a/mobile/src/features/Legal/ui/shared/Disclaimer/ShowDisclaimer.tsx
+++ b/mobile/src/features/Legal/ui/shared/Disclaimer/ShowDisclaimer.tsx
@@ -56,37 +56,35 @@ export const ShowDisclaimer = ({type, disabled}: Props) => {
     openModal({
       title: strings.global.disclaimer,
       content: (
-        <Modal.Content>
-          <View style={{height: 600}}>
-            <Markdown
-              colorScheme={basePalette}
-              backgroundColor={ta.bg_color_max.backgroundColor}
-              value={disclaimerText || ''}
-              flatListProps={{
-                style: {
-                  backgroundColor: p.bg_color_max,
-                },
-              }}
-              styles={{
-                text: {
-                  ...a.body_1_lg_regular,
-                  ...ta.text_gray_max,
-                  ...a.py_sm,
-                },
-                h2: {
-                  ...a.body_1_lg_medium,
-                  ...ta.text_gray_max,
-                  ...a.py_sm,
-                },
-                h1: {
-                  ...ta.text_gray_max,
-                  ...a.heading_3_medium,
-                  ...a.py_sm,
-                },
-              }}
-            />
-          </View>
-        </Modal.Content>
+        <View style={{height: 600}}>
+          <Markdown
+            colorScheme={basePalette}
+            backgroundColor={ta.bg_color_max.backgroundColor}
+            value={disclaimerText || ''}
+            flatListProps={{
+              style: {
+                backgroundColor: p.bg_color_max,
+              },
+            }}
+            styles={{
+              text: {
+                ...a.body_1_lg_regular,
+                ...ta.text_gray_max,
+                ...a.py_sm,
+              },
+              h2: {
+                ...a.body_1_lg_medium,
+                ...ta.text_gray_max,
+                ...a.py_sm,
+              },
+              h1: {
+                ...ta.text_gray_max,
+                ...a.heading_3_medium,
+                ...a.py_sm,
+              },
+            }}
+          />
+        </View>
       ),
       footer: (
         <Modal.Footer>
@@ -133,6 +131,13 @@ export const ShowDisclaimer = ({type, disabled}: Props) => {
   ])
 
   React.useEffect(() => {
+    console.log('[ShowDisclaimer] Effect', {
+      disabled,
+      accepted,
+      showed,
+      isLoading,
+      hasText: !!disclaimerText,
+    })
     if (
       !disabled &&
       !accepted &&
@@ -140,6 +145,7 @@ export const ShowDisclaimer = ({type, disabled}: Props) => {
       !isLoading &&
       disclaimerText
     ) {
+      console.log('[ShowDisclaimer] Opening modal')
       openDisclaimerModal()
     }
   }, [

--- a/mobile/src/features/Legal/ui/shared/Disclaimer/ShowDisclaimer.tsx
+++ b/mobile/src/features/Legal/ui/shared/Disclaimer/ShowDisclaimer.tsx
@@ -56,37 +56,37 @@ export const ShowDisclaimer = ({type, disabled}: Props) => {
     openModal({
       title: strings.global.disclaimer,
       content: (
-        // Not using Modal.Content here to avoid nested VirtualizedLists warning
-        // Markdown component uses FlatList internally, which conflicts with Modal.Content's ScrollView
-        <View style={{height: 600}}>
-          <Markdown
-            colorScheme={basePalette}
-            backgroundColor={ta.bg_color_max.backgroundColor}
-            value={disclaimerText || ''}
-            flatListProps={{
-              style: {
-                backgroundColor: p.bg_color_max,
-              },
-            }}
-            styles={{
-              text: {
-                ...a.body_1_lg_regular,
-                ...ta.text_gray_max,
-                ...a.py_sm,
-              },
-              h2: {
-                ...a.body_1_lg_medium,
-                ...ta.text_gray_max,
-                ...a.py_sm,
-              },
-              h1: {
-                ...ta.text_gray_max,
-                ...a.heading_3_medium,
-                ...a.py_sm,
-              },
-            }}
-          />
-        </View>
+        <Modal.Content>
+          <View style={{height: 600}}>
+            <Markdown
+              colorScheme={basePalette}
+              backgroundColor={ta.bg_color_max.backgroundColor}
+              value={disclaimerText || ''}
+              flatListProps={{
+                style: {
+                  backgroundColor: p.bg_color_max,
+                },
+              }}
+              styles={{
+                text: {
+                  ...a.body_1_lg_regular,
+                  ...ta.text_gray_max,
+                  ...a.py_sm,
+                },
+                h2: {
+                  ...a.body_1_lg_medium,
+                  ...ta.text_gray_max,
+                  ...a.py_sm,
+                },
+                h1: {
+                  ...ta.text_gray_max,
+                  ...a.heading_3_medium,
+                  ...a.py_sm,
+                },
+              }}
+            />
+          </View>
+        </Modal.Content>
       ),
       footer: (
         <Modal.Footer>

--- a/mobile/src/ui/Modal/context/ModalContext.tsx
+++ b/mobile/src/ui/Modal/context/ModalContext.tsx
@@ -137,7 +137,7 @@ export const ModalProvider = ({children, initialState}: Props) => {
     }) => {
       Keyboard.dismiss()
 
-      if (state.isOpen) {
+      if (isOpenRef.current) {
         dispatch({
           type: 'addToQueue',
           modalData: {
@@ -173,7 +173,7 @@ export const ModalProvider = ({children, initialState}: Props) => {
         canExpand,
       })
     },
-    [state.isOpen],
+    [],
   )
 
   const actions = React.useMemo<ModalActions>(
@@ -347,7 +347,7 @@ const modalReducer = (state: ModalState, action: ModalAction) => {
           canContinue: nextModal.canContinue ?? defaultState.canContinue,
           onClose: nextModal.onClose,
           full: nextModal.full ?? defaultState.full,
-          hasExpanded: defaultState.hasExpanded, // Always reset to default when opening from queue
+          hasExpanded: defaultState.hasExpanded,
           canExpand: nextModal.canExpand ?? defaultState.canExpand,
           isOpen: true,
           queue: state.queue.slice(1),

--- a/mobile/src/ui/Modal/context/ModalContext.tsx
+++ b/mobile/src/ui/Modal/context/ModalContext.tsx
@@ -50,7 +50,7 @@ type ModalActions = {
     full?: boolean
     canExpand?: boolean
   }) => void
-  closeModal: (dismissAll?: boolean) => void
+  closeModal: () => void
   setLoading: (isLoading: boolean) => void
   setFooter: (footer: React.ReactNode | undefined) => void
   setTitle: (title: string) => void
@@ -95,19 +95,15 @@ export const ModalProvider = ({children, initialState}: Props) => {
     queueRef.current = state.queue
   }, [state.isOpen, state.queue])
 
-  const closeModal = React.useCallback(
-    (dismissAll?: boolean) => {
-      if (isKeyboardOpen) {
-        Keyboard.dismiss()
-        return
-      }
-      dispatch({
-        type: 'closeAndProcessQueue',
-        dismissAll: Boolean(dismissAll),
-      })
-    },
-    [isKeyboardOpen],
-  )
+  const closeModal = React.useCallback(() => {
+    if (isKeyboardOpen) {
+      Keyboard.dismiss()
+      return
+    }
+    dispatch({
+      type: 'closeAndProcessQueue',
+    })
+  }, [isKeyboardOpen])
 
   const openModal = React.useCallback(
     ({
@@ -137,13 +133,7 @@ export const ModalProvider = ({children, initialState}: Props) => {
     }) => {
       Keyboard.dismiss()
 
-      console.log('[ModalContext] openModal', {
-        title,
-        isOpen: isOpenRef.current,
-      })
-
       if (isOpenRef.current) {
-        console.log('[ModalContext] Queuing modal')
         dispatch({
           type: 'addToQueue',
           modalData: {
@@ -164,7 +154,6 @@ export const ModalProvider = ({children, initialState}: Props) => {
         return
       }
 
-      console.log('[ModalContext] Opening modal immediately')
       dispatch({
         type: 'open',
         content,
@@ -281,7 +270,7 @@ type ModalAction =
       canExpand?: boolean
     }
   | {type: 'close'}
-  | {type: 'closeAndProcessQueue'; dismissAll?: boolean}
+  | {type: 'closeAndProcessQueue'}
   | {type: 'addToQueue'; modalData: ModalQueueItem}
   | {type: 'clearQueue'}
   | {type: 'setLoading'; isLoading: boolean}
@@ -332,10 +321,6 @@ const modalReducer = (state: ModalState, action: ModalAction) => {
       }
 
     case 'closeAndProcessQueue':
-      console.log('[ModalReducer] closeAndProcessQueue', {
-        queueLength: state.queue.length,
-      })
-
       if (state.onClose) {
         try {
           state.onClose()
@@ -344,12 +329,8 @@ const modalReducer = (state: ModalState, action: ModalAction) => {
         }
       }
 
-      if (state.queue.length > 0 && action.dismissAll) {
+      if (state.queue.length > 0) {
         const nextModal = state.queue[0]
-        console.log(
-          '[ModalReducer] Processing queue, opening:',
-          nextModal.title,
-        )
         return {
           ...defaultState,
           content: nextModal.content,
@@ -369,7 +350,6 @@ const modalReducer = (state: ModalState, action: ModalAction) => {
         }
       }
 
-      console.log('[ModalReducer] Closing completely')
       return {
         ...defaultState,
       }

--- a/mobile/src/ui/Modal/context/ModalContext.tsx
+++ b/mobile/src/ui/Modal/context/ModalContext.tsx
@@ -137,7 +137,13 @@ export const ModalProvider = ({children, initialState}: Props) => {
     }) => {
       Keyboard.dismiss()
 
+      console.log('[ModalContext] openModal', {
+        title,
+        isOpen: isOpenRef.current,
+      })
+
       if (isOpenRef.current) {
+        console.log('[ModalContext] Queuing modal')
         dispatch({
           type: 'addToQueue',
           modalData: {
@@ -158,6 +164,7 @@ export const ModalProvider = ({children, initialState}: Props) => {
         return
       }
 
+      console.log('[ModalContext] Opening modal immediately')
       dispatch({
         type: 'open',
         content,
@@ -325,6 +332,10 @@ const modalReducer = (state: ModalState, action: ModalAction) => {
       }
 
     case 'closeAndProcessQueue':
+      console.log('[ModalReducer] closeAndProcessQueue', {
+        queueLength: state.queue.length,
+      })
+
       if (state.onClose) {
         try {
           state.onClose()
@@ -335,6 +346,10 @@ const modalReducer = (state: ModalState, action: ModalAction) => {
 
       if (state.queue.length > 0 && action.dismissAll) {
         const nextModal = state.queue[0]
+        console.log(
+          '[ModalReducer] Processing queue, opening:',
+          nextModal.title,
+        )
         return {
           ...defaultState,
           content: nextModal.content,
@@ -354,6 +369,7 @@ const modalReducer = (state: ModalState, action: ModalAction) => {
         }
       }
 
+      console.log('[ModalReducer] Closing completely')
       return {
         ...defaultState,
       }


### PR DESCRIPTION
**Fix: DApp Modal Queue Bug**

When entering the DApp list for the first time, two modals should appear in sequence: welcome first, then disclaimer. However, clicking "Next" in the welcome modal caused both modals to close instead of showing the disclaimer.

The issue was a stale closure in `ModalContext`'s `openModal` callback. It had `state.isOpen` in its dependency array, which caused the callback to capture an outdated value when checking if a modal was already open. This prevented the disclaimer from being properly queued while the welcome modal was still open.

The fix uses `isOpenRef.current` instead of `state.isOpen` to always read the current modal state without re-creating the callback. This ensures that when both modals try to open during the same render cycle, the disclaimer correctly sees the welcome modal is open and gets queued. When the user clicks "Next", the welcome modal closes and the queue processes, opening the disclaimer as intended.

**VirtualizedList Warning Fix**

The disclaimer modal was triggering a "VirtualizedLists should never be nested inside plain ScrollViews" warning. This happened because the Markdown component uses a FlatList internally for rendering content, and it was wrapped in `Modal.Content`, which provides its own `ScrollView`. Having a `FlatList` inside a `ScrollView` with the same orientation breaks React Native's windowing optimization. The fix removes the `Modal.Content` wrapper, allowing the `Markdown`'s internal `FlatList` to handle scrolling directly.

**TICKETS:**

- https://emurgo.atlassian.net/browse/YV-726
- https://emurgo.atlassian.net/browse/YV-727


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes modal queue so the disclaimer opens after the welcome modal, refactoring disclaimer open logic and adjusting disabled/close behaviors.
> 
> - **Modal System (`mobile/src/ui/Modal/context/ModalContext.tsx`)**:
>   - Change `closeModal` to no-arg and always process next queued modal; remove `dismissAll` flag and related reducer logic.
>   - Use `isOpenRef.current` in `openModal` to avoid stale `state.isOpen`; remove hook deps to keep stable callback.
> - **Discover DApp Flow**:
>   - `SelectDappFromListScreen.tsx`:
>     - Update `WelcomeDAppModal` disabled logic to `isShowedWelcomeDApp !== false`.
>     - Simplify `ShowDisclaimer` disabled to only when `isShowedWelcomeDApp === undefined`.
>   - `WelcomeDAppModal.tsx`:
>     - Update Next button to call `closeModal()` (no args).
>   - `ShowDisclaimer.tsx`:
>     - Reset `showed` on `type` change; extract `openDisclaimerModal` callback; use it in effect to open/queue the disclaimer modal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77f1ce8e7b9351a53ffb1fc39b073c4217a2f750. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->