### PR TITLE
fix(mobile): discover - push notification redirection

### DIFF
--- a/mobile/src/features/Discover/useCases/BrowseDapp/BrowseDappScreen.tsx
+++ b/mobile/src/features/Discover/useCases/BrowseDapp/BrowseDappScreen.tsx
@@ -39,7 +39,7 @@ export const BrowseDappScreen = () => {
           })
         }
       }
-    }, [navigation, p, ta, tabs.length]),
+    }, [navigation, p, ta]),
   )
 
   return (

--- a/mobile/src/features/Discover/useCases/BrowseDapp/BrowseDappScreen.tsx
+++ b/mobile/src/features/Discover/useCases/BrowseDapp/BrowseDappScreen.tsx
@@ -36,6 +36,7 @@ export const BrowseDappScreen = () => {
 
       return () => {
         if (tabNav) {
+          // Restore the full style with theme values (without display property)
           tabNav.setOptions({
             tabBarStyle: {
               ...ta.bg_color_max,

--- a/mobile/src/features/Discover/useCases/BrowseDapp/BrowseDappScreen.tsx
+++ b/mobile/src/features/Discover/useCases/BrowseDapp/BrowseDappScreen.tsx
@@ -5,7 +5,6 @@ import * as React from 'react'
 import {FlatList, View} from 'react-native'
 
 import {useBrowser} from '~/features/Discover/common/BrowserProvider'
-import {useNavigateTo} from '~/features/Discover/common/useNavigateTo'
 import {Space} from '~/ui/Space/Space'
 
 import {BrowserTabsBar} from './BrowserTabsBar'
@@ -16,15 +15,9 @@ export const BrowseDappScreen = () => {
   const flatListRef = React.useRef<FlatList>(null)
   const {tabs, tabsOpen} = useBrowser()
   const navigation = useNavigation()
-  const navigateTo = useNavigateTo()
 
   useFocusEffect(
     React.useCallback(() => {
-      if (tabs.length === 0) {
-        navigateTo.selectDappFromList()
-        return
-      }
-
       const tabNav = navigation.getParent()?.getParent()
       if (tabNav) {
         tabNav.setOptions({
@@ -46,7 +39,7 @@ export const BrowseDappScreen = () => {
           })
         }
       }
-    }, [navigation, navigateTo, p, ta, tabs.length]),
+    }, [navigation, p, ta, tabs.length]),
   )
 
   return (

--- a/mobile/src/features/Discover/useCases/BrowseDapp/BrowseDappScreen.tsx
+++ b/mobile/src/features/Discover/useCases/BrowseDapp/BrowseDappScreen.tsx
@@ -5,6 +5,7 @@ import * as React from 'react'
 import {FlatList, View} from 'react-native'
 
 import {useBrowser} from '~/features/Discover/common/BrowserProvider'
+import {useNavigateTo} from '~/features/Discover/common/useNavigateTo'
 import {Space} from '~/ui/Space/Space'
 
 import {BrowserTabsBar} from './BrowserTabsBar'
@@ -15,9 +16,15 @@ export const BrowseDappScreen = () => {
   const flatListRef = React.useRef<FlatList>(null)
   const {tabs, tabsOpen} = useBrowser()
   const navigation = useNavigation()
+  const navigateTo = useNavigateTo()
 
   useFocusEffect(
     React.useCallback(() => {
+      if (tabs.length === 0) {
+        navigateTo.selectDappFromList()
+        return
+      }
+
       const tabNav = navigation.getParent()?.getParent()
       if (tabNav) {
         tabNav.setOptions({
@@ -29,7 +36,6 @@ export const BrowseDappScreen = () => {
 
       return () => {
         if (tabNav) {
-          // Restore the full style with theme values (without display property)
           tabNav.setOptions({
             tabBarStyle: {
               ...ta.bg_color_max,
@@ -39,7 +45,7 @@ export const BrowseDappScreen = () => {
           })
         }
       }
-    }, [navigation, p, ta]),
+    }, [navigation, navigateTo, p, ta, tabs.length]),
   )
 
   return (

--- a/mobile/src/features/Notifications/common/tools.ts
+++ b/mobile/src/features/Notifications/common/tools.ts
@@ -227,7 +227,7 @@ const handleInternalNavigation = async (
           walletNavigation.navigateToGovernanceCentre()
           break
         case 'discover':
-          walletNavigation.navigateToDiscoverBrowserDapp()
+          walletNavigation.navigateToDiscoverDappSelection()
           break
       }
     } catch (error) {

--- a/mobile/src/kernel/navigation/hooks/useWalletNavigation.ts
+++ b/mobile/src/kernel/navigation/hooks/useWalletNavigation.ts
@@ -297,6 +297,18 @@ export const useWalletNavigation = () => {
       })
     },
 
+    navigateToDiscoverDappSelection: () => {
+      navigation.navigate('manage-wallets', {
+        screen: 'main-wallet-routes',
+        params: {
+          screen: 'discover',
+          params: {
+            screen: 'discover-select-dapp-from-list',
+          },
+        },
+      })
+    },
+
     navigateToSwap: () => {
       const currentNetwork = selectedNetworkRef.current.network
 

--- a/mobile/src/kernel/navigation/types.tsx
+++ b/mobile/src/kernel/navigation/types.tsx
@@ -372,6 +372,7 @@ export type WalletNavigation = {
   navigateToAnalyticsSettings: () => void
   navigateToGovernanceCentre: () => void
   navigateToDiscoverBrowserDapp: () => void
+  navigateToDiscoverDappSelection: () => void
   navigateToSwap: () => void
   resetToSwapWithToken: () => void
   navigateToExchange: () => void


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YV-860

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Redirects 'discover' push notification navigation to the Dapp selection screen and adds the corresponding navigation method and types.
> 
> - **Notifications**:
>   - `handleInternalNavigation('discover')`: now calls `walletNavigation.navigateToDiscoverDappSelection()` instead of `navigateToDiscoverBrowserDapp()`.
> - **Navigation**:
>   - Add `navigateToDiscoverDappSelection()` to `useWalletNavigation`, routing to `discover-select-dapp-from-list`.
>   - Update `WalletNavigation` type to include `navigateToDiscoverDappSelection`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2edc379d238e111704dfbda461cb18f1e2770564. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->