### PR TITLE
chore(wallet): increase default timer to lock app

### DIFF
--- a/mobile/packages/swap/adapters/api/muesliswap/transformers.ts
+++ b/mobile/packages/swap/adapters/api/muesliswap/transformers.ts
@@ -351,8 +351,10 @@ export const transformersMaker = ({
         inputs,
         routeHint,
       }: Swap.CreateRequest): LimitOrderRequest => {
+        // For multi-hop swaps (multiple pool IDs), don't send pool_id
+        const isMultiHop = routeHint?.poolIds && routeHint.poolIds.length > 1
         // Mutually exclusive: prefer pool_id when provided, otherwise use order_contract
-        const pool_id = routeHint?.poolIds?.[0]
+        const pool_id = isMultiHop ? undefined : routeHint?.poolIds?.[0]
         const order_contract = pool_id
           ? undefined
           : mapProtocolToOrderContract({protocol, routeHint})

--- a/mobile/packages/types/swap/api.ts
+++ b/mobile/packages/types/swap/api.ts
@@ -58,7 +58,7 @@ export type SwapSplit = {
   // Optional metadata for route fidelity
   aggregator?: SwapAggregator
   aggregatorDexKey?: string
-  aggregatorPoolId?: string
+  aggregatorPoolId?: string | string[]
   quoteId?: string
   // Optional image URL to be used as a fallback icon in the UI
   aggregatorImageUrl?: string

--- a/mobile/src/features/Auth/context/AuthProvider.tsx
+++ b/mobile/src/features/Auth/context/AuthProvider.tsx
@@ -26,7 +26,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren<Props>> = ({
 
   // NOTE: This should be configurable
   useBackgroundTimer({
-    after: time.minutes(1),
+    after: time.minutes(5),
     execute: () => {
       if (loggedState.status === 'logged-in') {
         logger.debug('logout (auto)', {origin: 'AuthProvider', type: 'user'})

--- a/mobile/src/features/Auth/context/AuthProvider.tsx
+++ b/mobile/src/features/Auth/context/AuthProvider.tsx
@@ -26,7 +26,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren<Props>> = ({
 
   // NOTE: This should be configurable
   useBackgroundTimer({
-    after: time.minutes(5),
+    after: time.minutes(1),
     execute: () => {
       if (loggedState.status === 'logged-in') {
         logger.debug('logout (auto)', {origin: 'AuthProvider', type: 'user'})

--- a/mobile/src/features/Auth/context/AuthProvider.tsx
+++ b/mobile/src/features/Auth/context/AuthProvider.tsx
@@ -26,7 +26,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren<Props>> = ({
 
   // NOTE: This should be configurable
   useBackgroundTimer({
-    after: time.seconds(1),
+    after: time.minutes(5),
     execute: () => {
       if (loggedState.status === 'logged-in') {
         logger.debug('logout (auto)', {origin: 'AuthProvider', type: 'user'})

--- a/mobile/src/features/Swap/common/SwapProvider.tsx
+++ b/mobile/src/features/Swap/common/SwapProvider.tsx
@@ -483,7 +483,7 @@ export const SwapProvider = ({children}: React.PropsWithChildren) => {
                 aggregatorDexKey: state.estimate.splits[0].aggregatorDexKey,
                 poolIds:
                   state.estimate.splits[0].aggregatorPoolId != null
-                    ? [state.estimate.splits[0].aggregatorPoolId]
+                    ? [state.estimate.splits[0].aggregatorPoolId].flat()
                     : undefined,
                 quoteId: state.estimate.splits[0].quoteId,
               }

--- a/mobile/src/features/Swap/common/useGetInputs.ts
+++ b/mobile/src/features/Swap/common/useGetInputs.ts
@@ -8,15 +8,45 @@ export const useGetInputs = () => {
 
   return {
     getInputs: async (amounts: Balance.Amounts) => {
-      const result = await Promise.all(
-        (
-          (await _getRequiredUtxos(wallet, amounts, wallet.utxos, meta)) || []
-        ).map(async (u) => {
+      // Create amounts for 5 ADA
+      const adaAmount: Balance.Amount = {
+        tokenId: wallet.portfolioPrimaryTokenInfo.id,
+        quantity: '5000000', // 5 ADA = 5 * 10^6 lovelace
+      }
+      const adaAmounts: Balance.Amounts = {
+        [adaAmount.tokenId]: adaAmount.quantity,
+      }
+
+      // Get UTXOs for original amounts
+      const originalUtxos = await _getRequiredUtxos(
+        wallet,
+        amounts,
+        wallet.utxos,
+        meta,
+      )
+
+      // Get UTXOs for 5 ADA
+      const adaUtxos = await _getRequiredUtxos(
+        wallet,
+        adaAmounts,
+        wallet.utxos,
+        meta,
+      )
+
+      // Combine both results and remove duplicates using string comparison
+      const allUtxos = [...(originalUtxos || []), ...(adaUtxos || [])]
+
+      // Convert all UTXOs to hex strings first
+      const allUtxoStrings = await Promise.all(
+        allUtxos.map(async (u) => {
           return Buffer.from(await u.toBytes()).toString('hex')
         }),
       )
 
-      return result
+      // Remove duplicate strings
+      const uniqueUtxoStrings = [...new Set(allUtxoStrings)]
+
+      return uniqueUtxoStrings
     },
   }
 }

--- a/scripts/packages/swap/package.json
+++ b/scripts/packages/swap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoroi/swap",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "The Swap package of Yoroi SDK",
   "keywords": [
     "yoroi",

--- a/scripts/packages/types/package.json
+++ b/scripts/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoroi/types",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "The Yoroi Types package of Yoroi SDK",
   "keywords": [
     "yoroi",


### PR DESCRIPTION
Comment says should be configurable, and we could definitely add this to user settings. But until that's done, I think 5 minutes is more reasonable than 1 second. Right now it's impossible to switch apps without the whole app locking and loosing where you are. Use cases for this are copy pasting addresses or dreps from an explorer. Or checking seed phrases for recovery from another app.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase auto-logout background timer in `AuthProvider` from 1 second to 5 minutes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 413804ae1d0fa17f26b77bfc140c2994a7125eb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->