### PR TITLE
fix(swap): Add input utxo for fees

### DIFF
--- a/mobile/src/features/Swap/common/useGetInputs.ts
+++ b/mobile/src/features/Swap/common/useGetInputs.ts
@@ -8,15 +8,45 @@ export const useGetInputs = () => {
 
   return {
     getInputs: async (amounts: Balance.Amounts) => {
-      const result = await Promise.all(
-        (
-          (await _getRequiredUtxos(wallet, amounts, wallet.utxos, meta)) || []
-        ).map(async (u) => {
+      // Create amounts for 5 ADA
+      const adaAmount: Balance.Amount = {
+        tokenId: wallet.portfolioPrimaryTokenInfo.id,
+        quantity: '5000000', // 5 ADA = 5 * 10^6 lovelace
+      }
+      const adaAmounts: Balance.Amounts = {
+        [adaAmount.tokenId]: adaAmount.quantity,
+      }
+
+      // Get UTXOs for original amounts
+      const originalUtxos = await _getRequiredUtxos(
+        wallet,
+        amounts,
+        wallet.utxos,
+        meta,
+      )
+
+      // Get UTXOs for 5 ADA
+      const adaUtxos = await _getRequiredUtxos(
+        wallet,
+        adaAmounts,
+        wallet.utxos,
+        meta,
+      )
+
+      // Combine both results and remove duplicates using string comparison
+      const allUtxos = [...(originalUtxos || []), ...(adaUtxos || [])]
+
+      // Convert all UTXOs to hex strings first
+      const allUtxoStrings = await Promise.all(
+        allUtxos.map(async (u) => {
           return Buffer.from(await u.toBytes()).toString('hex')
         }),
       )
 
-      return result
+      // Remove duplicate strings
+      const uniqueUtxoStrings = [...new Set(allUtxoStrings)]
+
+      return uniqueUtxoStrings
     },
   }
 }


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YV-734

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds selection of UTXOs for an extra 5 ADA (fees), merges with original inputs, and removes duplicates before returning hex strings.
> 
> - **Swap**:
>   - **`useGetInputs`**:
>     - Adds calculation of a 5 ADA amount and fetches its required UTXOs.
>     - Merges fee UTXOs with original selection and removes duplicates.
>     - Continues returning inputs as hex-encoded strings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d4c9350b541998b5dd00a369cae773c6f8fad2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->