### PR TITLE
feat(mobile): add direct URL navigation option in dapp browser search

### DIFF
--- a/mobile/src/features/Discover/common/helpers.ts
+++ b/mobile/src/features/Discover/common/helpers.ts
@@ -50,6 +50,74 @@ export interface DAppItem {
 }
 
 const googleDappId = 'google_search'
+const directUrlId = 'direct_url'
+
+/**
+ * Checks if a string looks like a URL
+ * Matches patterns like:
+ * - example.com
+ * - www.example.com
+ * - http://example.com
+ * - https://example.com
+ * - example.com/path
+ */
+export const looksLikeUrl = (str: string): boolean => {
+  if (!str || str.trim() === '') return false
+
+  const trimmed = str.trim()
+
+  // Check if it already has a protocol
+  if (hasProtocol(trimmed)) {
+    try {
+      const url = new URL(trimmed)
+      return !!url
+    } catch {
+      return false
+    }
+  }
+
+  // Check for domain-like patterns (contains a dot and looks like a domain)
+  // Matches: example.com, www.example.com, subdomain.example.com
+  // But not: just words, single word, or strings without dots
+  const domainPattern =
+    /^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}(\/.*)?$/
+
+  // Also check for localhost patterns
+  const localhostPattern = /^localhost(:\d+)?(\/.*)?$/i
+
+  return domainPattern.test(trimmed) || localhostPattern.test(trimmed)
+}
+
+export const getDirectUrlItem = (url: string): DAppItem => {
+  const normalizedUrl = urlWithProtocol(url)
+  try {
+    const parsedUrl = new URL(normalizedUrl)
+    const domainName = parsedUrl.hostname.replace(/^www\./, '')
+
+    return {
+      id: directUrlId,
+      name: domainName,
+      description: 'Navigate to URL',
+      category: 'url',
+      logo: '',
+      uri: normalizedUrl,
+      origins: [parsedUrl.origin],
+      isSingleAddress: false,
+    }
+  } catch {
+    // Fallback if URL parsing fails
+    return {
+      id: directUrlId,
+      name: url,
+      description: 'Navigate to URL',
+      category: 'url',
+      logo: '',
+      uri: normalizedUrl,
+      origins: [],
+      isSingleAddress: false,
+    }
+  }
+}
 
 export const getGoogleSearchItem = (searchQuery: string): DAppItem => ({
   id: googleDappId,
@@ -63,6 +131,7 @@ export const getGoogleSearchItem = (searchQuery: string): DAppItem => ({
 })
 
 export const isGoogleSearchItem = (dApp: DAppItem) => dApp.id === googleDappId
+export const isDirectUrlItem = (dApp: DAppItem) => dApp.id === directUrlId
 
 type CreateDappConnectorOptions = {
   appStorage: App.Storage

--- a/mobile/src/features/Discover/useCases/SearchDappInBrowser/SearchDappInBrowserScreen.tsx
+++ b/mobile/src/features/Discover/useCases/SearchDappInBrowser/SearchDappInBrowserScreen.tsx
@@ -7,7 +7,12 @@ import {v4} from 'uuid'
 
 import {useBrowser} from '~/features/Discover/common/BrowserProvider'
 
-import {getGoogleSearchItem, urlWithProtocol} from '../../common/helpers'
+import {
+  getDirectUrlItem,
+  getGoogleSearchItem,
+  looksLikeUrl,
+  urlWithProtocol,
+} from '../../common/helpers'
 import {useNavigateTo} from '../../common/useNavigateTo'
 import {BrowserSearchToolbar} from '../BrowseDapp/BrowserSearchToolbar'
 import {DAppListItem} from '../SelectDappFromList/DAppListItem/DAppListItem'
@@ -27,6 +32,8 @@ export const SearchDappInBrowserScreen = () => {
   const tabActive = tabs[tabActiveIndex]
   const [searchValue, setSearchValue] = React.useState('')
   const isFocused = useIsFocused()
+  const isUrl = looksLikeUrl(searchValue)
+  const directUrlItem = isUrl ? getDirectUrlItem(searchValue) : null
   const googleItem = getGoogleSearchItem(searchValue)
 
   const handleGoBack = () => {
@@ -79,12 +86,22 @@ export const SearchDappInBrowserScreen = () => {
 
       <ScrollView style={[a.p_lg]}>
         {searchValue !== '' && (
-          <DAppListItem
-            key={googleItem.id}
-            dApp={googleItem}
-            connected={false}
-            onPress={() => handleSubmit(true)}
-          />
+          <>
+            {isUrl && directUrlItem && (
+              <DAppListItem
+                key={directUrlItem.id}
+                dApp={directUrlItem}
+                connected={false}
+                onPress={() => handleSubmit(false)}
+              />
+            )}
+            <DAppListItem
+              key={googleItem.id}
+              dApp={googleItem}
+              connected={false}
+              onPress={() => handleSubmit(true)}
+            />
+          </>
         )}
       </ScrollView>
     </View>

--- a/mobile/src/features/Discover/useCases/SelectDappFromList/DAppListItem/DAppListItem.tsx
+++ b/mobile/src/features/Discover/useCases/SelectDappFromList/DAppListItem/DAppListItem.tsx
@@ -30,6 +30,7 @@ import {WarningBanner} from '~/ui/WarningBanner/WarningBanner'
 import {
   type DAppItem,
   getDappFallbackLogo,
+  isDirectUrlItem,
   isGoogleSearchItem,
 } from '../../../common/helpers'
 
@@ -97,7 +98,7 @@ export const DAppListItem = ({dApp, connected, onPress}: Props) => {
   const handlePress = () => {
     if (onPress) return onPress()
 
-    if (!connected || isGoogleSearchItem(dApp)) {
+    if (!connected || isGoogleSearchItem(dApp) || isDirectUrlItem(dApp)) {
       return handleOpenDApp()
     }
 
@@ -167,6 +168,8 @@ export const DAppListItem = ({dApp, connected, onPress}: Props) => {
       <View style={[{flexDirection: 'row', gap: 12}]}>
         {isGoogleSearchItem(dApp) ? (
           <Icon.Google />
+        ) : isDirectUrlItem(dApp) ? (
+          <Icon.Globe />
         ) : (
           <Image
             source={{uri: logo}}
@@ -202,7 +205,7 @@ export const DAppListItem = ({dApp, connected, onPress}: Props) => {
 
             {dApp.isSingleAddress && <LabelSingleAddress />}
 
-            {!isGoogleSearchItem(dApp) && (
+            {!isGoogleSearchItem(dApp) && !isDirectUrlItem(dApp) && (
               <LabelCategoryDApp category={dApp.category} />
             )}
           </View>

--- a/mobile/src/features/Transactions/TxHistoryNavigator.tsx
+++ b/mobile/src/features/Transactions/TxHistoryNavigator.tsx
@@ -27,7 +27,11 @@ import {SwapNavigator} from '~/features/Swap/navigator'
 import {useSelectedWallet} from '~/features/WalletManager/hooks/useSelectedWallet'
 import {WithWalletOpened} from '~/features/WalletManager/ui/shared/WithWalletOpened'
 import {useStrings} from '~/kernel/i18n/useStrings'
-import {defaultStackNavigationOptions} from '~/kernel/navigation/common/helpers'
+import {
+  BackButton,
+  defaultStackNavigationOptions,
+} from '~/kernel/navigation/common/helpers'
+import {useWalletNavigation} from '~/kernel/navigation/hooks/useWalletNavigation'
 import {TxHistoryRoutes} from '~/kernel/navigation/types'
 
 import {UtxoConsolidation} from '../Transactions/useCases/UtxoConsolidation/UtxoConsolidation/UtxoConsolidation'
@@ -42,6 +46,7 @@ export const TxHistoryNavigator = () => {
   const strings = useStrings()
   const {palette: p, atoms: ta} = useTheme()
   const {meta} = useSelectedWallet()
+  const walletNavigation = useWalletNavigation()
 
   const screenOptions: StackNavigationOptions = React.useMemo(
     () => ({
@@ -55,6 +60,12 @@ export const TxHistoryNavigator = () => {
     () => ({
       title: meta.name,
       headerRight: () => <HeaderRightHistory />,
+      headerLeft: () => (
+        <BackButton
+          onPress={() => walletNavigation.resetToWalletSelection()}
+          color={ta.text_gray_max.color}
+        />
+      ),
       headerTransparent: true,
       headerStyle: {
         ...a.bg_transparent,
@@ -66,7 +77,7 @@ export const TxHistoryNavigator = () => {
       },
       headerTintColor: ta.text_gray_max.color,
     }),
-    [meta.name, ta.text_gray_max.color],
+    [meta.name, ta.text_gray_max.color, walletNavigation],
   )
 
   return (

--- a/mobile/src/features/Transactions/useCases/TxHistory/TxHistory.tsx
+++ b/mobile/src/features/Transactions/useCases/TxHistory/TxHistory.tsx
@@ -1,8 +1,9 @@
 import {atoms as a, useTheme} from '@yoroi/theme'
 
+import {useNavigation} from '@react-navigation/native'
 import {LinearGradient} from 'expo-linear-gradient'
 import * as React from 'react'
-import {LayoutAnimation, Text, View} from 'react-native'
+import {BackHandler, LayoutAnimation, Platform, Text, View} from 'react-native'
 
 import infoIcon from '~/assets/img/icon/info-light-green.png'
 import {useBuyCryptoBanner} from '~/features/Exchange/common/useBuyCryptoBanner'
@@ -13,6 +14,7 @@ import {useSelectedWallet} from '~/features/WalletManager/hooks/useSelectedWalle
 import {useSync} from '~/features/WalletManager/hooks/useSync'
 import {features} from '~/kernel/features'
 import {useStrings} from '~/kernel/i18n/useStrings'
+import {useWalletNavigation} from '~/kernel/navigation/hooks/useWalletNavigation'
 import {Space, SpaceHeight} from '~/ui/Space/Space'
 
 import {TxList} from '../TxList/TxList'
@@ -31,6 +33,8 @@ export const TxHistory = () => {
 
   const strings = useStrings()
   const {atoms: ta, palette: p, isDark} = useTheme()
+  const navigation = useNavigation()
+  const walletNavigation = useWalletNavigation()
 
   useGetImportantAlertsModal({enabled: features.pushNotifications})
 
@@ -50,6 +54,43 @@ export const TxHistory = () => {
   })
 
   const handleOnRefresh = () => sync()
+
+  // Handle back navigation - always reset to wallet selection when on history-list
+  React.useEffect(() => {
+    // Handle OS back button (Android) - only when on history-list screen
+    if (Platform.OS === 'android') {
+      const backHandler = BackHandler.addEventListener(
+        'hardwareBackPress',
+        () => {
+          // Check if we can go back in the current stack
+          // If not, we're at the root (history-list) and should reset to wallet selection
+          if (!navigation.canGoBack()) {
+            walletNavigation.resetToWalletSelection()
+            return true // Prevent default back behavior
+          }
+          // Otherwise, let normal navigation handle it (go back to previous screen in stack)
+          return false
+        },
+      )
+
+      return () => backHandler.remove()
+    }
+    return undefined
+  }, [navigation, walletNavigation])
+
+  // Handle navigation back button (header button and gesture)
+  // This only fires when trying to remove history-list from the stack
+  React.useEffect(() => {
+    const unsubscribe = navigation.addListener('beforeRemove', (e) => {
+      // Prevent default behavior
+      e.preventDefault()
+
+      // Reset to wallet selection
+      walletNavigation.resetToWalletSelection()
+    })
+
+    return unsubscribe
+  }, [navigation, walletNavigation])
 
   return (
     <LinearGradient

--- a/mobile/src/features/Transactions/useCases/TxHistory/TxHistory.tsx
+++ b/mobile/src/features/Transactions/useCases/TxHistory/TxHistory.tsx
@@ -80,13 +80,19 @@ export const TxHistory = () => {
 
   // Handle navigation back button (header button and gesture)
   // This only fires when trying to remove history-list from the stack
+  // Only intercept user-initiated back navigation (GO_BACK), not programmatic navigation
   React.useEffect(() => {
     const unsubscribe = navigation.addListener('beforeRemove', (e) => {
-      // Prevent default behavior
-      e.preventDefault()
+      // Only intercept user-initiated back navigation
+      // Allow programmatic navigation (RESET, NAVIGATE, etc.) to proceed normally
+      if (e.data.action.type === 'GO_BACK') {
+        // Prevent default behavior
+        e.preventDefault()
 
-      // Reset to wallet selection
-      walletNavigation.resetToWalletSelection()
+        // Reset to wallet selection
+        walletNavigation.resetToWalletSelection()
+      }
+      // For other action types (RESET, NAVIGATE, etc.), let them proceed normally
     })
 
     return unsubscribe


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds direct URL option to the dapp browser search and makes back navigation from Tx History reset to wallet selection (header, gesture, and Android hardware back).
> 
> - **Discover / DApp Browser**:
>   - Add `looksLikeUrl`, `getDirectUrlItem`, and `isDirectUrlItem` in `common/helpers` for URL detection and item creation.
>   - Update `SearchDappInBrowserScreen` to suggest and open direct URLs alongside Google search.
>   - Update `DAppListItem` to treat `direct_url` like search (opens immediately), show a globe icon, and hide category label for direct URLs.
> - **Transactions / Navigation**:
>   - Add header `BackButton` in `TxHistoryNavigator` that resets to wallet selection.
>   - In `TxHistory`, intercept back actions (Android hardware and navigation `GO_BACK`) to reset to wallet selection when at root.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c07d6e33616f2f0c014422127b5b88532c54520. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->