### PR TITLE
feature(mobile): setup firebase topic

### DIFF
--- a/mobile/src/features/Notifications/common/hooks.ts
+++ b/mobile/src/features/Notifications/common/hooks.ts
@@ -15,7 +15,7 @@ import {logger} from '~/kernel/logger/logger'
 import {useWalletNavigation} from '~/kernel/navigation/hooks/useWalletNavigation'
 
 import {pushNotificationsManager} from './notification-manager'
-import {parseNotificationId} from './notifications'
+import {generateNotificationId, parseNotificationId} from './notifications'
 import {usePrimaryTokenPriceChangedNotification} from './primary-token-price-changed-notification'
 import {useRewardsUpdatedNotifications} from './rewards-updated-notification'
 import {triggerNotificationAction} from './tools'
@@ -44,21 +44,28 @@ const createPushNotification = (options: {
 const initPushNotifications = (
   walletNavigation: ReturnType<typeof useWalletNavigation>,
 ) => {
+  let firebaseForegroundUnsubscribe: (() => void) | undefined
+  let responseListener: Notifications.Subscription | undefined
+  let isSubscribedToTopic = false
+  let isUnmounted = false
+
   const registerFirebaseIfPermissionsGranted = async () => {
     try {
+      if (isUnmounted) return
+
       const {status} = await Notifications.getPermissionsAsync()
       if (status === 'granted') {
+        if (isUnmounted) return
+
         await messaging().registerDeviceForRemoteMessages()
         await messaging().requestPermission()
         await messaging().subscribeToTopic('yoroi_campaigns')
+        isSubscribedToTopic = true
       }
     } catch (error) {
       logger.error('Push registration failed', {error})
     }
   }
-
-  let firebaseForegroundUnsubscribe: (() => void) | undefined
-  let responseListener: Notifications.Subscription | undefined
 
   const createDefaultChannel = () =>
     Notifications.setNotificationChannelAsync('default', {
@@ -90,9 +97,10 @@ const initPushNotifications = (
     const title = remoteMessage.notification?.title
     const body = remoteMessage.notification?.body
     const data = remoteMessage.data
+
     if (isString(title) && isString(body)) {
       const pushNotification = createPushNotification({
-        id: Date.now(),
+        id: generateNotificationId(),
         title,
         description: body,
         data: data as Record<string, unknown>,
@@ -121,7 +129,9 @@ const initPushNotifications = (
         string,
         unknown
       >
-      const id = parseNotificationId(String(data?.id ?? ''))
+      const maybeId = parseNotificationId(String(data?.id ?? ''))
+      const id = Number.isNaN(maybeId) ? Date.now() : maybeId
+
       triggerNotificationAction({
         manager: pushNotificationsManager,
         id,
@@ -130,23 +140,30 @@ const initPushNotifications = (
       })
     })
 
-  const configureAfterChannel = async () => {
-    setupNotificationHandler()
-    await registerFirebaseIfPermissionsGranted()
-    firebaseForegroundUnsubscribe = attachForegroundListener()
-    responseListener = attachResponseListener()
+  const init = async () => {
+    try {
+      await createDefaultChannel()
+      await registerFirebaseIfPermissionsGranted()
+      setupNotificationHandler()
+
+      if (isUnmounted) return
+
+      firebaseForegroundUnsubscribe = attachForegroundListener()
+      responseListener = attachResponseListener()
+    } catch (error) {
+      logger.error('Push notifications init failed', {error})
+    }
   }
 
-  createDefaultChannel()
-    .then(configureAfterChannel)
-    .catch((error) => {
-      logger.error('Push notifications init failed', {error})
-    })
+  init()
 
   return () => {
+    isUnmounted = true
     firebaseForegroundUnsubscribe?.()
     responseListener?.remove()
-    messaging().unsubscribeFromTopic('yoroi_campaigns')
+    if (isSubscribedToTopic) {
+      messaging().unsubscribeFromTopic('yoroi_campaigns')
+    }
   }
 }
 
@@ -174,7 +191,7 @@ export const useInitNotifications = ({
   )
   React.useEffect(
     () => (pushEnabled ? initPushNotifications(walletNavigation) : undefined),
-    [walletNavigation, pushEnabled, manager],
+    [walletNavigation, pushEnabled],
   )
   useTransactionReceivedNotifications({enabled: localEnabled})
   usePrimaryTokenPriceChangedNotification({enabled: false}) // Temporarily disabled until requested by product team

--- a/mobile/src/features/Notifications/common/hooks.ts
+++ b/mobile/src/features/Notifications/common/hooks.ts
@@ -117,7 +117,11 @@ const initPushNotifications = (
 
   const attachResponseListener = () =>
     Notifications.addNotificationResponseReceivedListener((_response) => {
-      const id = parseNotificationId(Date.now().toString())
+      const data = _response.notification.request.content.data as Record<
+        string,
+        unknown
+      >
+      const id = parseNotificationId(String(data?.id ?? ''))
       triggerNotificationAction({
         manager: pushNotificationsManager,
         id,

--- a/mobile/src/features/Notifications/common/hooks.ts
+++ b/mobile/src/features/Notifications/common/hooks.ts
@@ -5,7 +5,9 @@ import {
   Notifications as YoroiNotifications,
 } from '@yoroi/types'
 
-import messaging from '@react-native-firebase/messaging'
+import messaging, {
+  FirebaseMessagingTypes,
+} from '@react-native-firebase/messaging'
 import * as Notifications from 'expo-notifications'
 import * as React from 'react'
 
@@ -42,20 +44,6 @@ const createPushNotification = (options: {
 const initPushNotifications = (
   walletNavigation: ReturnType<typeof useWalletNavigation>,
 ) => {
-  Notifications.setNotificationChannelAsync('default', {
-    name: 'Default',
-    importance: Notifications.AndroidImportance.HIGH,
-  })
-  Notifications.setNotificationHandler({
-    handleNotification: async () => ({
-      shouldShowAlert: true,
-      shouldPlaySound: true,
-      shouldSetBadge: false,
-      shouldShowBanner: true,
-      shouldShowList: true,
-    }),
-  })
-
   const registerFirebaseIfPermissionsGranted = async () => {
     try {
       const {status} = await Notifications.getPermissionsAsync()
@@ -69,48 +57,65 @@ const initPushNotifications = (
     }
   }
 
-  registerFirebaseIfPermissionsGranted()
+  let firebaseForegroundUnsubscribe: (() => void) | undefined
+  let responseListener: Notifications.Subscription | undefined
 
-  const firebaseForegroundUnsubscribe = messaging().onMessage(
-    async (remoteMessage) => {
-      const {status} = await Notifications.getPermissionsAsync()
+  const createDefaultChannel = () =>
+    Notifications.setNotificationChannelAsync('default', {
+      name: 'Default',
+      importance: Notifications.AndroidImportance.HIGH,
+    })
 
-      if (status !== 'granted') {
-        logger.info('Message received but notifications are disabled')
-        return
-      }
+  const setupNotificationHandler = () => {
+    Notifications.setNotificationHandler({
+      handleNotification: async () => ({
+        shouldShowAlert: true,
+        shouldPlaySound: true,
+        shouldSetBadge: false,
+        shouldShowBanner: true,
+        shouldShowList: true,
+      }),
+    })
+  }
 
-      logger.info('Message received in foreground', {remoteMessage})
+  const handleForegroundMessage = async (
+    remoteMessage: FirebaseMessagingTypes.RemoteMessage,
+  ) => {
+    const {status} = await Notifications.getPermissionsAsync()
+    if (status !== 'granted') {
+      logger.info('Message received but notifications are disabled')
+      return
+    }
+    logger.info('Message received in foreground', {remoteMessage})
+    const title = remoteMessage.notification?.title
+    const body = remoteMessage.notification?.body
+    const data = remoteMessage.data
+    if (isString(title) && isString(body)) {
+      const pushNotification = createPushNotification({
+        id: Date.now(),
+        title,
+        description: body,
+        data: data as Record<string, unknown>,
+      })
+      await pushNotificationsManager.events.push(pushNotification)
+      logger.info('Campaign notification added to app notifications', {
+        title,
+        body,
+        data,
+        messageId: remoteMessage.messageId,
+      })
+    } else if (data) {
+      logger.info('Data-only message received', {
+        data,
+        messageId: remoteMessage.messageId,
+      })
+    }
+  }
 
-      const title = remoteMessage.notification?.title
-      const body = remoteMessage.notification?.body
-      const data = remoteMessage.data
+  const attachForegroundListener = () =>
+    messaging().onMessage(handleForegroundMessage)
 
-      if (isString(title) && isString(body)) {
-        const pushNotification = createPushNotification({
-          id: Date.now(),
-          title,
-          description: body,
-          data: data as Record<string, unknown>,
-        })
-        await pushNotificationsManager.events.push(pushNotification)
-
-        logger.info('Campaign notification added to app notifications', {
-          title,
-          body,
-          data,
-          messageId: remoteMessage.messageId,
-        })
-      } else if (data) {
-        logger.info('Data-only message received', {
-          data,
-          messageId: remoteMessage.messageId,
-        })
-      }
-    },
-  )
-
-  const responseListener =
+  const attachResponseListener = () =>
     Notifications.addNotificationResponseReceivedListener((_response) => {
       const id = parseNotificationId(Date.now().toString())
       triggerNotificationAction({
@@ -121,9 +126,23 @@ const initPushNotifications = (
       })
     })
 
+  const configureAfterChannel = async () => {
+    setupNotificationHandler()
+    await registerFirebaseIfPermissionsGranted()
+    firebaseForegroundUnsubscribe = attachForegroundListener()
+    responseListener = attachResponseListener()
+  }
+
+  createDefaultChannel()
+    .then(configureAfterChannel)
+    .catch((error) => {
+      logger.error('Push notifications init failed', {error})
+    })
+
   return () => {
-    firebaseForegroundUnsubscribe()
+    firebaseForegroundUnsubscribe?.()
     responseListener?.remove()
+    messaging().unsubscribeFromTopic('yoroi_campaigns')
   }
 }
 

--- a/mobile/src/features/Notifications/common/hooks.ts
+++ b/mobile/src/features/Notifications/common/hooks.ts
@@ -42,6 +42,10 @@ const createPushNotification = (options: {
 const initPushNotifications = (
   walletNavigation: ReturnType<typeof useWalletNavigation>,
 ) => {
+  Notifications.setNotificationChannelAsync('default', {
+    name: 'Default',
+    importance: Notifications.AndroidImportance.HIGH,
+  })
   Notifications.setNotificationHandler({
     handleNotification: async () => ({
       shouldShowAlert: true,
@@ -58,9 +62,10 @@ const initPushNotifications = (
       if (status === 'granted') {
         await messaging().registerDeviceForRemoteMessages()
         await messaging().requestPermission()
+        await messaging().subscribeToTopic('yoroi_campaigns')
       }
     } catch (error) {
-      logger.error('Firebase registration failed', {error})
+      logger.error('Push registration failed', {error})
     }
   }
 
@@ -71,11 +76,11 @@ const initPushNotifications = (
       const {status} = await Notifications.getPermissionsAsync()
 
       if (status !== 'granted') {
-        logger.info('Firebase message received but notifications are disabled')
+        logger.info('Message received but notifications are disabled')
         return
       }
 
-      logger.info('Firebase message received in foreground: ', {remoteMessage})
+      logger.info('Message received in foreground', {remoteMessage})
 
       const title = remoteMessage.notification?.title
       const body = remoteMessage.notification?.body
@@ -90,17 +95,14 @@ const initPushNotifications = (
         })
         await pushNotificationsManager.events.push(pushNotification)
 
-        logger.info(
-          'Firebase campaign notification added to Yoroi notifications: ',
-          {
-            title,
-            body,
-            data,
-            messageId: remoteMessage.messageId,
-          },
-        )
+        logger.info('Campaign notification added to app notifications', {
+          title,
+          body,
+          data,
+          messageId: remoteMessage.messageId,
+        })
       } else if (data) {
-        logger.info('Firebase data-only message received: ', {
+        logger.info('Data-only message received', {
           data,
           messageId: remoteMessage.messageId,
         })

--- a/mobile/src/features/Notifications/common/tools.ts
+++ b/mobile/src/features/Notifications/common/tools.ts
@@ -38,8 +38,9 @@ export const triggerNotificationsPermissionModal = async () => {
     try {
       await messaging().registerDeviceForRemoteMessages()
       await messaging().requestPermission()
+      await messaging().subscribeToTopic('yoroi_campaigns')
     } catch (error) {
-      logger.error('Firebase registration failed', {error})
+      logger.error('Push registration failed', {error})
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Subscribes devices to the `yoroi_campaigns` Firebase topic and refactors push notification initialization, foreground handling, and cleanup.
> 
> - **Notifications (mobile)**:
>   - **Firebase/topic**:
>     - Subscribe to `yoroi_campaigns` on registration/permission grant; unsubscribe on teardown.
>   - **Foreground handling**:
>     - Add handler for FCM messages to create in-app notifications using `generateNotificationId`; improved data-only logging.
>   - **Initialization**:
>     - Create default Android channel; set unified `Notifications.setNotificationHandler`.
>   - **Response handling**:
>     - Parse notification `id` from payload via `parseNotificationId` with fallback.
>   - **Lifecycle/Cleanup**:
>     - Track unmount state; attach/detach listeners safely; improve error logs.
>   - **Misc**:
>     - Simplify effect deps in `useInitNotifications` (remove unused `manager`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81824e8e8722aaaad37cc15876c96559b9e27b81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->