### PR TITLE
chore: merge develop to preview

### DIFF
--- a/mobile/src/features/Transactions/TxHistoryNavigator.tsx
+++ b/mobile/src/features/Transactions/TxHistoryNavigator.tsx
@@ -223,7 +223,7 @@ export const TxHistoryNavigator = () => {
         <Stack.Screen
           name="exchange-create-order"
           options={{
-            title: strings.exchange.buyCrypto,
+            title: strings.exchange.title,
           }}
           getComponent={() => CreateExchangeOrderScreen}
         />

--- a/mobile/src/kernel/i18n/messages/exchange.ts
+++ b/mobile/src/kernel/i18n/messages/exchange.ts
@@ -98,7 +98,7 @@ export const exchangeMessages = defineMessages({
     defaultMessage: '!!!Sell currency warning',
   },
   title: {
-    id: 'global.buyInfo',
+    id: 'global.exchange',
     defaultMessage: '!!!Exchange',
   },
   getFirstCrypto: {

--- a/mobile/src/kernel/navigation/WalletTabNavigator.tsx
+++ b/mobile/src/kernel/navigation/WalletTabNavigator.tsx
@@ -44,7 +44,7 @@ export const WalletTabNavigator = () => {
               tabBarStyle: {
                 ...ta.bg_color_max,
                 borderTopWidth: 0.5,
-                borderTopColor: p.gray_600,
+                borderTopColor: p.gray_200,
               },
               tabBarActiveTintColor: p.primary_600,
               tabBarInactiveTintColor: p.gray_600,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Standardizes exchange screen title to `strings.exchange.title` and changes wallet tab bar border to `p.gray_200`.
> 
> - **Exchange title updates**:
>   - `TxHistoryNavigator`: `exchange-create-order` screen title switched from `strings.exchange.buyCrypto` to `strings.exchange.title`.
>   - i18n: `exchange.title` message id changed from `global.buyInfo` to `global.exchange`.
> - **UI tweak**:
>   - `WalletTabNavigator`: tab bar `borderTopColor` updated from `p.gray_600` to `p.gray_200`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2808d154e44507f73f2c79e106b603dc7699b3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->