### PR TITLE
feat(wallet): Show fcm in production devmode

### DIFF
--- a/mobile/src/features/Settings/ui/screens/ChangeApplicationSettingsScreen/AboutScreen/useFCMToken.ts
+++ b/mobile/src/features/Settings/ui/screens/ChangeApplicationSettingsScreen/AboutScreen/useFCMToken.ts
@@ -3,10 +3,12 @@ import {useQuery} from '@tanstack/react-query'
 import * as Notifications from 'expo-notifications'
 import * as React from 'react'
 
-import {isDev, isNightly} from '~/kernel/constants'
+import {useAuth} from '~/features/Auth/context/AuthProvider'
+import {isNightly} from '~/kernel/constants'
 
 export const useFCMToken = () => {
   const [hasPermission, setHasPermission] = React.useState(false)
+  const {isAuthDev} = useAuth()
 
   React.useEffect(() => {
     Notifications.getPermissionsAsync().then(({status}) => {
@@ -17,7 +19,7 @@ export const useFCMToken = () => {
   const {data: FCMToken} = useQuery({
     queryKey: ['fcmToken'],
     queryFn: () => getToken(getMessaging()),
-    enabled: (isNightly || isDev) && hasPermission,
+    enabled: (isNightly || isAuthDev) && hasPermission,
   })
 
   return FCMToken

--- a/mobile/src/features/Settings/ui/screens/ChangeApplicationSettingsScreen/AboutScreen/useFCMToken.ts
+++ b/mobile/src/features/Settings/ui/screens/ChangeApplicationSettingsScreen/AboutScreen/useFCMToken.ts
@@ -17,7 +17,7 @@ export const useFCMToken = () => {
   }, [])
 
   const {data: FCMToken} = useQuery({
-    queryKey: ['fcmToken'],
+    queryKey: ['fcmToken', isAuthDev],
     queryFn: () => getToken(getMessaging()),
     enabled: (isNightly || isAuthDev) && hasPermission,
   })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Gate FCM token fetching by `isNightly` or `isAuthDev`, and include `isAuthDev` in the query key.
> 
> - **Settings > About > `useFCMToken`**:
>   - Use `useAuth()` to read `isAuthDev`.
>   - Update react-query key to `['fcmToken', isAuthDev]`.
>   - Enable token fetching when `(isNightly || isAuthDev) && hasPermission` (removes `isDev` gate).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f01c9c6cc7f844611fae134b4be5b4d7d6dd48a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->