### PR TITLE
fix(wallet): useGetInputs edge case

### DIFF
--- a/mobile/src/features/Swap/common/useGetInputs.ts
+++ b/mobile/src/features/Swap/common/useGetInputs.ts
@@ -4,6 +4,7 @@ import {useSelectedWallet} from '~/features/WalletManager/hooks/useSelectedWalle
 import {_getRequiredUtxos} from '~/wallets/cardano/cip30/cip30'
 import {CardanoMobileWrapped} from '~/wallets/cardano/wrappedCsl'
 
+// Returns empty array if not enough UTXOs are found
 export const useGetInputs = () => {
   const {wallet, meta} = useSelectedWallet()
 
@@ -57,18 +58,20 @@ export const useGetInputs = () => {
           csl,
         )
 
+        // If we can't get UTXOs for the original amounts, we can't proceed
+        if (!originalUtxos || originalUtxos.length === 0) {
+          return []
+        }
+
         // Extract selected UTXO identifiers to exclude them from the second call
+        // Match by both txHash and txIndex since utxo_id format may vary
         const selectedUtxoKeys = new Set<string>()
-        if (originalUtxos && originalUtxos.length > 0) {
-          // Extract txHash and txIndex from CSL UTXOs to match with RawUtxos
-          // Match by both txHash and txIndex since utxo_id format may vary
-          for (const utxo of originalUtxos) {
-            const input = utxo.input()
-            const txHash = input.transactionId().toHex()
-            const txIndex = input.index()
-            const key = `${txHash}:${txIndex}`
-            selectedUtxoKeys.add(key)
-          }
+        for (const utxo of originalUtxos) {
+          const input = utxo.input()
+          const txHash = input.transactionId().toHex()
+          const txIndex = input.index()
+          const key = `${txHash}:${txIndex}`
+          selectedUtxoKeys.add(key)
         }
 
         // Filter out already selected UTXOs from the pool

--- a/mobile/src/features/Swap/common/useGetInputs.ts
+++ b/mobile/src/features/Swap/common/useGetInputs.ts
@@ -18,6 +18,37 @@ export const useGetInputs = () => {
           [adaAmount.tokenId]: adaAmount.quantity,
         }
 
+        // First, try to get UTXOs for the combined amount (requested + 5 ADA fee)
+        // If a single UTXO can cover both, we'll use just that one
+        const primaryTokenId = wallet.portfolioPrimaryTokenInfo.id
+        const requestedAmount = amounts[primaryTokenId] || '0'
+        const combinedAmount = (
+          BigInt(requestedAmount) + BigInt(adaAmount.quantity)
+        ).toString() as Balance.Quantity
+        const combinedAmounts: Balance.Amounts = {
+          ...amounts,
+          [primaryTokenId]: combinedAmount,
+        } as Balance.Amounts
+
+        const combinedUtxos = await _getRequiredUtxos(
+          wallet,
+          combinedAmounts,
+          wallet.utxos,
+          meta,
+          csl,
+        )
+
+        if (combinedUtxos && combinedUtxos.length > 0) {
+          const combinedUtxoStrings = await Promise.all(
+            combinedUtxos.map(async (u) => {
+              return Buffer.from(await u.toBytes()).toString('hex')
+            }),
+          )
+
+          return combinedUtxoStrings
+        }
+
+        // If combined approach didn't work, fall back to two-step approach
         const originalUtxos = await _getRequiredUtxos(
           wallet,
           amounts,
@@ -26,10 +57,31 @@ export const useGetInputs = () => {
           csl,
         )
 
+        // Extract selected UTXO identifiers to exclude them from the second call
+        const selectedUtxoKeys = new Set<string>()
+        if (originalUtxos && originalUtxos.length > 0) {
+          // Extract txHash and txIndex from CSL UTXOs to match with RawUtxos
+          // Match by both txHash and txIndex since utxo_id format may vary
+          for (const utxo of originalUtxos) {
+            const input = utxo.input()
+            const txHash = input.transactionId().toHex()
+            const txIndex = input.index()
+            const key = `${txHash}:${txIndex}`
+            selectedUtxoKeys.add(key)
+          }
+        }
+
+        // Filter out already selected UTXOs from the pool
+        // Match by txHash and txIndex to handle different utxo_id formats
+        const remainingUtxos = wallet.utxos.filter((utxo) => {
+          const key = `${utxo.tx_hash}:${utxo.tx_index}`
+          return !selectedUtxoKeys.has(key)
+        })
+
         const adaUtxos = await _getRequiredUtxos(
           wallet,
           adaAmounts,
-          wallet.utxos,
+          remainingUtxos,
           meta,
           csl,
         )


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YV-734?focusedCommentId=44448

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors swap input selection to first try a single UTXO covering request + 5 ADA, otherwise select in two steps while excluding overlaps and deduplicating results, returning [] when insufficient.
> 
> - **Swap**:
>   - **`useGetInputs`**:
>     - Try combined selection for requested amount + 5 ADA; return early if successful.
>     - Fallback: select for requested amounts; return empty array if none found.
>     - Exclude already-chosen UTXOs (match by `txHash:txIndex`) when selecting ADA; use `remainingUtxos`.
>     - Return hex-encoded UTXOs with deduplication.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2791e5f697ddf9245d4a693dc46ba102d10bad6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->