### PR TITLE
fix(mobile): press twice to select gov option

### DIFF
--- a/mobile/src/features/Staking/Governance/common/useGovernanceVoteFlow.ts
+++ b/mobile/src/features/Staking/Governance/common/useGovernanceVoteFlow.ts
@@ -69,6 +69,7 @@ export const useGovernanceVoteFlow = ({
         governanceActions.handleNoConfidenceAction({
           unsignedTx,
         })
+        return
       }
 
       optionsOnSuccess?.(unsignedTx)

--- a/mobile/src/features/Staking/Governance/common/useGovernanceVoteFlow.ts
+++ b/mobile/src/features/Staking/Governance/common/useGovernanceVoteFlow.ts
@@ -42,7 +42,16 @@ export const useGovernanceVoteFlow = ({
 
   const [pendingVote, setPendingVote] = React.useState<PendingVote>(null)
   const pendingActionRef = React.useRef<PendingAction>(null)
-  const {onSuccess: optionsOnSuccess, ...rest} = options ?? {}
+  const {
+    onSuccess: optionsOnSuccess,
+    onError: optionsOnError,
+    ...rest
+  } = options ?? {}
+
+  const resetPendingState = () => {
+    setPendingVote(null)
+    pendingActionRef.current = null
+  }
 
   const createGovernanceTxMutation = useCreateGovernanceTx(wallet, {
     ...rest,
@@ -55,6 +64,8 @@ export const useGovernanceVoteFlow = ({
           type,
           CIP105,
         })
+        resetPendingState()
+        optionsOnSuccess?.(unsignedTx)
         return
       }
 
@@ -62,6 +73,8 @@ export const useGovernanceVoteFlow = ({
         governanceActions.handleAbstainAction({
           unsignedTx,
         })
+        resetPendingState()
+        optionsOnSuccess?.(unsignedTx)
         return
       }
 
@@ -69,10 +82,17 @@ export const useGovernanceVoteFlow = ({
         governanceActions.handleNoConfidenceAction({
           unsignedTx,
         })
+        resetPendingState()
+        optionsOnSuccess?.(unsignedTx)
         return
       }
 
+      resetPendingState()
       optionsOnSuccess?.(unsignedTx)
+    },
+    onError: (error) => {
+      resetPendingState()
+      optionsOnError?.(error)
     },
   })
 

--- a/mobile/src/features/Staking/Governance/common/useGovernanceVoteFlow.ts
+++ b/mobile/src/features/Staking/Governance/common/useGovernanceVoteFlow.ts
@@ -3,8 +3,8 @@ import {Wallet} from '@yoroi/types'
 import {Certificate} from '@emurgo/cross-csl-core'
 import * as React from 'react'
 
-import {UsePromiseOptionsWithoutPromise} from '~/hooks/usePromise'
 import {useCreateGovernanceTx} from '~/features/Staking/hooks/useCreateGovernanceTx'
+import {UsePromiseOptionsWithoutPromise} from '~/hooks/usePromise'
 import {YoroiWallet} from '~/wallets/cardano/types'
 import {YoroiUnsignedTx} from '~/wallets/types/yoroi'
 
@@ -17,6 +17,12 @@ type DelegateOptions = {
   type: 'key' | 'script'
   CIP105: boolean
 }
+
+type PendingAction =
+  | {type: 'delegate'; options: DelegateOptions}
+  | {type: 'abstain'}
+  | {type: 'no-confidence'}
+  | null
 
 type UseGovernanceVoteFlowOptions = UsePromiseOptionsWithoutPromise<
   YoroiUnsignedTx,
@@ -35,14 +41,14 @@ export const useGovernanceVoteFlow = ({
   const governanceActions = useGovernanceActions()
 
   const [pendingVote, setPendingVote] = React.useState<PendingVote>(null)
-  const pendingVoteRef = React.useRef<PendingVote>(null)
-  const delegateOptionsRef = React.useRef<DelegateOptions | null>(null)
+  const pendingActionRef = React.useRef<PendingAction>(null)
+  const {onSuccess: optionsOnSuccess, ...rest} = options ?? {}
 
   const createGovernanceTxMutation = useCreateGovernanceTx(wallet, {
-    ...options,
+    ...rest,
     onSuccess: (unsignedTx) => {
-      if (pendingVoteRef.current === 'delegate' && delegateOptionsRef.current) {
-        const {hash, type, CIP105} = delegateOptionsRef.current
+      if (pendingActionRef.current?.type === 'delegate') {
+        const {hash, type, CIP105} = pendingActionRef.current.options
         governanceActions.handleDelegateAction({
           unsignedTx,
           hash,
@@ -52,35 +58,36 @@ export const useGovernanceVoteFlow = ({
         return
       }
 
-      if (pendingVoteRef.current === 'abstain') {
+      if (pendingActionRef.current?.type === 'abstain') {
         governanceActions.handleAbstainAction({
           unsignedTx,
         })
         return
       }
 
-      if (pendingVoteRef.current === 'no-confidence') {
+      if (pendingActionRef.current?.type === 'no-confidence') {
         governanceActions.handleNoConfidenceAction({
           unsignedTx,
         })
       }
+
+      optionsOnSuccess?.(unsignedTx)
     },
   })
 
   const setDelegatePending = (options: DelegateOptions) => {
     setPendingVote('delegate')
-    pendingVoteRef.current = 'delegate'
-    delegateOptionsRef.current = options
+    pendingActionRef.current = {type: 'delegate', options}
   }
 
   const setAbstainPending = () => {
     setPendingVote('abstain')
-    pendingVoteRef.current = 'abstain'
+    pendingActionRef.current = {type: 'abstain'}
   }
 
   const setNoConfidencePending = () => {
     setPendingVote('no-confidence')
-    pendingVoteRef.current = 'no-confidence'
+    pendingActionRef.current = {type: 'no-confidence'}
   }
 
   const submit = (certificates: Certificate[]) => {
@@ -99,5 +106,3 @@ export const useGovernanceVoteFlow = ({
     submit,
   } as const
 }
-
-

--- a/mobile/src/features/Staking/Governance/common/useGovernanceVoteFlow.ts
+++ b/mobile/src/features/Staking/Governance/common/useGovernanceVoteFlow.ts
@@ -111,7 +111,27 @@ export const useGovernanceVoteFlow = ({
     pendingActionRef.current = {type: 'no-confidence'}
   }
 
-  const submit = (certificates: Certificate[]) => {
+  const submitDelegate = (
+    certificates: Certificate[],
+    options: DelegateOptions,
+  ) => {
+    setDelegatePending(options)
+    createGovernanceTxMutation.resolve({
+      certificates,
+      addressMode,
+    })
+  }
+
+  const submitAbstain = (certificates: Certificate[]) => {
+    setAbstainPending()
+    createGovernanceTxMutation.resolve({
+      certificates,
+      addressMode,
+    })
+  }
+
+  const submitNoConfidence = (certificates: Certificate[]) => {
+    setNoConfidencePending()
     createGovernanceTxMutation.resolve({
       certificates,
       addressMode,
@@ -121,9 +141,8 @@ export const useGovernanceVoteFlow = ({
   return {
     pendingVote,
     isCreatingTx: createGovernanceTxMutation.isPending,
-    setDelegatePending,
-    setAbstainPending,
-    setNoConfidencePending,
-    submit,
+    submitDelegate,
+    submitAbstain,
+    submitNoConfidence,
   } as const
 }

--- a/mobile/src/features/Staking/Governance/common/useGovernanceVoteFlow.ts
+++ b/mobile/src/features/Staking/Governance/common/useGovernanceVoteFlow.ts
@@ -1,0 +1,103 @@
+import {Wallet} from '@yoroi/types'
+
+import {Certificate} from '@emurgo/cross-csl-core'
+import * as React from 'react'
+
+import {UsePromiseOptionsWithoutPromise} from '~/hooks/usePromise'
+import {useCreateGovernanceTx} from '~/features/Staking/hooks/useCreateGovernanceTx'
+import {YoroiWallet} from '~/wallets/cardano/types'
+import {YoroiUnsignedTx} from '~/wallets/types/yoroi'
+
+import {useGovernanceActions} from './helpers'
+
+type PendingVote = 'abstain' | 'no-confidence' | 'delegate' | null
+
+type DelegateOptions = {
+  hash: string
+  type: 'key' | 'script'
+  CIP105: boolean
+}
+
+type UseGovernanceVoteFlowOptions = UsePromiseOptionsWithoutPromise<
+  YoroiUnsignedTx,
+  [{certificates: Certificate[]; addressMode: Wallet.AddressMode}]
+>
+
+export const useGovernanceVoteFlow = ({
+  wallet,
+  addressMode,
+  options,
+}: {
+  wallet: YoroiWallet
+  addressMode: Wallet.AddressMode
+  options?: UseGovernanceVoteFlowOptions
+}) => {
+  const governanceActions = useGovernanceActions()
+
+  const [pendingVote, setPendingVote] = React.useState<PendingVote>(null)
+  const pendingVoteRef = React.useRef<PendingVote>(null)
+  const delegateOptionsRef = React.useRef<DelegateOptions | null>(null)
+
+  const createGovernanceTxMutation = useCreateGovernanceTx(wallet, {
+    ...options,
+    onSuccess: (unsignedTx) => {
+      if (pendingVoteRef.current === 'delegate' && delegateOptionsRef.current) {
+        const {hash, type, CIP105} = delegateOptionsRef.current
+        governanceActions.handleDelegateAction({
+          unsignedTx,
+          hash,
+          type,
+          CIP105,
+        })
+        return
+      }
+
+      if (pendingVoteRef.current === 'abstain') {
+        governanceActions.handleAbstainAction({
+          unsignedTx,
+        })
+        return
+      }
+
+      if (pendingVoteRef.current === 'no-confidence') {
+        governanceActions.handleNoConfidenceAction({
+          unsignedTx,
+        })
+      }
+    },
+  })
+
+  const setDelegatePending = (options: DelegateOptions) => {
+    setPendingVote('delegate')
+    pendingVoteRef.current = 'delegate'
+    delegateOptionsRef.current = options
+  }
+
+  const setAbstainPending = () => {
+    setPendingVote('abstain')
+    pendingVoteRef.current = 'abstain'
+  }
+
+  const setNoConfidencePending = () => {
+    setPendingVote('no-confidence')
+    pendingVoteRef.current = 'no-confidence'
+  }
+
+  const submit = (certificates: Certificate[]) => {
+    createGovernanceTxMutation.resolve({
+      certificates,
+      addressMode,
+    })
+  }
+
+  return {
+    pendingVote,
+    isCreatingTx: createGovernanceTxMutation.isPending,
+    setDelegatePending,
+    setAbstainPending,
+    setNoConfidencePending,
+    submit,
+  } as const
+}
+
+

--- a/mobile/src/features/Staking/Governance/useCases/ChangeVote/ChangeVoteScreen.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/ChangeVote/ChangeVoteScreen.tsx
@@ -78,6 +78,7 @@ export const ChangeVoteScreen = () => {
 
   const handleDelegate = () => {
     openDRepIdModal(async (options) => {
+      if (isCreatingTx) return
       const stakingKey = wallet.getStakingKey()
 
       setDelegatePending(options)
@@ -93,6 +94,7 @@ export const ChangeVoteScreen = () => {
   }
 
   const handleDelegateToYoroi = async () => {
+    if (isCreatingTx) return
     const stakingKey = wallet.getStakingKey()
 
     setDelegatePending({
@@ -111,6 +113,7 @@ export const ChangeVoteScreen = () => {
   }
 
   const handleAbstain = async () => {
+    if (isCreatingTx) return
     const stakingKey = wallet.getStakingKey()
     setAbstainPending()
 
@@ -123,6 +126,7 @@ export const ChangeVoteScreen = () => {
   }
 
   const handleNoConfidence = async () => {
+    if (isCreatingTx) return
     const stakingKey = wallet.getStakingKey()
     setNoConfidencePending()
 

--- a/mobile/src/features/Staking/Governance/useCases/ChangeVote/ChangeVoteScreen.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/ChangeVote/ChangeVoteScreen.tsx
@@ -40,11 +40,6 @@ export const ChangeVoteScreen = () => {
     : null
   const {openModal} = useModal()
   const {manager} = useGovernance()
-  const [, setPendingDelegateOptions] = React.useState<{
-    hash: string
-    type: 'key' | 'script'
-    CIP105: boolean
-  } | null>(null)
 
   const createDelegationCertificate = useDelegationCertificate()
   const createVotingCertificate = useVotingCertificate()
@@ -91,12 +86,6 @@ export const ChangeVoteScreen = () => {
         hash: options.hash,
         type: options.type,
         stakingKey,
-      })
-
-      setPendingDelegateOptions({
-        hash: options.hash,
-        type: options.type,
-        CIP105: options.CIP105,
       })
 
       submit([certificate])

--- a/mobile/src/features/Staking/Governance/useCases/ChangeVote/ChangeVoteScreen.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/ChangeVote/ChangeVoteScreen.tsx
@@ -16,7 +16,6 @@ import {ScrollView} from 'react-native-gesture-handler'
 import {useRemoteConfig} from '~/features/RemoteConfig/hooks/useRemoteConfig'
 import {LearnMoreLink} from '~/features/Staking/Governance/common/LearnMoreLink/LearnMoreLink'
 import {YoroiRecordLink} from '~/features/Staking/Governance/common/YoroiRecordLink/YoroiRecordLink'
-import {useCreateGovernanceTx} from '~/features/Staking/hooks/useCreateGovernanceTx'
 import {useStakingKey} from '~/features/Staking/hooks/useStakingKey'
 import {useSelectedWallet} from '~/features/WalletManager/hooks/useSelectedWallet'
 import {useStrings} from '~/kernel/i18n/useStrings'
@@ -24,10 +23,8 @@ import {useModal} from '~/ui/Modal/context/ModalContext'
 import {Space} from '~/ui/Space/Space'
 
 import {Action} from '../../common/Action/Action'
-import {
-  mapStakingKeyStateToGovernanceAction,
-  useGovernanceActions,
-} from '../../common/helpers'
+import {mapStakingKeyStateToGovernanceAction} from '../../common/helpers'
+import {useGovernanceVoteFlow} from '../../common/useGovernanceVoteFlow'
 import {EnterDrepIdModal} from '../EnterDrepIdModal/EnterDrepIdModal'
 
 export const ChangeVoteScreen = () => {
@@ -43,45 +40,26 @@ export const ChangeVoteScreen = () => {
     : null
   const {openModal} = useModal()
   const {manager} = useGovernance()
-  const [pendingVote, setPendingVote] = React.useState<
-    | 'abstain'
-    | 'no-confidence'
-    | 'delegate-to-yoroi'
-    | 'delegate-not-yoroi'
-    | null
-  >(null)
-  const governanceActions = useGovernanceActions()
-
-  const createDelegationCertificate = useDelegationCertificate()
-  const createVotingCertificate = useVotingCertificate()
-
-  const createGovernanceTxMutation = useCreateGovernanceTx(wallet)
-  const [pendingDelegateOptions, setPendingDelegateOptions] = React.useState<{
+  const [, setPendingDelegateOptions] = React.useState<{
     hash: string
     type: 'key' | 'script'
     CIP105: boolean
   } | null>(null)
 
-  React.useEffect(() => {
-    if (
-      pendingDelegateOptions &&
-      createGovernanceTxMutation.value &&
-      !createGovernanceTxMutation.isPending
-    ) {
-      governanceActions.handleDelegateAction({
-        unsignedTx: createGovernanceTxMutation.value,
-        hash: pendingDelegateOptions.hash,
-        type: pendingDelegateOptions.type,
-        CIP105: pendingDelegateOptions.CIP105,
-      })
-      setPendingDelegateOptions(null)
-    }
-  }, [
-    pendingDelegateOptions,
-    createGovernanceTxMutation.value,
-    createGovernanceTxMutation.isPending,
-    governanceActions,
-  ])
+  const createDelegationCertificate = useDelegationCertificate()
+  const createVotingCertificate = useVotingCertificate()
+
+  const {
+    pendingVote,
+    isCreatingTx,
+    setDelegatePending,
+    setAbstainPending,
+    setNoConfidencePending,
+    submit,
+  } = useGovernanceVoteFlow({
+    wallet,
+    addressMode: meta.addressMode,
+  })
 
   if (!isNonNullable(action)) throw new Error('User has never voted')
 
@@ -107,7 +85,7 @@ export const ChangeVoteScreen = () => {
     openDRepIdModal(async (options) => {
       const stakingKey = wallet.getStakingKey()
 
-      setPendingVote('delegate-not-yoroi')
+      setDelegatePending(options)
 
       const certificate = await createDelegationCertificate({
         hash: options.hash,
@@ -121,17 +99,18 @@ export const ChangeVoteScreen = () => {
         CIP105: options.CIP105,
       })
 
-      createGovernanceTxMutation.resolve({
-        certificates: [certificate],
-        addressMode: meta.addressMode,
-      })
+      submit([certificate])
     })
   }
 
   const handleDelegateToYoroi = async () => {
     const stakingKey = wallet.getStakingKey()
 
-    setPendingVote('delegate-to-yoroi')
+    setDelegatePending({
+      hash: GOVERNANCE_YOROI_DREP_ID_HEX,
+      type: 'key',
+      CIP105: false,
+    })
 
     const certificate = await createDelegationCertificate({
       hash: GOVERNANCE_YOROI_DREP_ID_HEX,
@@ -139,67 +118,36 @@ export const ChangeVoteScreen = () => {
       stakingKey,
     })
 
-    createGovernanceTxMutation.resolve({
-      certificates: [certificate],
-      addressMode: meta.addressMode,
-    })
-
-    if (createGovernanceTxMutation.value) {
-      governanceActions.handleDelegateAction({
-        unsignedTx: createGovernanceTxMutation.value,
-        hash: GOVERNANCE_YOROI_DREP_ID_HEX,
-        type: 'key',
-        CIP105: false,
-      })
-    }
+    submit([certificate])
   }
 
   const handleAbstain = async () => {
     const stakingKey = wallet.getStakingKey()
-    setPendingVote('abstain')
+    setAbstainPending()
 
     const certificate = await createVotingCertificate({
       vote: 'abstain',
       stakingKey,
     })
 
-    createGovernanceTxMutation.resolve({
-      certificates: [certificate],
-      addressMode: meta.addressMode,
-    })
-
-    if (createGovernanceTxMutation.value) {
-      governanceActions.handleAbstainAction({
-        unsignedTx: createGovernanceTxMutation.value,
-      })
-    }
+    submit([certificate])
   }
 
   const handleNoConfidence = async () => {
     const stakingKey = wallet.getStakingKey()
-    setPendingVote('no-confidence')
+    setNoConfidencePending()
 
     const certificate = await createVotingCertificate({
       vote: 'no-confidence',
       stakingKey,
     })
 
-    createGovernanceTxMutation.resolve({
-      certificates: [certificate],
-      addressMode: meta.addressMode,
-    })
-
-    if (createGovernanceTxMutation.value) {
-      governanceActions.handleNoConfidenceAction({
-        unsignedTx: createGovernanceTxMutation.value,
-      })
-    }
+    submit([certificate])
   }
 
   const voteKind = action?.kind
   const voteHash =
     voteKind === 'delegate' && action != null ? action.hash : undefined
-  const isCreatingTx = createGovernanceTxMutation.isPending
   const isDelegatingNotToYoroiDrep =
     voteKind === 'delegate' && voteHash !== GOVERNANCE_YOROI_DREP_ID_HEX
 
@@ -220,7 +168,7 @@ export const ChangeVoteScreen = () => {
               title={strings.staking.delegateToAYoroiDrep}
               description={strings.staking.delegateToAYoroiDRepDescription}
               onPress={handleDelegateToYoroi}
-              pending={isCreatingTx && pendingVote === 'delegate-to-yoroi'}
+              pending={isCreatingTx && pendingVote === 'delegate'}
               showGradient
             >
               <YoroiRecordLink />
@@ -232,7 +180,7 @@ export const ChangeVoteScreen = () => {
             title={strings.staking.actionDelegateToADRepTitle}
             description={strings.staking.actionDelegateToADRepDescription}
             onPress={handleDelegate}
-            pending={isCreatingTx && pendingVote === 'delegate-not-yoroi'}
+            pending={isCreatingTx && pendingVote === 'delegate'}
           />
         )}
 
@@ -241,7 +189,7 @@ export const ChangeVoteScreen = () => {
             title={strings.staking.changeDRep}
             description={strings.staking.actionDelegateToADRepDescription}
             onPress={handleDelegate}
-            pending={isCreatingTx && pendingVote === 'delegate-not-yoroi'}
+            pending={isCreatingTx && pendingVote === 'delegate'}
           />
         )}
 

--- a/mobile/src/features/Staking/Governance/useCases/ChangeVote/ChangeVoteScreen.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/ChangeVote/ChangeVoteScreen.tsx
@@ -77,8 +77,8 @@ export const ChangeVoteScreen = () => {
   }
 
   const handleDelegate = () => {
+    if (isCreatingTx) return
     openDRepIdModal(async (options) => {
-      if (isCreatingTx) return
       const stakingKey = wallet.getStakingKey()
 
       setDelegatePending(options)

--- a/mobile/src/features/Staking/Governance/useCases/ChangeVote/ChangeVoteScreen.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/ChangeVote/ChangeVoteScreen.tsx
@@ -47,16 +47,17 @@ export const ChangeVoteScreen = () => {
   const {
     pendingVote,
     isCreatingTx,
-    setDelegatePending,
-    setAbstainPending,
-    setNoConfidencePending,
-    submit,
+    submitDelegate,
+    submitAbstain,
+    submitNoConfidence,
   } = useGovernanceVoteFlow({
     wallet,
     addressMode: meta.addressMode,
   })
 
   if (!isNonNullable(action)) throw new Error('User has never voted')
+
+  const isPending = isCreatingTx || pendingVote !== null
 
   const openDRepIdModal = (
     onSubmit: (options: {
@@ -77,11 +78,9 @@ export const ChangeVoteScreen = () => {
   }
 
   const handleDelegate = () => {
-    if (isCreatingTx) return
+    if (isPending) return
     openDRepIdModal(async (options) => {
       const stakingKey = wallet.getStakingKey()
-
-      setDelegatePending(options)
 
       const certificate = await createDelegationCertificate({
         hash: options.hash,
@@ -89,19 +88,19 @@ export const ChangeVoteScreen = () => {
         stakingKey,
       })
 
-      submit([certificate])
+      submitDelegate([certificate], options)
     })
   }
 
   const handleDelegateToYoroi = async () => {
-    if (isCreatingTx) return
+    if (isPending) return
     const stakingKey = wallet.getStakingKey()
 
-    setDelegatePending({
+    const options = {
       hash: GOVERNANCE_YOROI_DREP_ID_HEX,
-      type: 'key',
+      type: 'key' as const,
       CIP105: false,
-    })
+    }
 
     const certificate = await createDelegationCertificate({
       hash: GOVERNANCE_YOROI_DREP_ID_HEX,
@@ -109,33 +108,31 @@ export const ChangeVoteScreen = () => {
       stakingKey,
     })
 
-    submit([certificate])
+    submitDelegate([certificate], options)
   }
 
   const handleAbstain = async () => {
-    if (isCreatingTx) return
+    if (isPending) return
     const stakingKey = wallet.getStakingKey()
-    setAbstainPending()
 
     const certificate = await createVotingCertificate({
       vote: 'abstain',
       stakingKey,
     })
 
-    submit([certificate])
+    submitAbstain([certificate])
   }
 
   const handleNoConfidence = async () => {
-    if (isCreatingTx) return
+    if (isPending) return
     const stakingKey = wallet.getStakingKey()
-    setNoConfidencePending()
 
     const certificate = await createVotingCertificate({
       vote: 'no-confidence',
       stakingKey,
     })
 
-    submit([certificate])
+    submitNoConfidence([certificate])
   }
 
   const voteKind = action?.kind

--- a/mobile/src/features/Staking/Governance/useCases/Home/HomeScreen.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/Home/HomeScreen.tsx
@@ -270,10 +270,9 @@ const NeverParticipatedInGovernanceVariant = () => {
   const {
     pendingVote,
     isCreatingTx,
-    setDelegatePending,
-    setAbstainPending,
-    setNoConfidencePending,
-    submit,
+    submitDelegate,
+    submitAbstain,
+    submitNoConfidence,
   } = useGovernanceVoteFlow({
     wallet,
     addressMode: meta.addressMode,
@@ -288,6 +287,8 @@ const NeverParticipatedInGovernanceVariant = () => {
       },
     },
   })
+
+  const isPending = isCreatingTx || pendingVote !== null
 
   const openDRepIdModal = (
     onSubmit: (options: {
@@ -308,11 +309,9 @@ const NeverParticipatedInGovernanceVariant = () => {
   }
 
   const handleDelegate = () => {
-    if (isCreatingTx) return
+    if (isPending) return
     openDRepIdModal(async (options) => {
       const stakingKey = wallet.getStakingKey()
-
-      setDelegatePending(options)
 
       const certificate = await createDelegationCertificate({
         hash: options.hash,
@@ -325,19 +324,19 @@ const NeverParticipatedInGovernanceVariant = () => {
       const certs =
         stakeCert !== null ? [stakeCert, certificate] : [certificate]
 
-      submit(certs)
+      submitDelegate(certs, options)
     })
   }
 
   const handleDelegateToYoroi = async () => {
-    if (isCreatingTx) return
+    if (isPending) return
     const stakingKey = wallet.getStakingKey()
 
-    setDelegatePending({
+    const options = {
       hash: GOVERNANCE_YOROI_DREP_ID_HEX,
-      type: 'key',
+      type: 'key' as const,
       CIP105: false,
-    })
+    }
 
     const certificate = await createDelegationCertificate({
       hash: GOVERNANCE_YOROI_DREP_ID_HEX,
@@ -349,13 +348,12 @@ const NeverParticipatedInGovernanceVariant = () => {
       : null
     const certs = stakeCert !== null ? [stakeCert, certificate] : [certificate]
 
-    submit(certs)
+    submitDelegate(certs, options)
   }
 
   const handleAbstain = async () => {
-    if (isCreatingTx) return
+    if (isPending) return
     const stakingKey = wallet.getStakingKey()
-    setAbstainPending()
 
     const certificate = await createVotingCertificate({
       vote: 'abstain',
@@ -366,13 +364,12 @@ const NeverParticipatedInGovernanceVariant = () => {
       : null
     const certs = stakeCert !== null ? [stakeCert, certificate] : [certificate]
 
-    submit(certs)
+    submitAbstain(certs)
   }
 
   const handleNoConfidence = async () => {
-    if (isCreatingTx) return
+    if (isPending) return
     const stakingKey = wallet.getStakingKey()
-    setNoConfidencePending()
 
     const certificate = await createVotingCertificate({
       vote: 'no-confidence',
@@ -383,7 +380,7 @@ const NeverParticipatedInGovernanceVariant = () => {
       : null
     const certs = stakeCert !== null ? [stakeCert, certificate] : [certificate]
 
-    submit(certs)
+    submitNoConfidence(certs)
   }
 
   return (

--- a/mobile/src/features/Staking/Governance/useCases/Home/HomeScreen.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/Home/HomeScreen.tsx
@@ -308,8 +308,8 @@ const NeverParticipatedInGovernanceVariant = () => {
   }
 
   const handleDelegate = () => {
+    if (isCreatingTx) return
     openDRepIdModal(async (options) => {
-      if (isCreatingTx) return
       const stakingKey = wallet.getStakingKey()
 
       setDelegatePending(options)

--- a/mobile/src/features/Staking/Governance/useCases/Home/HomeScreen.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/Home/HomeScreen.tsx
@@ -11,7 +11,7 @@ import {
 import {ThemedPalette, atoms as a, useTheme} from '@yoroi/theme'
 
 import {NotEnoughMoneyToSendError} from '@emurgo/yoroi-lib/dist/errors'
-import React, {type ReactNode} from 'react'
+import * as React from 'react'
 import {Text, View} from 'react-native'
 import {ScrollView} from 'react-native-gesture-handler'
 
@@ -19,7 +19,6 @@ import {useRemoteConfig} from '~/features/RemoteConfig/hooks/useRemoteConfig'
 import {LearnMoreLink} from '~/features/Staking/Governance/common/LearnMoreLink/LearnMoreLink'
 import {YoroiRecordLink} from '~/features/Staking/Governance/common/YoroiRecordLink/YoroiRecordLink'
 import {formatDrepHashToCIP129Format} from '~/features/Staking/Governance/common/drep'
-import {useCreateGovernanceTx} from '~/features/Staking/hooks/useCreateGovernanceTx'
 import {useStakingInfo} from '~/features/Staking/hooks/useStakingInfo'
 import {useStakingKey} from '~/features/Staking/hooks/useStakingKey'
 import {useTransactionInfos} from '~/features/Transactions/hooks/useTransactionInfos'
@@ -31,11 +30,9 @@ import {Space} from '~/ui/Space/Space'
 import {TransactionInfo} from '~/wallets/types/other'
 
 import {Action} from '../../common/Action/Action'
-import {
-  mapStakingKeyStateToGovernanceAction,
-  useGovernanceActions,
-} from '../../common/helpers'
+import {mapStakingKeyStateToGovernanceAction} from '../../common/helpers'
 import {useNavigateTo} from '../../common/navigation'
+import {useGovernanceVoteFlow} from '../../common/useGovernanceVoteFlow'
 import {GovernanceVote} from '../../types'
 import {EnterDrepIdModal} from '../EnterDrepIdModal/EnterDrepIdModal'
 
@@ -231,7 +228,7 @@ const ParticipatingInGovernanceVariant = ({
 
 const formattingOptions = (p: ThemedPalette) => {
   return {
-    b: (text: ReactNode) => {
+    b: (text: React.ReactNode) => {
       return (
         <Text
           style={[
@@ -244,7 +241,7 @@ const formattingOptions = (p: ThemedPalette) => {
         </Text>
       )
     },
-    textComponent: (text: ReactNode) => (
+    textComponent: (text: React.ReactNode) => (
       <Text style={[a.body_1_lg_regular, {color: p.text_gray_medium}]}>
         {text}
       </Text>
@@ -262,14 +259,6 @@ const NeverParticipatedInGovernanceVariant = () => {
   const {manager} = useGovernance()
   const {openModal} = useModal()
   const stakingInfo = useStakingInfo(wallet)
-  const [pendingVote, setPendingVote] = React.useState<
-    | 'abstain'
-    | 'no-confidence'
-    | 'delegate-to-yoroi'
-    | 'delegate-not-yoroi'
-    | null
-  >(null)
-  const governanceActions = useGovernanceActions()
 
   const hasStakingKeyRegistered = stakingInfo?.data?.status !== 'not-registered'
   useWalletEvent(wallet, 'utxos', stakingInfo.refetch)
@@ -278,15 +267,25 @@ const NeverParticipatedInGovernanceVariant = () => {
   const createDelegationCertificate = useDelegationCertificate()
   const createVotingCertificate = useVotingCertificate()
 
-  const createGovernanceTxMutation = useCreateGovernanceTx(wallet, {
-    shouldThrow: false,
-    onError: (error) => {
-      if (error instanceof NotEnoughMoneyToSendError) {
-        navigateTo.noFunds()
-      } else {
-        // Re-throw other errors to trigger error boundary
+  const {
+    pendingVote,
+    isCreatingTx,
+    setDelegatePending,
+    setAbstainPending,
+    setNoConfidencePending,
+    submit,
+  } = useGovernanceVoteFlow({
+    wallet,
+    addressMode: meta.addressMode,
+    options: {
+      shouldThrow: false,
+      onError: (error) => {
+        if (error instanceof NotEnoughMoneyToSendError) {
+          navigateTo.noFunds()
+          return
+        }
         throw error
-      }
+      },
     },
   })
 
@@ -312,7 +311,7 @@ const NeverParticipatedInGovernanceVariant = () => {
     openDRepIdModal(async (options) => {
       const stakingKey = wallet.getStakingKey()
 
-      setPendingVote('delegate-not-yoroi')
+      setDelegatePending(options)
 
       const certificate = createDelegationCertificate({
         hash: options.hash,
@@ -325,26 +324,18 @@ const NeverParticipatedInGovernanceVariant = () => {
       const certs =
         stakeCert !== null ? [stakeCert, certificate] : [certificate]
 
-      createGovernanceTxMutation.resolve({
-        certificates: certs,
-        addressMode: meta.addressMode,
-      })
-
-      if (createGovernanceTxMutation.value) {
-        governanceActions.handleDelegateAction({
-          unsignedTx: createGovernanceTxMutation.value,
-          hash: options.hash,
-          type: options.type,
-          CIP105: options.CIP105,
-        })
-      }
+      submit(certs)
     })
   }
 
   const handleDelegateToYoroi = () => {
     const stakingKey = wallet.getStakingKey()
 
-    setPendingVote('delegate-to-yoroi')
+    setDelegatePending({
+      hash: GOVERNANCE_YOROI_DREP_ID_HEX,
+      type: 'key',
+      CIP105: false,
+    })
 
     const certificate = createDelegationCertificate({
       hash: GOVERNANCE_YOROI_DREP_ID_HEX,
@@ -356,24 +347,12 @@ const NeverParticipatedInGovernanceVariant = () => {
       : null
     const certs = stakeCert !== null ? [stakeCert, certificate] : [certificate]
 
-    createGovernanceTxMutation.resolve({
-      certificates: certs,
-      addressMode: meta.addressMode,
-    })
-
-    if (createGovernanceTxMutation.value) {
-      governanceActions.handleDelegateAction({
-        unsignedTx: createGovernanceTxMutation.value,
-        hash: GOVERNANCE_YOROI_DREP_ID_HEX,
-        type: 'key',
-        CIP105: false,
-      })
-    }
+    submit(certs)
   }
 
   const handleAbstain = () => {
     const stakingKey = wallet.getStakingKey()
-    setPendingVote('abstain')
+    setAbstainPending()
 
     const certificate = createVotingCertificate({
       vote: 'abstain',
@@ -384,21 +363,12 @@ const NeverParticipatedInGovernanceVariant = () => {
       : null
     const certs = stakeCert !== null ? [stakeCert, certificate] : [certificate]
 
-    createGovernanceTxMutation.resolve({
-      certificates: certs,
-      addressMode: meta.addressMode,
-    })
-
-    if (createGovernanceTxMutation.value) {
-      governanceActions.handleAbstainAction({
-        unsignedTx: createGovernanceTxMutation.value,
-      })
-    }
+    submit(certs)
   }
 
   const handleNoConfidence = () => {
     const stakingKey = wallet.getStakingKey()
-    setPendingVote('no-confidence')
+    setNoConfidencePending()
 
     const certificate = createVotingCertificate({
       vote: 'no-confidence',
@@ -409,19 +379,8 @@ const NeverParticipatedInGovernanceVariant = () => {
       : null
     const certs = stakeCert !== null ? [stakeCert, certificate] : [certificate]
 
-    createGovernanceTxMutation.resolve({
-      certificates: certs,
-      addressMode: meta.addressMode,
-    })
-
-    if (createGovernanceTxMutation.value) {
-      governanceActions.handleNoConfidenceAction({
-        unsignedTx: createGovernanceTxMutation.value,
-      })
-    }
+    submit(certs)
   }
-
-  const isCreatingTx = createGovernanceTxMutation.isPending
 
   return (
     <ScrollView style={[a.px_lg, a.flex_1, ta.bg_color_max]}>
@@ -439,7 +398,7 @@ const NeverParticipatedInGovernanceVariant = () => {
             title={strings.staking.delegateToAYoroiDrep}
             description={strings.staking.delegateToAYoroiDRepDescription}
             onPress={handleDelegateToYoroi}
-            pending={isCreatingTx && pendingVote === 'delegate-to-yoroi'}
+            pending={isCreatingTx && pendingVote === 'delegate'}
             showGradient
           >
             <YoroiRecordLink />
@@ -450,7 +409,7 @@ const NeverParticipatedInGovernanceVariant = () => {
           title={strings.staking.actionDelegateToADRepTitle}
           description={strings.staking.actionDelegateToADRepDescription}
           onPress={handleDelegate}
-          pending={isCreatingTx && pendingVote === 'delegate-not-yoroi'}
+          pending={isCreatingTx && pendingVote === 'delegate'}
         />
 
         <Action

--- a/mobile/src/features/Staking/Governance/useCases/Home/HomeScreen.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/Home/HomeScreen.tsx
@@ -309,6 +309,7 @@ const NeverParticipatedInGovernanceVariant = () => {
 
   const handleDelegate = () => {
     openDRepIdModal(async (options) => {
+      if (isCreatingTx) return
       const stakingKey = wallet.getStakingKey()
 
       setDelegatePending(options)
@@ -329,6 +330,7 @@ const NeverParticipatedInGovernanceVariant = () => {
   }
 
   const handleDelegateToYoroi = () => {
+    if (isCreatingTx) return
     const stakingKey = wallet.getStakingKey()
 
     setDelegatePending({
@@ -351,6 +353,7 @@ const NeverParticipatedInGovernanceVariant = () => {
   }
 
   const handleAbstain = () => {
+    if (isCreatingTx) return
     const stakingKey = wallet.getStakingKey()
     setAbstainPending()
 
@@ -367,6 +370,7 @@ const NeverParticipatedInGovernanceVariant = () => {
   }
 
   const handleNoConfidence = () => {
+    if (isCreatingTx) return
     const stakingKey = wallet.getStakingKey()
     setNoConfidencePending()
 

--- a/mobile/src/features/Staking/Governance/useCases/Home/HomeScreen.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/Home/HomeScreen.tsx
@@ -314,7 +314,7 @@ const NeverParticipatedInGovernanceVariant = () => {
 
       setDelegatePending(options)
 
-      const certificate = createDelegationCertificate({
+      const certificate = await createDelegationCertificate({
         hash: options.hash,
         type: options.type,
         stakingKey,
@@ -329,7 +329,7 @@ const NeverParticipatedInGovernanceVariant = () => {
     })
   }
 
-  const handleDelegateToYoroi = () => {
+  const handleDelegateToYoroi = async () => {
     if (isCreatingTx) return
     const stakingKey = wallet.getStakingKey()
 
@@ -339,7 +339,7 @@ const NeverParticipatedInGovernanceVariant = () => {
       CIP105: false,
     })
 
-    const certificate = createDelegationCertificate({
+    const certificate = await createDelegationCertificate({
       hash: GOVERNANCE_YOROI_DREP_ID_HEX,
       type: 'key',
       stakingKey,
@@ -352,12 +352,12 @@ const NeverParticipatedInGovernanceVariant = () => {
     submit(certs)
   }
 
-  const handleAbstain = () => {
+  const handleAbstain = async () => {
     if (isCreatingTx) return
     const stakingKey = wallet.getStakingKey()
     setAbstainPending()
 
-    const certificate = createVotingCertificate({
+    const certificate = await createVotingCertificate({
       vote: 'abstain',
       stakingKey,
     })
@@ -369,12 +369,12 @@ const NeverParticipatedInGovernanceVariant = () => {
     submit(certs)
   }
 
-  const handleNoConfidence = () => {
+  const handleNoConfidence = async () => {
     if (isCreatingTx) return
     const stakingKey = wallet.getStakingKey()
     setNoConfidencePending()
 
-    const certificate = createVotingCertificate({
+    const certificate = await createVotingCertificate({
       vote: 'no-confidence',
       stakingKey,
     })


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YV-786

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a shared vote-flow hook and refactors governance screens to use it, unifying pending handling and blocking duplicate presses.
> 
> - **Core**:
>   - **New Hook**: `common/useGovernanceVoteFlow.ts`
>     - Manages `pendingVote` state and `PendingAction` refs; wraps `useCreateGovernanceTx`.
>     - Handles success flows for `delegate`, `abstain`, and `no-confidence` via `useGovernanceActions`.
>     - Exposes `submitDelegate`, `submitAbstain`, `submitNoConfidence`, and `isCreatingTx`; accepts `addressMode` and optional options.
> - **UI**:
>   - **ChangeVoteScreen** and **HomeScreen**:
>     - Replaced direct TX creation and manual state with `useGovernanceVoteFlow`.
>     - Added `isPending` guards to ignore presses while a TX is in progress; standardized `pending` prop checks to `pendingVote === 'delegate'`.
>     - In Home (never participated), routes `NotEnoughMoneyToSendError` to no-funds screen via hook `onError` option.
> - **Type/Minor**:
>   - Switched to `React.ReactNode` in formatting helpers; removed unused imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8975b5b0ffb2c1caa6819abe2749a9837d37b7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->