### PR TITLE
fix(mobile): analytics opt-in applies immediately

### DIFF
--- a/mobile/PlatformShell.tsx
+++ b/mobile/PlatformShell.tsx
@@ -22,7 +22,9 @@ import {ModalProvider} from '~/ui/Modal/context/ModalContext'
 import {BackgroundTimerProvider} from './src/hooks/BackgroundTimerContext'
 
 export function PlatformShell({children}: React.PropsWithChildren) {
-  const metricsEnabled = metricsEnabledStorageKeyManager.read()
+  const [metricsEnabled, setMetricsEnabled] = React.useState<boolean>(
+    metricsEnabledStorageKeyManager.read(),
+  )
 
   const {init} = useScreenCapture()
 
@@ -41,6 +43,7 @@ export function PlatformShell({children}: React.PropsWithChildren) {
         platform={platform}
         client={client}
         metricsEnabledStorage={metricsEnabledStorageKeyManager}
+        onEnabledChange={setMetricsEnabled}
       >
         <TrackedRouterContainer>
           <ModalProvider>

--- a/mobile/src/features/Analytics/context/AnalyticsRootProvider.tsx
+++ b/mobile/src/features/Analytics/context/AnalyticsRootProvider.tsx
@@ -7,6 +7,7 @@ type Props = React.PropsWithChildren<{
   platform: 'IOS' | 'Android' | 'Web'
   client: AnalyticsProvider
   metricsEnabledStorage: MetricsEnabledStorage
+  onEnabledChange?: (enabled: boolean) => void
 }>
 
 type AnalyticsContextValue = {
@@ -32,6 +33,7 @@ export function AnalyticsRootProvider({
   platform,
   client: clientProp,
   metricsEnabledStorage,
+  onEnabledChange,
 }: Props) {
   const [enabled, setEnabledState] = React.useState<boolean>(
     Boolean(initialEnabled),
@@ -41,11 +43,10 @@ export function AnalyticsRootProvider({
   const setEnabled = React.useCallback(
     (next: boolean) => {
       setEnabledState(next)
-      try {
-        metricsEnabledStorage.save(next)
-      } catch {}
+      metricsEnabledStorage.save(next)
+      onEnabledChange?.(next)
     },
-    [metricsEnabledStorage],
+    [metricsEnabledStorage, onEnabledChange],
   )
 
   const capture = React.useCallback<AnalyticsContextValue['capture']>(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make analytics opt-in toggle take effect immediately by managing state in PlatformShell and propagating changes via a new callback from AnalyticsRootProvider.
> 
> - **Analytics (Mobile)**
>   - `mobile/PlatformShell.tsx`:
>     - Manage `metricsEnabled` with React state and pass `onEnabledChange` to `AnalyticsRootProvider`.
>     - `usePosthogClient` now reacts to `metricsEnabled` to enable/disable SDK instantly.
>   - `mobile/src/features/Analytics/context/AnalyticsRootProvider.tsx`:
>     - Add optional `onEnabledChange` prop; invoke it from `setEnabled`.
>     - Always persist `enabled` via `metricsEnabledStorage.save` and remove try/catch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28aebebd99d2b08da54dd2f512df0cfe7d0b7a82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->