### PR TITLE
fix: hide navtab in dappView

### DIFF
--- a/mobile/src/features/Discover/useCases/BrowseDapp/BrowseDappScreen.tsx
+++ b/mobile/src/features/Discover/useCases/BrowseDapp/BrowseDappScreen.tsx
@@ -1,5 +1,6 @@
 import {atoms as a, useTheme} from '@yoroi/theme'
 
+import {useFocusEffect, useNavigation} from '@react-navigation/native'
 import * as React from 'react'
 import {FlatList, View} from 'react-native'
 
@@ -13,6 +14,15 @@ export const BrowseDappScreen = () => {
   const {palette: p} = useTheme()
   const flatListRef = React.useRef<FlatList>(null)
   const {tabs, tabsOpen} = useBrowser()
+  const navigation = useNavigation()
+
+  useFocusEffect(
+    React.useCallback(() => {
+      const tabNav = navigation.getParent()?.getParent()
+      tabNav?.setOptions({tabBarStyle: {display: 'none'}})
+      return () => tabNav?.setOptions({tabBarStyle: undefined})
+    }, [navigation]),
+  )
 
   return (
     <View style={[a.flex_1, {backgroundColor: p.bg_color_max}]}>


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YV-659

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hide the app’s tab bar when `BrowseDappScreen` is focused, restoring it on blur.
> 
> - **Discover**
>   - **`mobile/src/features/Discover/useCases/BrowseDapp/BrowseDappScreen.tsx`**:
>     - Hide parent tab bar on focus using `useFocusEffect`/`useNavigation` (`tabBarStyle: {display: 'none'}`), restoring default on cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df15af008bd1428a44927dcdbc0dcc310f5754b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->