### PR TITLE
fix(swap): conditionally include include_protocols in minswap adapter

### DIFF
--- a/mobile/packages/swap/adapters/api/minswap/transformers.test.ts
+++ b/mobile/packages/swap/adapters/api/minswap/transformers.test.ts
@@ -419,6 +419,36 @@ describe('transformersMaker', () => {
       expect(result.exclude_protocols).toEqual([Dex.MinswapV2])
     })
 
+    it('should not include include_protocols when protocol is undefined', () => {
+      const mockRequest = {
+        amountIn: 10,
+        blockedProtocols: [],
+        slippage: 1,
+        tokenIn: '.' as const,
+        tokenOut: 'test-token.' as const,
+        protocol: undefined,
+      }
+
+      const result = transformers.estimate.request(mockRequest)
+
+      expect(result).not.toHaveProperty('include_protocols')
+    })
+
+    it('should include include_protocols when protocol is defined', () => {
+      const mockRequest = {
+        amountIn: 10,
+        blockedProtocols: [],
+        slippage: 1,
+        tokenIn: '.' as const,
+        tokenOut: 'test-token.' as const,
+        protocol: 'minswap-v2' as any,
+      }
+
+      const result = transformers.estimate.request(mockRequest)
+
+      expect(result.include_protocols).toEqual([Dex.MinswapV2])
+    })
+
     it('should handle unknown Dex protocol in response', () => {
       // Test the default case in mapDexToProtocol by providing an invalid protocol
       const mockResponse = {

--- a/mobile/packages/swap/adapters/api/minswap/transformers.test.ts
+++ b/mobile/packages/swap/adapters/api/minswap/transformers.test.ts
@@ -449,6 +449,37 @@ describe('transformersMaker', () => {
       expect(result.include_protocols).toEqual([Dex.MinswapV2])
     })
 
+    it('should not include include_protocols when protocol maps to Unsupported', () => {
+      const mockRequest = {
+        amountIn: 10,
+        blockedProtocols: [],
+        slippage: 1,
+        tokenIn: '.' as const,
+        tokenOut: 'test-token.' as const,
+        protocol: 'unsupported' as any,
+      }
+
+      const result = transformers.estimate.request(mockRequest)
+
+      expect(result).not.toHaveProperty('include_protocols')
+    })
+
+    it('should not include include_protocols when protocol is not supported by minswap', () => {
+      // Test with protocols that map to Unsupported (e.g., Teddy_v1, Cerra, Genius, etc.)
+      const mockRequest = {
+        amountIn: 10,
+        blockedProtocols: [],
+        slippage: 1,
+        tokenIn: '.' as const,
+        tokenOut: 'test-token.' as const,
+        protocol: 'teddy-v1' as any,
+      }
+
+      const result = transformers.estimate.request(mockRequest)
+
+      expect(result).not.toHaveProperty('include_protocols')
+    })
+
     it('should handle unknown Dex protocol in response', () => {
       // Test the default case in mapDexToProtocol by providing an invalid protocol
       const mockResponse = {

--- a/mobile/packages/swap/adapters/api/minswap/transformers.ts
+++ b/mobile/packages/swap/adapters/api/minswap/transformers.ts
@@ -230,6 +230,8 @@ export const transformersMaker = (config: MinswapApiConfig) => {
           tokenOut,
           protocol,
         }: Swap.EstimateRequest): EstimateRequest => {
+          const mappedProtocol =
+            protocol !== undefined ? mapProtocolToDex(protocol) : undefined
           const request: EstimateRequest = {
             token_in: toTokenId(tokenIn),
             token_out: toTokenId(tokenOut),
@@ -238,9 +240,10 @@ export const transformersMaker = (config: MinswapApiConfig) => {
             exclude_protocols: blockedProtocols?.map((p) =>
               mapProtocolToDex(p),
             ),
-            ...(protocol !== undefined && {
-              include_protocols: [mapProtocolToDex(protocol)],
-            }),
+            ...(mappedProtocol !== undefined &&
+              mappedProtocol !== Dex.Unsupported && {
+                include_protocols: [mappedProtocol],
+              }),
             amount_in_decimal: true, // Tell API that amounts are in decimal format
             ...(partner !== undefined && {partner}),
           }
@@ -283,6 +286,8 @@ export const transformersMaker = (config: MinswapApiConfig) => {
           protocol,
           inputs,
         }: Swap.CreateRequest): CreateRequest => {
+          const mappedProtocol =
+            protocol !== undefined ? mapProtocolToDex(protocol) : undefined
           const request = {
             sender: address,
             min_amount_out: '0', // Will be calculated by the API
@@ -294,9 +299,10 @@ export const transformersMaker = (config: MinswapApiConfig) => {
               exclude_protocols: blockedProtocols?.map((p) =>
                 mapProtocolToDex(p),
               ),
-              ...(protocol !== undefined && {
-                include_protocols: [mapProtocolToDex(protocol)],
-              }),
+              ...(mappedProtocol !== undefined &&
+                mappedProtocol !== Dex.Unsupported && {
+                  include_protocols: [mappedProtocol],
+                }),
               ...(partner !== undefined && {partner}),
             },
             amount_in_decimal: true, // Also set at the top level for build-tx

--- a/mobile/packages/swap/adapters/api/minswap/transformers.ts
+++ b/mobile/packages/swap/adapters/api/minswap/transformers.ts
@@ -238,8 +238,9 @@ export const transformersMaker = (config: MinswapApiConfig) => {
             exclude_protocols: blockedProtocols?.map((p) =>
               mapProtocolToDex(p),
             ),
-            include_protocols:
-              protocol !== undefined ? [mapProtocolToDex(protocol)] : undefined,
+            ...(protocol !== undefined && {
+              include_protocols: [mapProtocolToDex(protocol)],
+            }),
             amount_in_decimal: true, // Tell API that amounts are in decimal format
             ...(partner !== undefined && {partner}),
           }
@@ -293,10 +294,9 @@ export const transformersMaker = (config: MinswapApiConfig) => {
               exclude_protocols: blockedProtocols?.map((p) =>
                 mapProtocolToDex(p),
               ),
-              include_protocols:
-                protocol !== undefined
-                  ? [mapProtocolToDex(protocol)]
-                  : undefined,
+              ...(protocol !== undefined && {
+                include_protocols: [mapProtocolToDex(protocol)],
+              }),
               ...(partner !== undefined && {partner}),
             },
             amount_in_decimal: true, // Also set at the top level for build-tx

--- a/scripts/packages/swap/package.json
+++ b/scripts/packages/swap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoroi/swap",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "description": "The Swap package of Yoroi SDK",
   "keywords": [
     "yoroi",


### PR DESCRIPTION
- Fix issue where include_protocols was set to undefined when protocol is undefined
- Use conditional spread operator to only include property when protocol is defined
- Apply fix to both estimate and create request transformers
- Add tests to verify behavior when protocol is undefined vs defined
- Bump package version to 7.0.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Conditionally adds `include_protocols` in Minswap estimate/create requests only when protocol maps to a supported Dex; adds tests and bumps package to 7.0.4.
> 
> - **Minswap adapter**:
>   - **Requests**:
>     - Update `estimate.request` and `create.request` in `mobile/packages/swap/adapters/api/minswap/transformers.ts` to include `include_protocols` only when `protocol` maps to a supported `Dex`.
>   - **Tests**:
>     - Add cases ensuring `include_protocols` is omitted when `protocol` is undefined or unsupported, and included when valid (`transformers.test.ts`).
> - **Version**:
>   - Bump `@yoroi/swap` to `7.0.4` (`scripts/packages/swap/package.json`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9253cba845507084e9e5f7742f3a30292e798b76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->