### PR TITLE
fix(wallet): Fix order prices being inverted

### DIFF
--- a/mobile/src/features/Swap/useCases/ListOrders/ListOrders.tsx
+++ b/mobile/src/features/Swap/useCases/ListOrders/ListOrders.tsx
@@ -184,7 +184,7 @@ const Order = ({order}: {order: Swap.Order}) => {
     order.actualAmountOut === 0
       ? order.expectedAmountOut
       : order.actualAmountOut
-  const priceCalc = amountOut === 0 ? 0 : order.amountIn / amountOut
+  const priceCalc = order.amountIn === 0 ? 0 : amountOut / order.amountIn
 
   const roundedPrice = parseNumberFromText({
     text: String(priceCalc),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Corrects order price calculation to use amountOut per amountIn and guards against zero amountIn.
> 
> - **Swap Orders UI**
>   - Fix price computation in `mobile/src/features/Swap/useCases/ListOrders/ListOrders.tsx` to `amountOut / order.amountIn` (was `order.amountIn / amountOut`).
>   - Update zero-division guard to check `order.amountIn === 0` (instead of `amountOut === 0`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f58d70903e2210d69216a27ae9855cc32ea2899. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

https://emurgo.atlassian.net/browse/YV-741