### PR TITLE
fix(wallet): Refix navigation after dapp

### DIFF
--- a/mobile/src/features/Discover/useDappConnectorManager.tsx
+++ b/mobile/src/features/Discover/useDappConnectorManager.tsx
@@ -2,11 +2,13 @@ import {useAsyncStorage} from '@yoroi/common'
 import {DappConnection, DappConnector} from '@yoroi/dapp-connector'
 
 import {Transaction} from '@emurgo/cross-csl-core'
+import {useNavigation} from '@react-navigation/native'
 import * as React from 'react'
 
 import {useSelectedWallet} from '~/features/WalletManager/hooks/useSelectedWallet'
 import {useStrings} from '~/kernel/i18n/useStrings'
 import {logger} from '~/kernel/logger/logger'
+import {removeRouteFromNavigationState} from '~/kernel/navigation/common/helpers'
 import {useWalletNavigation} from '~/kernel/navigation/hooks/useWalletNavigation'
 import {cip30LedgerExtensionMaker} from '~/wallets/cardano/cip30/cip30-ledger'
 import {YoroiWallet} from '~/wallets/cardano/types'
@@ -26,6 +28,7 @@ import {useShowCollateralNotFoundAlert} from './common/useShowCollateralNotFound
 
 export const useDappConnectorManager = () => {
   const appStorage = useAsyncStorage()
+  const navigation = useNavigation()
   const {navigateToDiscoverBrowserDapp, navigateToTxReview} =
     useWalletNavigation()
   const {wallet, meta} = useSelectedWallet()
@@ -103,9 +106,16 @@ export const useDappConnectorManager = () => {
               return
             }
 
-            // Silenced debug logs - too spammy
             resolve(args?.rootKey)
             navigateToDiscoverBrowserDapp()
+            // Remove review-tx-routes from navigation stack after navigating back to browser
+            // Use setTimeout to ensure navigation completes before removing the route
+            // Increase maxDepth to ensure we traverse up to WalletNavigator where review-tx-routes is located
+            setTimeout(() => {
+              removeRouteFromNavigationState(navigation, 'review-tx-routes', {
+                maxDepth: 5,
+              })
+            }, 100)
           },
           onCancel: () => {
             if (!shouldResolve) return
@@ -132,6 +142,7 @@ export const useDappConnectorManager = () => {
       dappCollateralRequestUtils,
       navigateToDiscoverBrowserDapp,
       dappList?.dapps,
+      navigation,
     ],
   )
 
@@ -168,6 +179,14 @@ export const useDappConnectorManager = () => {
             }
             resolve(args?.tx)
             navigateToDiscoverBrowserDapp()
+            // Remove review-tx-routes from navigation stack after navigating back to browser
+            // Use setTimeout to ensure navigation completes before removing the route
+            // Increase maxDepth to ensure we traverse up to WalletNavigator where review-tx-routes is located
+            setTimeout(() => {
+              removeRouteFromNavigationState(navigation, 'review-tx-routes', {
+                maxDepth: 5,
+              })
+            }, 100)
           },
           onErrorWithoutFeedback: (error) => {
             shouldResolve = false
@@ -194,6 +213,7 @@ export const useDappConnectorManager = () => {
       navigateToTxReview,
       navigateToDiscoverBrowserDapp,
       dappList?.dapps,
+      navigation,
     ],
   )
 

--- a/mobile/src/features/Discover/useDappConnectorManager.tsx
+++ b/mobile/src/features/Discover/useDappConnectorManager.tsx
@@ -26,9 +26,9 @@ import {useShowCollateralNotFoundAlert} from './common/useShowCollateralNotFound
 
 export const useDappConnectorManager = () => {
   const appStorage = useAsyncStorage()
-  const {navigateToDiscoverBrowserDapp} = useWalletNavigation()
+  const {navigateToDiscoverBrowserDapp, navigateToTxReview} =
+    useWalletNavigation()
   const {wallet, meta} = useSelectedWallet()
-  const {navigateToTxReview} = useWalletNavigation()
   const {tabs, tabActiveIndex} = useBrowser()
   const dappCollateralRequestUtils = useDappCollateralRequestUtils(wallet)
 
@@ -103,6 +103,7 @@ export const useDappConnectorManager = () => {
               return
             }
 
+            // Silenced debug logs - too spammy
             resolve(args?.rootKey)
             navigateToDiscoverBrowserDapp()
           },

--- a/mobile/src/features/Portfolio/context/PortfolioTokenActivityProvider.tsx
+++ b/mobile/src/features/Portfolio/context/PortfolioTokenActivityProvider.tsx
@@ -32,7 +32,7 @@ export const PortfolioTokenActivityProvider = ({
 }: React.PropsWithChildren) => {
   const {walletManager} = useWalletManager()
   const {
-    networkManager: {tokenManager},
+    networkManager: {tokenManager, network},
   } = useSelectedNetwork()
   const queryClient = useQueryClient()
   const [state, dispatch] = React.useReducer(
@@ -106,11 +106,11 @@ export const PortfolioTokenActivityProvider = ({
         ) as Portfolio.Token.Id[],
       )
 
-      queryClient.invalidateQueries({queryKey})
+      queryClient.invalidateQueries({queryKey: [...queryKey, network]})
     })
 
     return () => subscription.unsubscribe()
-  }, [actions, queryClient, walletManager])
+  }, [actions, queryClient, walletManager, network])
 
   const query = useQuery({
     enabled: state.secondaryTokenIds.length > 0,
@@ -118,7 +118,12 @@ export const PortfolioTokenActivityProvider = ({
     gcTime: time.fiveMinutes,
     retryDelay: time.oneSecond,
     refetchInterval: time.oneMinute,
-    queryKey: [...queryKey, state.activityWindow, state.secondaryTokenIds],
+    queryKey: [
+      ...queryKey,
+      network,
+      state.activityWindow,
+      state.secondaryTokenIds,
+    ],
     queryFn: async () => {
       if (
         state.secondaryTokenIds == null ||

--- a/mobile/src/kernel/navigation/common/helpers.tsx
+++ b/mobile/src/kernel/navigation/common/helpers.tsx
@@ -280,50 +280,112 @@ type Color = `#${string}` | `rgba(${number},${number},${number},${number})`
 
 /**
  * Removes a specific route from the navigation state without animation
- * @param navigation - The navigation object (must have getState and reset methods)
+ * Supports traversing parent navigators to find the route at the correct level
+ * @param navigation - The navigation object (must have getState, reset, and getParent methods)
  * @param routeName - The name of the route to remove
+ * @param options - Optional configuration
  */
 export const removeRouteFromNavigationState = (
   navigation: {
     getState: () => NavigationState | undefined
     reset: (state: NavigationState | any) => void
+    getParent?: () => any
+    dispatch?: (action: any) => void
   },
   routeName: string,
+  options?: {
+    /**
+     * Maximum depth to traverse up the navigator hierarchy (default: 3)
+     */
+    maxDepth?: number
+    /**
+     * Whether to traverse parent navigators to find the route (default: true)
+     */
+    traverseParents?: boolean
+  },
 ): void => {
-  const state = navigation.getState()
-  if (!state) return
+  const maxDepth = options?.maxDepth ?? 3
+  const traverseParents = options?.traverseParents ?? true
 
-  // Filter out the route with the specified name
+  // Try to find the route in the current navigator or parent navigators
+  let targetNavigation = navigation
+  let currentDepth = 0
+  let foundRoute = false
+
+  while (currentDepth < maxDepth && traverseParents) {
+    const state = targetNavigation.getState()
+    if (!state) {
+      break
+    }
+
+    const hasRoute = state.routes.some((route) => route.name === routeName)
+    if (hasRoute) {
+      foundRoute = true
+      break
+    }
+
+    // Try parent navigator
+    if (targetNavigation.getParent) {
+      const parent = targetNavigation.getParent()
+      if (parent) {
+        targetNavigation = parent
+        currentDepth++
+      } else {
+        break
+      }
+    } else {
+      break
+    }
+  }
+
+  if (!foundRoute && traverseParents) {
+    return
+  }
+
+  const state = targetNavigation.getState()
+  if (!state) {
+    return
+  }
+
+  // Filter out ALL routes with the specified name (handles duplicates)
   const filteredRoutes = state.routes.filter(
     (route) => route.name !== routeName,
   )
 
+  // Bug fix 1: Handle empty routes case
+  if (filteredRoutes.length === 0) {
+    // Don't allow removing all routes - this would break navigation state
+    return
+  }
+
   // Only reset if we actually removed a route
   if (filteredRoutes.length < state.routes.length) {
-    // Find the index of the route to remove in the original routes array
-    const removedRouteIndex = state.routes.findIndex(
-      (route) => route.name === routeName,
-    )
-
-    // Calculate the new index based on where the route was removed
+    // Bug fix 3: Count ALL removed routes before current index (handles duplicates)
     const currentIndex = state.index ?? 0
-    let newIndex: number
+    let removedCountBeforeCurrent = 0
 
-    if (removedRouteIndex === -1) {
-      // Route not found (shouldn't happen, but handle gracefully)
-      newIndex = currentIndex
-    } else if (removedRouteIndex <= currentIndex) {
-      // Route was removed at or before current index, adjust index
-      newIndex = Math.max(0, currentIndex - 1)
+    for (let i = 0; i < currentIndex; i++) {
+      if (state.routes[i]?.name === routeName) {
+        removedCountBeforeCurrent++
+      }
+    }
+
+    // Calculate the new index based on how many routes were removed before current
+    let newIndex: number
+    if (removedCountBeforeCurrent > 0) {
+      // Routes were removed before current index, adjust index
+      newIndex = Math.max(0, currentIndex - removedCountBeforeCurrent)
     } else {
-      // Route was removed after current index, keep index the same
+      // No routes removed before current index, keep index the same
       newIndex = currentIndex
     }
 
     // Ensure the new index is valid for the filtered routes
+    // Bug fix 1: This is now safe because we return early if filteredRoutes.length === 0
     newIndex = Math.min(filteredRoutes.length - 1, Math.max(0, newIndex))
 
-    navigation.reset({
+    // Use reset method to update navigation state
+    targetNavigation.reset({
       ...state,
       index: newIndex,
       routes: filteredRoutes,


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YV-757?focusedCommentId=44715

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances navigation cleanup post-dapp TX using a parent-traversing route-removal helper and scopes portfolio token activity queries/invalidation by network.
> 
> - **Discover / Dapp TX Flow**:
>   - After successful TX/sign (SW + HW), navigate back to browser then remove `review-tx-routes` via `removeRouteFromNavigationState` with `maxDepth: 5` using `setTimeout` to ensure completion.
>   - Inject `useNavigation` and update hook deps accordingly.
> - **Navigation Helpers** (`kernel/navigation/common/helpers.tsx`):
>   - Extend `removeRouteFromNavigationState` to traverse parent navigators (`getParent`) with configurable `maxDepth`/`traverseParents`.
>   - Handle duplicate target routes, prevent empty route stacks, and correctly recalculate `index`; use `targetNavigation.reset`.
>   - Update types/docs accordingly.
> - **Portfolio** (`PortfolioTokenActivityProvider.tsx`):
>   - Include `network` in `queryKey` and invalidation (`invalidateQueries`) for token activity, and add `network` to effect deps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79b5c2ca02cca77d7ff903a11347464f560839cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->