### PR TITLE
chore: bump app version in preview to 6.1.2

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Yoroi",
     "slug": "yoroi",
     "owner": "emurgo",
-    "version": "6.1.1",
+    "version": "6.1.2",
     "orientation": "portrait",
     "icon": "./assets/yoroi/icon.png",
     "userInterfaceStyle": "automatic",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yoroi-v2",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yoroi-v2",
-      "version": "6.1.1",
+      "version": "6.1.2",
       "hasInstallScript": true,
       "dependencies": {
         "@cardano-foundation/ledgerjs-hw-app-cardano": "7.1.4",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi-v2",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "main": "index.ts",
   "scripts": {
     "postinstall": "patch-package",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps mobile app version from 6.1.1 to 6.1.2 in `mobile/app.json`, `mobile/package.json`, and `mobile/package-lock.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69b0862d45e53a618b93c51d58123781e5cb1e24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->