### PR TITLE
fix(mobile): update ThemeProvider to handle OS theme changes in system settings

### DIFF
--- a/mobile/packages/theme/ThemeProvider.test.tsx
+++ b/mobile/packages/theme/ThemeProvider.test.tsx
@@ -169,6 +169,47 @@ describe('ThemeProvider and useTheme Tests', () => {
     expect(screen.getByText('system')).toBeTruthy()
     expect(screen.getByText('default-dark')).toBeTruthy()
   })
+
+  test('ThemeProvider updates palette when OS theme changes in system mode', () => {
+    // Start with light OS theme
+    ;(useColorScheme as jest.Mock).mockReturnValue('light')
+
+    const TestComponent = () => {
+      const theme = useTheme()
+      return (
+        <>
+          <Text testID="config">{theme.config}</Text>
+          <Text testID="palette">{theme.paletteName}</Text>
+          <Text testID="base">{theme.basePalette}</Text>
+        </>
+      )
+    }
+
+    const {rerender} = render(
+      <ThemeProvider storage={mockStorage}>
+        <TestComponent />
+      </ThemeProvider>,
+    )
+
+    // Should start with light theme (system mode with light OS theme)
+    expect(screen.getByTestId('config')).toHaveTextContent('system')
+    expect(screen.getByTestId('palette')).toHaveTextContent('default-light')
+    expect(screen.getByTestId('base')).toHaveTextContent('light')
+
+    // Simulate OS theme change to dark
+    ;(useColorScheme as jest.Mock).mockReturnValue('dark')
+
+    rerender(
+      <ThemeProvider storage={mockStorage}>
+        <TestComponent />
+      </ThemeProvider>,
+    )
+
+    // Should update to dark theme (system mode with dark OS theme)
+    expect(screen.getByTestId('config')).toHaveTextContent('system')
+    expect(screen.getByTestId('palette')).toHaveTextContent('default-dark')
+    expect(screen.getByTestId('base')).toHaveTextContent('dark')
+  })
 })
 
 describe('useThemedAtoms and useBasePalette Tests', () => {

--- a/mobile/packages/theme/ThemeProvider.tsx
+++ b/mobile/packages/theme/ThemeProvider.tsx
@@ -77,6 +77,12 @@ export const ThemeProvider = ({
     detectTheme(hostTheme, selectedThemeConfig),
   )
 
+  React.useEffect(() => {
+    if (selectedThemeConfig === 'system') {
+      setPaletteName(detectTheme(hostTheme, selectedThemeConfig))
+    }
+  }, [hostTheme, selectedThemeConfig])
+
   const value = React.useMemo<ThemeContext>(
     () => ({
       config: selectedThemeConfig,

--- a/mobile/packages/theme/ThemeProvider.tsx
+++ b/mobile/packages/theme/ThemeProvider.tsx
@@ -73,15 +73,10 @@ export const ThemeProvider = ({
   const hostTheme = useColorScheme() ?? 'dark'
   const [selectedThemeConfig, setSelectedThemeConfig] =
     React.useState<ThemeConfig>(() => storage.read())
-  const [paletteName, setPaletteName] = React.useState<ThemeName>(
-    detectTheme(hostTheme, selectedThemeConfig),
+  const paletteName = React.useMemo<ThemeName>(
+    () => detectTheme(hostTheme, selectedThemeConfig),
+    [hostTheme, selectedThemeConfig],
   )
-
-  React.useEffect(() => {
-    if (selectedThemeConfig === 'system') {
-      setPaletteName(detectTheme(hostTheme, selectedThemeConfig))
-    }
-  }, [hostTheme, selectedThemeConfig])
 
   const value = React.useMemo<ThemeContext>(
     () => ({
@@ -126,7 +121,6 @@ export const ThemeProvider = ({
 
       selectTheme: (newThemeName: ThemeConfig) => {
         setSelectedThemeConfig(newThemeName)
-        setPaletteName(detectTheme(hostTheme, newThemeName))
         storage.save(newThemeName)
       },
       isLight: themes[paletteName].base === 'light',
@@ -134,7 +128,7 @@ export const ThemeProvider = ({
       basePaletteInverted:
         themes[paletteName].base === 'dark' ? 'light' : 'dark',
     }),
-    [hostTheme, storage, paletteName, selectedThemeConfig],
+    [storage, paletteName, selectedThemeConfig],
   )
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>


### PR DESCRIPTION
[Ticket](https://emurgo.atlassian.net/browse/YV-84?atlOrigin=eyJpIjoiYWZjZjg1MWI5NDQ4NDlmYjk1ZGQ4MGI1ZDJlOTUyOTEiLCJwIjoiaiJ9)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> ThemeProvider now derives `paletteName` from OS theme via memoization (no local state), updates on system changes, exports `useBasePalette`, and adds tests for OS-driven palette updates.
> 
> - **ThemeProvider**:
>   - Replace `useState`-managed `paletteName` with memoized `detectTheme(hostTheme, selectedThemeConfig)` so palette reacts to OS theme changes.
>   - Remove `setPaletteName` from `selectTheme` and adjust memo deps accordingly.
>   - Export `useBasePalette`.
> - **Tests**:
>   - Add test ensuring palette updates when OS theme toggles in system mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8afd5d282bf1f98b6919702b0de5fe01c433874e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->