### PR TITLE
fix(mobile): connecting ble sends back wallet list

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -12,6 +12,7 @@ import {TransferProvider} from '@yoroi/transfer'
 import * as Sentry from '@sentry/react-native'
 import * as Updates from 'expo-updates'
 import * as React from 'react'
+import {Platform} from 'react-native'
 
 import {BrowserProvider} from '~/features/Discover/common/BrowserProvider'
 import {PortfolioTokenActivityProvider} from '~/features/Portfolio/context/PortfolioTokenActivityProvider'
@@ -84,8 +85,13 @@ function AppShell({children}: React.PropsWithChildren) {
 }
 
 function BusinessShell({children}: React.PropsWithChildren) {
+  // Only provide BackgroundTimerProvider on Android where permission dialogs
+  // send the app to background, potentially triggering auto-logout
+  const ConditionalBackgroundTimerProvider =
+    Platform.OS === 'android' ? BackgroundTimerProvider : React.Fragment
+
   return (
-    <BackgroundTimerProvider>
+    <ConditionalBackgroundTimerProvider>
       <AuthProvider
         authStorageKeyManager={authStorageKeyManager}
         pinStorageKeyManager={pinStorageKeyManager}
@@ -121,7 +127,7 @@ function BusinessShell({children}: React.PropsWithChildren) {
           </PairingProvider>
         </SearchProvider>
       </AuthProvider>
-    </BackgroundTimerProvider>
+    </ConditionalBackgroundTimerProvider>
   )
 }
 

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -12,7 +12,6 @@ import {TransferProvider} from '@yoroi/transfer'
 import * as Sentry from '@sentry/react-native'
 import * as Updates from 'expo-updates'
 import * as React from 'react'
-import {Platform} from 'react-native'
 
 import {BrowserProvider} from '~/features/Discover/common/BrowserProvider'
 import {PortfolioTokenActivityProvider} from '~/features/Portfolio/context/PortfolioTokenActivityProvider'
@@ -35,7 +34,6 @@ import {CurrencyProvider} from './src/features/Settings/context/CurrencyProvider
 import {AutomaticWalletOpenerProvider} from './src/features/WalletManager/context/AutomaticWalletOpeningProvider'
 import {WalletManagerProvider} from './src/features/WalletManager/context/WalletManagerProvider'
 import {walletManager} from './src/features/WalletManager/wallet-manager'
-import {BackgroundTimerProvider} from './src/hooks/BackgroundTimerContext'
 import {useFonts} from './src/hooks/useFonts'
 import {ConnectionProvider} from './src/kernel/connection/ConnectionProvider'
 import {LanguageProvider} from './src/kernel/i18n/LanguageProvider'
@@ -85,47 +83,40 @@ function AppShell({children}: React.PropsWithChildren) {
 }
 
 function BusinessShell({children}: React.PropsWithChildren) {
-  // Only enable on Android where permission dialogs trigger auto-logout
-  const isAndroid = Platform.OS === 'android'
-
   return (
-    <BackgroundTimerProvider active={isAndroid}>
-      <AuthProvider
-        authStorageKeyManager={authStorageKeyManager}
-        pinStorageKeyManager={pinStorageKeyManager}
-        installationIdKeyManager={installationIdStorageKeyManager}
-      >
-        <SearchProvider>
-          <PairingProvider
-            currencyStorageKeyManager={currencyStorageKeyManager}
-          >
-            <WalletManagerProvider walletManager={walletManager}>
-              <PortfolioTokenActivityProvider>
-                <AutomaticWalletOpenerProvider>
-                  <TransferProvider>
-                    <ReviewTxProvider>
-                      <SetupWalletProvider>
-                        <BrowserProvider>
-                          <LinksProvider>
-                            <YoroiNotificationManager>
-                              <CurrencyProvider>
-                                <CatalystProvider manager={catalystManager}>
-                                  <ReceiveProvider>{children}</ReceiveProvider>
-                                </CatalystProvider>
-                              </CurrencyProvider>
-                            </YoroiNotificationManager>
-                          </LinksProvider>
-                        </BrowserProvider>
-                      </SetupWalletProvider>
-                    </ReviewTxProvider>
-                  </TransferProvider>
-                </AutomaticWalletOpenerProvider>
-              </PortfolioTokenActivityProvider>
-            </WalletManagerProvider>
-          </PairingProvider>
-        </SearchProvider>
-      </AuthProvider>
-    </BackgroundTimerProvider>
+    <AuthProvider
+      authStorageKeyManager={authStorageKeyManager}
+      pinStorageKeyManager={pinStorageKeyManager}
+      installationIdKeyManager={installationIdStorageKeyManager}
+    >
+      <SearchProvider>
+        <PairingProvider currencyStorageKeyManager={currencyStorageKeyManager}>
+          <WalletManagerProvider walletManager={walletManager}>
+            <PortfolioTokenActivityProvider>
+              <AutomaticWalletOpenerProvider>
+                <TransferProvider>
+                  <ReviewTxProvider>
+                    <SetupWalletProvider>
+                      <BrowserProvider>
+                        <LinksProvider>
+                          <YoroiNotificationManager>
+                            <CurrencyProvider>
+                              <CatalystProvider manager={catalystManager}>
+                                <ReceiveProvider>{children}</ReceiveProvider>
+                              </CatalystProvider>
+                            </CurrencyProvider>
+                          </YoroiNotificationManager>
+                        </LinksProvider>
+                      </BrowserProvider>
+                    </SetupWalletProvider>
+                  </ReviewTxProvider>
+                </TransferProvider>
+              </AutomaticWalletOpenerProvider>
+            </PortfolioTokenActivityProvider>
+          </WalletManagerProvider>
+        </PairingProvider>
+      </SearchProvider>
+    </AuthProvider>
   )
 }
 

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -34,6 +34,7 @@ import {CurrencyProvider} from './src/features/Settings/context/CurrencyProvider
 import {AutomaticWalletOpenerProvider} from './src/features/WalletManager/context/AutomaticWalletOpeningProvider'
 import {WalletManagerProvider} from './src/features/WalletManager/context/WalletManagerProvider'
 import {walletManager} from './src/features/WalletManager/wallet-manager'
+import {BackgroundTimerProvider} from './src/hooks/BackgroundTimerContext'
 import {useFonts} from './src/hooks/useFonts'
 import {ConnectionProvider} from './src/kernel/connection/ConnectionProvider'
 import {LanguageProvider} from './src/kernel/i18n/LanguageProvider'
@@ -84,39 +85,43 @@ function AppShell({children}: React.PropsWithChildren) {
 
 function BusinessShell({children}: React.PropsWithChildren) {
   return (
-    <AuthProvider
-      authStorageKeyManager={authStorageKeyManager}
-      pinStorageKeyManager={pinStorageKeyManager}
-      installationIdKeyManager={installationIdStorageKeyManager}
-    >
-      <SearchProvider>
-        <PairingProvider currencyStorageKeyManager={currencyStorageKeyManager}>
-          <WalletManagerProvider walletManager={walletManager}>
-            <PortfolioTokenActivityProvider>
-              <AutomaticWalletOpenerProvider>
-                <TransferProvider>
-                  <ReviewTxProvider>
-                    <SetupWalletProvider>
-                      <BrowserProvider>
-                        <LinksProvider>
-                          <YoroiNotificationManager>
-                            <CurrencyProvider>
-                              <CatalystProvider manager={catalystManager}>
-                                <ReceiveProvider>{children}</ReceiveProvider>
-                              </CatalystProvider>
-                            </CurrencyProvider>
-                          </YoroiNotificationManager>
-                        </LinksProvider>
-                      </BrowserProvider>
-                    </SetupWalletProvider>
-                  </ReviewTxProvider>
-                </TransferProvider>
-              </AutomaticWalletOpenerProvider>
-            </PortfolioTokenActivityProvider>
-          </WalletManagerProvider>
-        </PairingProvider>
-      </SearchProvider>
-    </AuthProvider>
+    <BackgroundTimerProvider>
+      <AuthProvider
+        authStorageKeyManager={authStorageKeyManager}
+        pinStorageKeyManager={pinStorageKeyManager}
+        installationIdKeyManager={installationIdStorageKeyManager}
+      >
+        <SearchProvider>
+          <PairingProvider
+            currencyStorageKeyManager={currencyStorageKeyManager}
+          >
+            <WalletManagerProvider walletManager={walletManager}>
+              <PortfolioTokenActivityProvider>
+                <AutomaticWalletOpenerProvider>
+                  <TransferProvider>
+                    <ReviewTxProvider>
+                      <SetupWalletProvider>
+                        <BrowserProvider>
+                          <LinksProvider>
+                            <YoroiNotificationManager>
+                              <CurrencyProvider>
+                                <CatalystProvider manager={catalystManager}>
+                                  <ReceiveProvider>{children}</ReceiveProvider>
+                                </CatalystProvider>
+                              </CurrencyProvider>
+                            </YoroiNotificationManager>
+                          </LinksProvider>
+                        </BrowserProvider>
+                      </SetupWalletProvider>
+                    </ReviewTxProvider>
+                  </TransferProvider>
+                </AutomaticWalletOpenerProvider>
+              </PortfolioTokenActivityProvider>
+            </WalletManagerProvider>
+          </PairingProvider>
+        </SearchProvider>
+      </AuthProvider>
+    </BackgroundTimerProvider>
   )
 }
 

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -85,13 +85,11 @@ function AppShell({children}: React.PropsWithChildren) {
 }
 
 function BusinessShell({children}: React.PropsWithChildren) {
-  // Only provide BackgroundTimerProvider on Android where permission dialogs
-  // send the app to background, potentially triggering auto-logout
-  const ConditionalBackgroundTimerProvider =
-    Platform.OS === 'android' ? BackgroundTimerProvider : React.Fragment
+  // Only enable on Android where permission dialogs trigger auto-logout
+  const isAndroid = Platform.OS === 'android'
 
   return (
-    <ConditionalBackgroundTimerProvider>
+    <BackgroundTimerProvider active={isAndroid}>
       <AuthProvider
         authStorageKeyManager={authStorageKeyManager}
         pinStorageKeyManager={pinStorageKeyManager}
@@ -127,7 +125,7 @@ function BusinessShell({children}: React.PropsWithChildren) {
           </PairingProvider>
         </SearchProvider>
       </AuthProvider>
-    </ConditionalBackgroundTimerProvider>
+    </BackgroundTimerProvider>
   )
 }
 

--- a/mobile/PlatformShell.tsx
+++ b/mobile/PlatformShell.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import {Platform} from 'react-native'
 import {KeyboardProvider} from 'react-native-keyboard-controller'
 import {
   SafeAreaProvider,
@@ -13,9 +14,13 @@ import {
 import {RouterContainer} from '~/kernel/navigation/RouterContainer'
 import {ModalProvider} from '~/ui/Modal/context/ModalContext'
 
+import {BackgroundTimerProvider} from './src/hooks/BackgroundTimerContext'
+
 export function PlatformShell({children}: React.PropsWithChildren) {
   const metricsManager = React.useMemo(() => makeMetricsManager(), [])
   const {init} = useScreenCapture()
+  // Only enable on Android where permission dialogs trigger auto-logout
+  const isAndroid = Platform.OS === 'android'
 
   React.useEffect(() => {
     init()
@@ -26,7 +31,11 @@ export function PlatformShell({children}: React.PropsWithChildren) {
       <MetricsProvider metricsManager={metricsManager}>
         <RouterContainer>
           <ModalProvider>
-            <KeyboardProvider statusBarTranslucent>{children}</KeyboardProvider>
+            <BackgroundTimerProvider active={isAndroid}>
+              <KeyboardProvider statusBarTranslucent>
+                {children}
+              </KeyboardProvider>
+            </BackgroundTimerProvider>
           </ModalProvider>
         </RouterContainer>
       </MetricsProvider>

--- a/mobile/src/hooks/BackgroundTimerContext.tsx
+++ b/mobile/src/hooks/BackgroundTimerContext.tsx
@@ -7,8 +7,8 @@ import * as React from 'react'
  * which can trigger auto-logout timers. This context allows temporarily disabling the
  * background timer while permission dialogs are active.
  *
- * On iOS, this provider is not mounted and hooks return no-op functions, making the
- * code seamlessly cross-platform without explicit Platform checks at usage sites.
+ * On iOS, set `active={false}` to provide no-op functions, making the code seamlessly
+ * cross-platform without explicit Platform checks at usage sites.
  */
 
 type BackgroundTimerContextType = {
@@ -21,27 +21,39 @@ const BackgroundTimerContext = React.createContext<
   BackgroundTimerContextType | undefined
 >(undefined)
 
-export const BackgroundTimerProvider: React.FC<React.PropsWithChildren> = ({
-  children,
-}) => {
+const NO_OP_VALUE: BackgroundTimerContextType = {
+  isDisabled: false,
+  disable: () => {},
+  enable: () => {},
+}
+
+type BackgroundTimerProviderProps = React.PropsWithChildren<{
+  active?: boolean
+}>
+
+export const BackgroundTimerProvider: React.FC<
+  BackgroundTimerProviderProps
+> = ({children, active = true}) => {
   const [isDisabled, setIsDisabled] = React.useState(false)
   const disableCountRef = React.useRef(0)
 
   const disable = React.useCallback(() => {
+    if (!active) return
     disableCountRef.current += 1
     setIsDisabled(true)
-  }, [])
+  }, [active])
 
   const enable = React.useCallback(() => {
+    if (!active) return
     disableCountRef.current = Math.max(0, disableCountRef.current - 1)
     if (disableCountRef.current === 0) {
       setIsDisabled(false)
     }
-  }, [])
+  }, [active])
 
   const value = React.useMemo(
-    () => ({isDisabled, disable, enable}),
-    [isDisabled, disable, enable],
+    () => (active ? {isDisabled, disable, enable} : NO_OP_VALUE),
+    [active, isDisabled, disable, enable],
   )
 
   return (

--- a/mobile/src/hooks/BackgroundTimerContext.tsx
+++ b/mobile/src/hooks/BackgroundTimerContext.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react'
+
+type BackgroundTimerContextType = {
+  isDisabled: boolean
+  disable: () => void
+  enable: () => void
+}
+
+const BackgroundTimerContext = React.createContext<
+  BackgroundTimerContextType | undefined
+>(undefined)
+
+export const BackgroundTimerProvider: React.FC<React.PropsWithChildren> = ({
+  children,
+}) => {
+  const [isDisabled, setIsDisabled] = React.useState(false)
+  const disableCountRef = React.useRef(0)
+
+  const disable = React.useCallback(() => {
+    disableCountRef.current += 1
+    setIsDisabled(true)
+  }, [])
+
+  const enable = React.useCallback(() => {
+    disableCountRef.current = Math.max(0, disableCountRef.current - 1)
+    if (disableCountRef.current === 0) {
+      setIsDisabled(false)
+    }
+  }, [])
+
+  const value = React.useMemo(
+    () => ({isDisabled, disable, enable}),
+    [isDisabled, disable, enable],
+  )
+
+  return (
+    <BackgroundTimerContext.Provider value={value}>
+      {children}
+    </BackgroundTimerContext.Provider>
+  )
+}
+
+export const useBackgroundTimerControl = () => {
+  const context = React.useContext(BackgroundTimerContext)
+  if (!context) {
+    throw new Error(
+      'useBackgroundTimerControl must be used within BackgroundTimerProvider',
+    )
+  }
+  return context
+}
+
+export const useBackgroundTimerState = () => {
+  const context = React.useContext(BackgroundTimerContext)
+  // If no provider exists, assume timer is enabled
+  return context?.isDisabled ?? false
+}

--- a/mobile/src/hooks/BackgroundTimerContext.tsx
+++ b/mobile/src/hooks/BackgroundTimerContext.tsx
@@ -1,5 +1,16 @@
 import * as React from 'react'
 
+/**
+ * BackgroundTimerContext - Android-specific solution for permission dialog handling
+ *
+ * On Android, permission dialogs (e.g., Bluetooth, Location) send the app to background,
+ * which can trigger auto-logout timers. This context allows temporarily disabling the
+ * background timer while permission dialogs are active.
+ *
+ * On iOS, this provider is not mounted and hooks return no-op functions, making the
+ * code seamlessly cross-platform without explicit Platform checks at usage sites.
+ */
+
 type BackgroundTimerContextType = {
   isDisabled: boolean
   disable: () => void
@@ -42,11 +53,17 @@ export const BackgroundTimerProvider: React.FC<React.PropsWithChildren> = ({
 
 export const useBackgroundTimerControl = () => {
   const context = React.useContext(BackgroundTimerContext)
+
+  // If no provider exists (e.g., on iOS), return no-op functions
+  // This allows the code to work seamlessly across platforms
   if (!context) {
-    throw new Error(
-      'useBackgroundTimerControl must be used within BackgroundTimerProvider',
-    )
+    return {
+      isDisabled: false,
+      disable: () => {},
+      enable: () => {},
+    }
   }
+
   return context
 }
 

--- a/mobile/src/hooks/useBackgroundTimer.ts
+++ b/mobile/src/hooks/useBackgroundTimer.ts
@@ -7,30 +7,34 @@ export function useBackgroundTimer({after, execute}: Props) {
   const bgTimeRef = React.useRef<number | null>(null)
   const isDisabled = useBackgroundTimerState()
 
+  const handleBackground = React.useCallback(() => {
+    // Only record timestamp if timer is active
+    if (!isDisabled) {
+      bgTimeRef.current = Date.now()
+    }
+  }, [isDisabled])
+
+  const handleActive = React.useCallback(() => {
+    // Check background time only if we have a timestamp and timer is active
+    if (bgTimeRef.current !== null && !isDisabled) {
+      const timeSpentInBg = Date.now() - bgTimeRef.current
+      if (timeSpentInBg >= after) execute()
+    }
+
+    // ALWAYS clear timestamp when returning to active state
+    // This prevents stale timestamps from persisting across state changes
+    // Even if timer was disabled, we need to clear any recorded timestamp
+    bgTimeRef.current = null
+  }, [isDisabled, after, execute])
+
   useAppState({
     on: 'background',
-    execute: () => {
-      // Only record timestamp if timer is active
-      if (!isDisabled) {
-        bgTimeRef.current = Date.now()
-      }
-    },
+    execute: handleBackground,
   })
 
   useAppState({
     on: 'active',
-    execute: () => {
-      // Check background time only if we have a timestamp and timer is active
-      if (bgTimeRef.current !== null && !isDisabled) {
-        const timeSpentInBg = Date.now() - bgTimeRef.current
-        if (timeSpentInBg >= after) execute()
-      }
-
-      // ALWAYS clear timestamp when returning to active state
-      // This prevents stale timestamps from persisting across state changes
-      // Even if timer was disabled, we need to clear any recorded timestamp
-      bgTimeRef.current = null
-    },
+    execute: handleActive,
   })
 }
 

--- a/mobile/src/hooks/useBackgroundTimer.ts
+++ b/mobile/src/hooks/useBackgroundTimer.ts
@@ -22,8 +22,8 @@ export function useBackgroundTimer({after, execute}: Props) {
       if (bgTimeRef.current !== null && !isDisabled) {
         const timeSpentInBg = Date.now() - bgTimeRef.current
         if (timeSpentInBg >= after) execute()
+        bgTimeRef.current = null
       }
-      bgTimeRef.current = null
     },
   })
 }

--- a/mobile/src/hooks/useBackgroundTimer.ts
+++ b/mobile/src/hooks/useBackgroundTimer.ts
@@ -10,6 +10,7 @@ export function useBackgroundTimer({after, execute}: Props) {
   useAppState({
     on: 'background',
     execute: () => {
+      // Only record timestamp if timer is active
       if (!isDisabled) {
         bgTimeRef.current = Date.now()
       }
@@ -19,11 +20,16 @@ export function useBackgroundTimer({after, execute}: Props) {
   useAppState({
     on: 'active',
     execute: () => {
+      // Check background time only if we have a timestamp and timer is active
       if (bgTimeRef.current !== null && !isDisabled) {
         const timeSpentInBg = Date.now() - bgTimeRef.current
         if (timeSpentInBg >= after) execute()
-        bgTimeRef.current = null
       }
+
+      // ALWAYS clear timestamp when returning to active state
+      // This prevents stale timestamps from persisting across state changes
+      // Even if timer was disabled, we need to clear any recorded timestamp
+      bgTimeRef.current = null
     },
   })
 }

--- a/mobile/src/hooks/useBackgroundTimer.ts
+++ b/mobile/src/hooks/useBackgroundTimer.ts
@@ -1,21 +1,25 @@
 import * as React from 'react'
 
+import {useBackgroundTimerState} from './BackgroundTimerContext'
 import {useAppState} from './useAppState'
 
 export function useBackgroundTimer({after, execute}: Props) {
   const bgTimeRef = React.useRef<number | null>(null)
+  const isDisabled = useBackgroundTimerState()
 
   useAppState({
     on: 'background',
     execute: () => {
-      bgTimeRef.current = Date.now()
+      if (!isDisabled) {
+        bgTimeRef.current = Date.now()
+      }
     },
   })
 
   useAppState({
     on: 'active',
     execute: () => {
-      if (bgTimeRef.current !== null) {
+      if (bgTimeRef.current !== null && !isDisabled) {
         const timeSpentInBg = Date.now() - bgTimeRef.current
         if (timeSpentInBg >= after) execute()
       }

--- a/mobile/src/hooks/useBluetooth.ts
+++ b/mobile/src/hooks/useBluetooth.ts
@@ -6,6 +6,8 @@ import {BleManager, Device, LogLevel, State} from 'react-native-ble-plx'
 
 import {logger} from '~/kernel/logger/logger'
 
+import {useBackgroundTimerControl} from './BackgroundTimerContext'
+
 export interface BluetoothDevice {
   id: string
   name: string | null
@@ -71,6 +73,7 @@ const requestBluetoothPermissions = async (): Promise<void> => {
 }
 
 export const useBluetooth = (): UseBluetoothReturn => {
+  const {disable, enable} = useBackgroundTimerControl()
   const [state, setState] = React.useState<BluetoothState>({
     isScanning: false,
     isConnected: false,
@@ -121,6 +124,8 @@ export const useBluetooth = (): UseBluetoothReturn => {
       }))
       logger.debug('Requesting Bluetooth permissions...')
 
+      // Disable background timer before requesting permissions
+      disable()
       await requestBluetoothPermissions()
 
       logger.debug('Bluetooth permissions granted')
@@ -140,8 +145,11 @@ export const useBluetooth = (): UseBluetoothReturn => {
             : 'Failed to request Bluetooth permissions',
       }))
       throw error
+    } finally {
+      // Re-enable background timer after permission dialog is dismissed
+      enable()
     }
-  }, [])
+  }, [disable, enable])
 
   const stopScan = React.useCallback(() => {
     if (bleManagerRef.current) {

--- a/mobile/src/hooks/useBluetooth.ts
+++ b/mobile/src/hooks/useBluetooth.ts
@@ -124,7 +124,8 @@ export const useBluetooth = (): UseBluetoothReturn => {
       }))
       logger.debug('Requesting Bluetooth permissions...')
 
-      // Disable background timer before requesting permissions
+      // Disable background timer before requesting permissions (Android-specific)
+      // On Android, permission dialogs send the app to background, which could trigger auto-logout
       disable()
       await requestBluetoothPermissions()
 

--- a/mobile/src/wallets/hw/hw.ts
+++ b/mobile/src/wallets/hw/hw.ts
@@ -2,6 +2,7 @@ import {UseMutationOptions, useMutation} from '@tanstack/react-query'
 import {MessageDescriptor} from 'react-intl'
 import {Permission, PermissionsAndroid, Platform} from 'react-native'
 
+import {useBackgroundTimerControl} from '~/hooks/BackgroundTimerContext'
 import {LocalizableError} from '~/kernel/i18n/LocalizableError'
 
 const requestLedgerPermissions = async () => {
@@ -17,9 +18,20 @@ const requestLedgerPermissions = async () => {
 export const useLedgerPermissions = (
   options?: UseMutationOptions<void, Error>,
 ) => {
+  const {disable, enable} = useBackgroundTimerControl()
+
   const mutation = useMutation({
     ...options,
-    mutationFn: requestLedgerPermissions,
+    mutationFn: async () => {
+      // Disable background timer before requesting permissions
+      disable()
+      try {
+        await requestLedgerPermissions()
+      } finally {
+        // Re-enable background timer after permission dialog is dismissed
+        enable()
+      }
+    },
   })
 
   return {

--- a/mobile/src/wallets/hw/hw.ts
+++ b/mobile/src/wallets/hw/hw.ts
@@ -23,7 +23,8 @@ export const useLedgerPermissions = (
   const mutation = useMutation({
     ...options,
     mutationFn: async () => {
-      // Disable background timer before requesting permissions
+      // Disable background timer before requesting permissions (Android-specific)
+      // On Android, permission dialogs send the app to background, which could trigger auto-logout
       disable()
       try {
         await requestLedgerPermissions()

--- a/mobile/src/wallets/hw/hw.ts
+++ b/mobile/src/wallets/hw/hw.ts
@@ -1,4 +1,5 @@
 import {UseMutationOptions, useMutation} from '@tanstack/react-query'
+import * as React from 'react'
 import {MessageDescriptor} from 'react-intl'
 import {Permission, PermissionsAndroid, Platform} from 'react-native'
 
@@ -20,19 +21,21 @@ export const useLedgerPermissions = (
 ) => {
   const {disable, enable} = useBackgroundTimerControl()
 
+  const mutationFn = React.useCallback(async () => {
+    // Disable background timer before requesting permissions (Android-specific)
+    // On Android, permission dialogs send the app to background, which could trigger auto-logout
+    disable()
+    try {
+      await requestLedgerPermissions()
+    } finally {
+      // Re-enable background timer after permission dialog is dismissed
+      enable()
+    }
+  }, [disable, enable])
+
   const mutation = useMutation({
     ...options,
-    mutationFn: async () => {
-      // Disable background timer before requesting permissions (Android-specific)
-      // On Android, permission dialogs send the app to background, which could trigger auto-logout
-      disable()
-      try {
-        await requestLedgerPermissions()
-      } finally {
-        // Re-enable background timer after permission dialog is dismissed
-        enable()
-      }
-    },
+    mutationFn,
   })
 
   return {


### PR DESCRIPTION
Fixes auto-logout issue on Android when requesting Bluetooth or Ledger permissions.

**Problem:** 

On Android, system permission dialogs send the app to background, triggering auto-logout timers and logging users out unexpectedly.

**Solution:**

Introduced BackgroundTimerContext to temporarily disable logout timer during permission requests
Applied to Bluetooth and Ledger permission flows
Android-specific implementation (no-op on iOS where permission dialogs don't background the app)

**Changes:**

Added context to control background timer state
Modified useBluetooth and useLedgerPermissions to disable timer before requesting permissions
Conditional provider mounting (Android only) for clean cross-platform code

https://emurgo.atlassian.net/browse/YV-669


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `BackgroundTimerContext` and integrates it to pause the background timer during Android permission dialogs for Bluetooth and Ledger, preventing unintended logouts.
> 
> - **Android background-timer control**:
>   - Add `mobile/src/hooks/BackgroundTimerContext.tsx` providing `BackgroundTimerProvider`, `useBackgroundTimerControl`, and `useBackgroundTimerState` to temporarily disable background timer.
>   - Wrap app with `BackgroundTimerProvider` in `mobile/PlatformShell.tsx` (Android-only via `Platform`), nesting above `KeyboardProvider`.
> - **Hooks**:
>   - Update `useBackgroundTimer` to respect `isDisabled` and clear timestamps safely.
> - **Bluetooth**:
>   - In `mobile/src/hooks/useBluetooth.ts`, disable/enable background timer around permission requests via `useBackgroundTimerControl`.
> - **Ledger permissions**:
>   - In `mobile/src/wallets/hw/hw.ts`, wrap `requestLedgerPermissions` with disable/enable from `useBackgroundTimerControl` and use a memoized `mutationFn`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d74ab9425d5747934d27c026ecd6543ecd6ea883. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->