### PR TITLE
refactor(mobile): operations notice modaltx review 

### DIFF
--- a/mobile/src/features/ReviewTx/useCases/ReviewTxScreen/ReviewTx/Overview/OverviewTab.tsx
+++ b/mobile/src/features/ReviewTx/useCases/ReviewTxScreen/ReviewTx/Overview/OverviewTab.tsx
@@ -9,7 +9,7 @@ import {atoms as a, useTheme} from '@yoroi/theme'
 import {Balance, Portfolio} from '@yoroi/types'
 
 import {CredKind} from '@emurgo/cross-csl-core'
-import {useQuery, useQueryClient} from '@tanstack/react-query'
+import {useQuery} from '@tanstack/react-query'
 import * as React from 'react'
 import {
   Image,
@@ -725,17 +725,24 @@ const useShowOperationsNotice = (operations: Operations) => {
   const strings = useStrings()
   const screenHeight = useWindowDimensions().height
   const {setOperationsNoticeShown} = useSetOperationsNoticeShown()
+  const {wallet} = useSelectedWallet()
+
+  const walletKey = React.useMemo(
+    () => `${operationsNoticeShownKey}:${wallet.id}`,
+    [wallet.id],
+  )
 
   const query = useQuery({
-    queryKey: ['useShowOperationsNotice'],
+    queryKey: ['useShowOperationsNotice', wallet.id],
     queryFn: () =>
-      storage.getItem(operationsNoticeShownKey).then((value) => {
+      storage.getItem(walletKey).then((value) => {
         const parsed = parseSafe(value)
         return isBoolean(parsed) ? parsed : true
       }),
-    initialData: false,
+    placeholderData: false,
     staleTime: Infinity,
     gcTime: Infinity,
+    refetchOnMount: 'always',
   })
 
   React.useEffect(() => {
@@ -752,14 +759,15 @@ const useShowOperationsNotice = (operations: Operations) => {
           height: Math.min(screenHeight * 0.9, 650),
           canDiscard: true,
         })
-        // Update query cache and storage via mutation
+
         setOperationsNoticeShown()
       }, 500)
     }
 
     const shouldOpen =
       operations.components.length > 0 &&
-      !query.isLoading &&
+      query.isSuccess &&
+      !query.isPlaceholderData &&
       query.data === true
 
     if (shouldOpen) {
@@ -774,23 +782,44 @@ const useShowOperationsNotice = (operations: Operations) => {
     operations.components.length,
     query.data,
     query.isLoading,
+    query.isPlaceholderData,
+    query.isSuccess,
     openModal,
     strings,
     screenHeight,
     setOperationsNoticeShown,
+    wallet.id,
+    walletKey,
   ])
 }
 
 const useSetOperationsNoticeShown = () => {
   const storage = useAsyncStorage()
-  const queryClient = useQueryClient()
+  const {wallet} = useSelectedWallet()
+  const walletKey = React.useMemo(
+    () => `${operationsNoticeShownKey}:${wallet.id}`,
+    [wallet.id],
+  )
 
   const mutation = useMutationWithInvalidations({
     mutationFn: async () => {
-      queryClient.setQueryData(['useShowOperationsNotice'], false)
-      await storage.setItem(operationsNoticeShownKey, JSON.stringify(false))
+      if (__DEV__) {
+        console.debug('[useShowOperationsNotice] storage write', {
+          walletId: wallet.id,
+          walletKey,
+          value: false,
+        })
+      }
+      await storage.setItem(walletKey, JSON.stringify(false))
     },
-    invalidateQueries: [],
+    invalidateQueries: [['useShowOperationsNotice', wallet.id]],
+    onSuccess: () => {
+      if (__DEV__) {
+        console.debug('[useShowOperationsNotice] invalidated query', {
+          queryKey: ['useShowOperationsNotice', wallet.id],
+        })
+      }
+    },
   })
 
   return {

--- a/mobile/src/features/ReviewTx/useCases/ReviewTxScreen/ReviewTx/Overview/OverviewTab.tsx
+++ b/mobile/src/features/ReviewTx/useCases/ReviewTxScreen/ReviewTx/Overview/OverviewTab.tsx
@@ -724,8 +724,8 @@ const useShowOperationsNotice = (operations: Operations) => {
   const {openModal} = useModal()
   const strings = useStrings()
   const screenHeight = useWindowDimensions().height
-  const {setOperationsNoticeShown} = useSetOperationsNoticeShown()
   const {wallet} = useSelectedWallet()
+  const {setOperationsNoticeShown} = useSetOperationsNoticeShown()
 
   const walletKey = React.useMemo(
     () => `${operationsNoticeShownKey}:${wallet.id}`,
@@ -806,7 +806,6 @@ const useSetOperationsNoticeShown = () => {
       await storage.setItem(walletKey, JSON.stringify(false))
     },
     invalidateQueries: [['useShowOperationsNotice', wallet.id]],
-    },
   })
 
   return {

--- a/mobile/src/features/ReviewTx/useCases/ReviewTxScreen/ReviewTx/Overview/OverviewTab.tsx
+++ b/mobile/src/features/ReviewTx/useCases/ReviewTxScreen/ReviewTx/Overview/OverviewTab.tsx
@@ -724,18 +724,12 @@ const useShowOperationsNotice = (operations: Operations) => {
   const {openModal} = useModal()
   const strings = useStrings()
   const screenHeight = useWindowDimensions().height
-  const {wallet} = useSelectedWallet()
   const {setOperationsNoticeShown} = useSetOperationsNoticeShown()
 
-  const walletKey = React.useMemo(
-    () => `${operationsNoticeShownKey}:${wallet.id}`,
-    [wallet.id],
-  )
-
   const query = useQuery({
-    queryKey: ['useShowOperationsNotice', wallet.id],
+    queryKey: ['useShowOperationsNotice'],
     queryFn: () =>
-      storage.getItem(walletKey).then((value) => {
+      storage.getItem(operationsNoticeShownKey).then((value) => {
         const parsed = parseSafe(value)
         return isBoolean(parsed) ? parsed : true
       }),
@@ -758,9 +752,8 @@ const useShowOperationsNotice = (operations: Operations) => {
           footer: <OperationsNoticeModalFooter />,
           height: Math.min(screenHeight * 0.9, 650),
           canDiscard: true,
+          onClose: () => setOperationsNoticeShown(),
         })
-
-        setOperationsNoticeShown()
       }, 500)
     }
 
@@ -788,24 +781,17 @@ const useShowOperationsNotice = (operations: Operations) => {
     strings,
     screenHeight,
     setOperationsNoticeShown,
-    wallet.id,
-    walletKey,
   ])
 }
 
 const useSetOperationsNoticeShown = () => {
   const storage = useAsyncStorage()
-  const {wallet} = useSelectedWallet()
-  const walletKey = React.useMemo(
-    () => `${operationsNoticeShownKey}:${wallet.id}`,
-    [wallet.id],
-  )
 
   const mutation = useMutationWithInvalidations({
     mutationFn: async () => {
-      await storage.setItem(walletKey, JSON.stringify(false))
+      await storage.setItem(operationsNoticeShownKey, JSON.stringify(false))
     },
-    invalidateQueries: [['useShowOperationsNotice', wallet.id]],
+    invalidateQueries: [['useShowOperationsNotice']],
   })
 
   return {

--- a/mobile/src/features/ReviewTx/useCases/ReviewTxScreen/ReviewTx/Overview/OverviewTab.tsx
+++ b/mobile/src/features/ReviewTx/useCases/ReviewTxScreen/ReviewTx/Overview/OverviewTab.tsx
@@ -807,10 +807,6 @@ const useSetOperationsNoticeShown = () => {
     },
     invalidateQueries: [['useShowOperationsNotice', wallet.id]],
     onSuccess: () => {
-      if (__DEV__) {
-        console.debug('[useShowOperationsNotice] invalidated query', {
-          queryKey: ['useShowOperationsNotice', wallet.id],
-        })
       }
     },
   })

--- a/mobile/src/features/ReviewTx/useCases/ReviewTxScreen/ReviewTx/Overview/OverviewTab.tsx
+++ b/mobile/src/features/ReviewTx/useCases/ReviewTxScreen/ReviewTx/Overview/OverviewTab.tsx
@@ -775,7 +775,6 @@ const useShowOperationsNotice = (operations: Operations) => {
   }, [
     operations.components.length,
     query.data,
-    query.isLoading,
     query.isPlaceholderData,
     query.isSuccess,
     openModal,

--- a/mobile/src/features/ReviewTx/useCases/ReviewTxScreen/ReviewTx/Overview/OverviewTab.tsx
+++ b/mobile/src/features/ReviewTx/useCases/ReviewTxScreen/ReviewTx/Overview/OverviewTab.tsx
@@ -746,7 +746,6 @@ const useShowOperationsNotice = (operations: Operations) => {
       clearTimeout(timeout)
 
       timeout = setTimeout(() => {
-        // Mark as shown immediately to avoid duplicate opens in StrictMode/dev
         setOperationsNoticeShown()
 
         openModal({

--- a/mobile/src/features/ReviewTx/useCases/ReviewTxScreen/ReviewTx/Overview/OverviewTab.tsx
+++ b/mobile/src/features/ReviewTx/useCases/ReviewTxScreen/ReviewTx/Overview/OverviewTab.tsx
@@ -806,8 +806,6 @@ const useSetOperationsNoticeShown = () => {
       await storage.setItem(walletKey, JSON.stringify(false))
     },
     invalidateQueries: [['useShowOperationsNotice', wallet.id]],
-    onSuccess: () => {
-      }
     },
   })
 

--- a/mobile/src/features/ReviewTx/useCases/ReviewTxScreen/ReviewTx/Overview/OverviewTab.tsx
+++ b/mobile/src/features/ReviewTx/useCases/ReviewTxScreen/ReviewTx/Overview/OverviewTab.tsx
@@ -746,13 +746,15 @@ const useShowOperationsNotice = (operations: Operations) => {
       clearTimeout(timeout)
 
       timeout = setTimeout(() => {
+        // Mark as shown immediately to avoid duplicate opens in StrictMode/dev
+        setOperationsNoticeShown()
+
         openModal({
           title: strings.txReview.overview.operationsNoticeTitle,
           content: <OperationsNoticeModalContent />,
           footer: <OperationsNoticeModalFooter />,
           height: Math.min(screenHeight * 0.9, 650),
           canDiscard: true,
-          onClose: () => setOperationsNoticeShown(),
         })
       }, 500)
     }

--- a/mobile/src/features/ReviewTx/useCases/ReviewTxScreen/ReviewTx/Overview/OverviewTab.tsx
+++ b/mobile/src/features/ReviewTx/useCases/ReviewTxScreen/ReviewTx/Overview/OverviewTab.tsx
@@ -803,13 +803,6 @@ const useSetOperationsNoticeShown = () => {
 
   const mutation = useMutationWithInvalidations({
     mutationFn: async () => {
-      if (__DEV__) {
-        console.debug('[useShowOperationsNotice] storage write', {
-          walletId: wallet.id,
-          walletKey,
-          value: false,
-        })
-      }
       await storage.setItem(walletKey, JSON.stringify(false))
     },
     invalidateQueries: [['useShowOperationsNotice', wallet.id]],

--- a/mobile/src/features/ReviewTx/useCases/ReviewTxScreen/ReviewTx/ReviewTx.tsx
+++ b/mobile/src/features/ReviewTx/useCases/ReviewTxScreen/ReviewTx/ReviewTx.tsx
@@ -90,7 +90,7 @@ export const ReviewTx = ({
     >
       <MaterialTab.Screen
         name={strings.txReview.tabLabel.overview}
-        component={() => (
+        children={() => (
           <TabWrapper onConfirm={onConfirm}>
             <OverviewTab
               tx={formattedTx}
@@ -106,7 +106,7 @@ export const ReviewTx = ({
 
       <MaterialTab.Screen
         name={strings.txReview.tabLabel.utxos}
-        component={() => (
+        children={() => (
           <TabWrapper onConfirm={onConfirm}>
             <UTxOsTab tx={formattedTx} />
           </TabWrapper>
@@ -116,7 +116,7 @@ export const ReviewTx = ({
       {showMetadataTab && (
         <MaterialTab.Screen
           name={strings.txReview.tabLabel.metadataTab}
-          component={() => (
+          children={() => (
             <TabWrapper onConfirm={onConfirm}>
               <MetadataTab
                 hash={formattedMetadata?.hash ?? null}
@@ -130,7 +130,7 @@ export const ReviewTx = ({
       {showMintTab && (
         <MaterialTab.Screen
           name={strings.txReview.tabLabel.mint}
-          component={() => (
+          children={() => (
             <TabWrapper onConfirm={onConfirm}>
               <MintTab mintData={formattedTx.mint} />
             </TabWrapper>
@@ -141,7 +141,7 @@ export const ReviewTx = ({
       {showReferenceInoutsTab && (
         <MaterialTab.Screen
           name={strings.txReview.tabLabel.referenceInputs}
-          component={() => (
+          children={() => (
             <TabWrapper onConfirm={onConfirm}>
               <ReferenceInputsTab
                 referenceInputs={formattedTx.referenceInputs}


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YV-720

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the operations notice logic to use react-query placeholder/refetch semantics with proper invalidation and moves MaterialTopTab screens from component to children render props.
> 
> - **Operations notice (in `OverviewTab.tsx`)**:
>   - Update `useQuery` options: use `placeholderData: false`, add `refetchOnMount: 'always'`, and gate on `query.isSuccess` and not `query.isPlaceholderData`.
>   - Call `setOperationsNoticeShown()` before opening the modal; adjust effect dependencies accordingly.
>   - Simplify mutation: remove `queryClient.setQueryData`, write to storage, and `invalidateQueries: [['useShowOperationsNotice']]`; drop `useQueryClient` import.
> - **Tabs (in `ReviewTx.tsx`)**:
>   - Replace `component={() => ...}` with `children={() => ...}` for all `MaterialTab.Screen` entries (`overview`, `utxos`, `metadataTab`, `mint`, `referenceInputs`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cea1f6adab83f5683e04d5118022a3994cb389ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->