### PR TITLE
fix(mobile): restore single/multiple address modal

### DIFF
--- a/mobile/src/features/Receive/useCases/DescribeSelectedAddressScreen.tsx
+++ b/mobile/src/features/Receive/useCases/DescribeSelectedAddressScreen.tsx
@@ -24,17 +24,15 @@ import {isEmptyString} from '~/wallets/utils/string'
 import {useReceive} from '../common/ReceiveProvider'
 import {useMultipleAddressesInfo} from '../common/useMultipleAddressesInfo'
 import {useNavigateTo} from '../common/useNavigateTo'
+import {useReceiveAddressesStatus} from '../common/useReceiveAddressesStatus'
 
 export const DescribeSelectedAddressScreen = () => {
   const strings = useStrings()
   const navigateTo = useNavigateTo()
   const {selectedAddress} = useReceive()
-  const {
-    /* isSingle,  */
-  } = useAddressMode()
-  // const addresses = useReceiveAddressesStatus(addressMode)
-  // TODO: REVISIT, RESTORE THIS FEATURE
-  // const isMultipleAddressesUsed = addresses.used.length > 1
+  const {isSingle: isSingleAddressMode, addressMode} = useAddressMode()
+  const addresses = useReceiveAddressesStatus(addressMode)
+  const isMultipleAddressesUsed = addresses.used.length > 1
   const {isShowingMultipleAddressInfo} = useMultipleAddressesInfo()
   const {openModal, closeModal} = useModal()
 
@@ -60,6 +58,7 @@ export const DescribeSelectedAddressScreen = () => {
     },
     [navigateTo],
   )
+
   React.useEffect(() => {
     if (!isShowingMultipleAddressInfo) return
 
@@ -80,6 +79,8 @@ export const DescribeSelectedAddressScreen = () => {
     return () => clearTimeout(timeout)
   }, [
     isShowingMultipleAddressInfo,
+    isSingleAddressMode,
+    isMultipleAddressesUsed,
     openModal,
     strings.receive.singleOrMultiple,
     handleOnModalConfirm,


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YV-718

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores the single/multiple address flow by wiring address mode and receive address status into `DescribeSelectedAddressScreen` and updating modal dependencies.
> 
> - **Mobile Receive** (`mobile/src/features/Receive/useCases/DescribeSelectedAddressScreen.tsx`):
>   - Re-enable address mode logic: use `useAddressMode()` to obtain `isSingle` and `addressMode`.
>   - Integrate `useReceiveAddressesStatus(addressMode)` and derive `isMultipleAddressesUsed`.
>   - Update modal effect deps to include `isSingleAddressMode` and `isMultipleAddressesUsed` for correct display behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97128484a710fc10a02230b59050c87538b4ca09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->