### PR TITLE
fix: change title of buy/sell

### DIFF
--- a/mobile/src/features/Transactions/TxHistoryNavigator.tsx
+++ b/mobile/src/features/Transactions/TxHistoryNavigator.tsx
@@ -223,7 +223,7 @@ export const TxHistoryNavigator = () => {
         <Stack.Screen
           name="exchange-create-order"
           options={{
-            title: strings.exchange.buyCrypto,
+            title: strings.exchange.title,
           }}
           getComponent={() => CreateExchangeOrderScreen}
         />

--- a/mobile/src/kernel/i18n/messages/exchange.ts
+++ b/mobile/src/kernel/i18n/messages/exchange.ts
@@ -98,7 +98,7 @@ export const exchangeMessages = defineMessages({
     defaultMessage: '!!!Sell currency warning',
   },
   title: {
-    id: 'global.buyInfo',
+    id: 'global.exchange',
     defaultMessage: '!!!Exchange',
   },
   getFirstCrypto: {

--- a/mobile/src/kernel/navigation/WalletTabNavigator.tsx
+++ b/mobile/src/kernel/navigation/WalletTabNavigator.tsx
@@ -44,7 +44,7 @@ export const WalletTabNavigator = () => {
               tabBarStyle: {
                 ...ta.bg_color_max,
                 borderTopWidth: 0.5,
-                borderTopColor: p.gray_600,
+                borderTopColor: p.gray_200,
               },
               tabBarActiveTintColor: p.primary_600,
               tabBarInactiveTintColor: p.gray_600,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches exchange create-order screen title to `strings.exchange.title` and changes its message id from `global.buyInfo` to `global.exchange`.
> 
> - **UI**:
>   - `mobile/src/features/Transactions/TxHistoryNavigator.tsx`: Set `exchange-create-order` screen title to `strings.exchange.title` (was `strings.exchange.buyCrypto`).
> - **i18n**:
>   - `mobile/src/kernel/i18n/messages/exchange.ts`: Update `exchangeMessages.title.id` from `global.buyInfo` to `global.exchange` (default message unchanged).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7155335bd928822d6233d26ceb50a6c285328d4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->