### PR TITLE
chore(wallet): increase spacing before CollapisbleHeader

### DIFF
--- a/mobile/src/features/Transactions/useCases/TxHistory/TxHistory.tsx
+++ b/mobile/src/features/Transactions/useCases/TxHistory/TxHistory.tsx
@@ -75,7 +75,7 @@ export const TxHistory = () => {
       end={{x: isDark ? 0 : 0, y: isDark ? 0.5 : 0}}
       style={{flex: 1}}
     >
-      <SpaceHeight size={91} />
+      <SpaceHeight size={100} />
 
       <CollapsibleHeader expanded={expanded}>
         <BalanceBanner />


### PR DESCRIPTION
It's overlapping with the header in the Pixel 10. I think it has something to do with different safe area top since the emulator doesn't have a notch, but I couldn't pinpoint exactly the real cause. This increase should be imperceptible enough for ok devices and make it better for affected ones.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase `SpaceHeight` from 91 to 100 in `mobile/src/features/Transactions/useCases/TxHistory/TxHistory.tsx` to add more top spacing before the collapsible header.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c5aebc67143a2ebf88b6e80ca0215e10b84114a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->