### PR TITLE
chore: merge develop to preview

### DIFF
--- a/mobile/packages/swap/adapters/api/minswap/transformers.test.ts
+++ b/mobile/packages/swap/adapters/api/minswap/transformers.test.ts
@@ -72,78 +72,33 @@ describe('transformersMaker', () => {
       })
     })
 
-    it('should handle all protocol mappings in mapProtocolToDex', () => {
-      // Test various protocol mappings by using them in blocked protocols
+    it('should not include exclude_protocols when blockedProtocols is removed', () => {
       const mockRequest = {
         amountIn: 10,
-        blockedProtocols: [
-          'minswap-v1' as any,
-          'minswap-stable' as any,
-          'muesliswap' as any,
-          'splash-v1' as any,
-          'sundaeswap-v3' as any,
-          'sundaeswap-v1' as any,
-          'vyfi-v1' as any,
-          'cswap' as any,
-          'wingriders-v2' as any,
-          'wingriders-v1' as any,
-          'wingriders-stable' as any,
-          'spectrum-v1' as any,
-        ],
         slippage: 1,
         tokenIn: '.' as const,
         tokenOut: 'test-token.' as const,
       }
 
       const result = transformers.estimate.request(mockRequest)
-      expect(result.exclude_protocols).toHaveLength(12)
-      expect(result.exclude_protocols).toContain(Dex.Minswap)
-      expect(result.exclude_protocols).toContain(Dex.MinswapStable)
-      expect(result.exclude_protocols).toContain(Dex.MuesliSwap)
-      expect(result.exclude_protocols).toContain(Dex.Splash)
-      expect(result.exclude_protocols).toContain(Dex.SundaeSwapV3)
-      expect(result.exclude_protocols).toContain(Dex.SundaeSwap)
-      expect(result.exclude_protocols).toContain(Dex.VyFinance)
-      expect(result.exclude_protocols).toContain(Dex.CswapV1)
-      expect(result.exclude_protocols).toContain(Dex.WingRidersV2)
-      expect(result.exclude_protocols).toContain(Dex.WingRiders)
-      expect(result.exclude_protocols).toContain(Dex.WingRidersStableV2)
-      expect(result.exclude_protocols).toContain(Dex.Spectrum)
+      expect(result.exclude_protocols).toBeUndefined()
     })
 
-    it('should handle unknown protocol in mapProtocolToDex default case', () => {
-      // Test the default case in mapProtocolToDex by using an unknown protocol
+    it('should not include exclude_protocols when blockedProtocols is removed', () => {
       const mockRequest = {
         amountIn: 10,
-        blockedProtocols: ['unknown-protocol' as any],
         slippage: 1,
         tokenIn: '.' as const,
         tokenOut: 'test-token.' as const,
       }
 
       const result = transformers.estimate.request(mockRequest)
-      expect(result.exclude_protocols).toContain(Dex.Unsupported)
+      expect(result.exclude_protocols).toBeUndefined()
     })
 
-    it('should handle splash-stable protocol mapping', () => {
-      // Test the splash-stable protocol mapping (line 50)
+    it('should not include exclude_protocols when blockedProtocols is removed', () => {
       const mockRequest = {
         amountIn: 10,
-        blockedProtocols: ['splash-v1' as any], // Use valid splash-v1 protocol
-        slippage: 1,
-        tokenIn: '.' as const,
-        tokenOut: 'test-token.' as const,
-      }
-
-      const result = transformers.estimate.request(mockRequest)
-      expect(result.exclude_protocols).toContain(Dex.Splash)
-    })
-
-    it('should handle blocked protocols mapping with undefined', () => {
-      // Test the blocked protocols mapping when blockedProtocols is undefined (line 286)
-      const mockRequest = {
-        amountIn: 10,
-        blockedProtocols: undefined,
         slippage: 1,
         tokenIn: '.' as const,
         tokenOut: 'test-token.' as const,
@@ -307,7 +262,6 @@ describe('transformersMaker', () => {
           'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae45655534441',
         amount: '10',
         slippage: 1,
-        exclude_protocols: [],
         amount_in_decimal: true,
       })
     })
@@ -408,7 +362,6 @@ describe('transformersMaker', () => {
     it('should handle estimate request with blocked protocols', () => {
       const mockRequest = {
         amountIn: 10,
-        blockedProtocols: ['minswap-v2' as any],
         slippage: 1,
         tokenIn: '.' as const,
         tokenOut: 'test-token.' as const,
@@ -416,7 +369,7 @@ describe('transformersMaker', () => {
 
       const result = transformers.estimate.request(mockRequest)
 
-      expect(result.exclude_protocols).toEqual([Dex.MinswapV2])
+      expect(result.exclude_protocols).toBeUndefined()
     })
 
     it('should handle unknown Dex protocol in response', () => {
@@ -496,7 +449,7 @@ describe('transformersMaker', () => {
         {dex: Dex.Minswap, expected: 'minswap-v1'},
         {dex: Dex.MinswapStable, expected: 'minswap-stable'},
         {dex: Dex.MuesliSwap, expected: 'muesliswap'},
-        {dex: Dex.Splash, expected: 'splash-v1'},
+        {dex: Dex.Splash, expected: 'splash'},
         {dex: Dex.SundaeSwapV3, expected: 'sundaeswap-v3'},
         {dex: Dex.SundaeSwap, expected: 'sundaeswap-v1'},
         {dex: Dex.VyFinance, expected: 'vyfi-v1'},
@@ -505,7 +458,7 @@ describe('transformersMaker', () => {
         {dex: Dex.WingRiders, expected: 'wingriders-v1'},
         {dex: Dex.WingRidersStableV2, expected: 'wingriders-stable'},
         {dex: Dex.Spectrum, expected: 'spectrum-v1'},
-        {dex: Dex.SplashStable, expected: 'splash-v1'},
+        {dex: Dex.SplashStable, expected: 'splash'},
       ]
 
       testCases.forEach(({dex, expected}) => {
@@ -599,7 +552,6 @@ describe('transformersMaker', () => {
           token_out:
             'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae45655534441',
           slippage: 1,
-          exclude_protocols: [],
         },
         amount_in_decimal: true,
       })

--- a/mobile/packages/swap/adapters/api/minswap/transformers.ts
+++ b/mobile/packages/swap/adapters/api/minswap/transformers.ts
@@ -18,41 +18,6 @@ import {
   TokensResponse,
 } from './types'
 
-const mapProtocolToDex = (protocol: Swap.Protocol): Dex => {
-  switch (protocol) {
-    case Swap.Protocol.Minswap_v2:
-      return Dex.MinswapV2
-    case Swap.Protocol.Minswap_v1:
-      return Dex.Minswap
-    case Swap.Protocol.Minswap_stable:
-      return Dex.MinswapStable
-    case Swap.Protocol.Muesliswap:
-      return Dex.MuesliSwap
-    case Swap.Protocol.Splash_v1:
-      return Dex.Splash
-    case Swap.Protocol.Sundaeswap_v3:
-      return Dex.SundaeSwapV3
-    case Swap.Protocol.Sundaeswap_v1:
-      return Dex.SundaeSwap
-    case Swap.Protocol.Vyfi_v1:
-      return Dex.VyFinance
-    case Swap.Protocol.Cswap:
-      return Dex.CswapV1
-    case Swap.Protocol.Wingriders_v2:
-      return Dex.WingRidersV2
-    case Swap.Protocol.Wingriders_v1:
-      return Dex.WingRiders
-    case Swap.Protocol.Wingriders_stable:
-      return Dex.WingRidersStableV2
-    case Swap.Protocol.Spectrum_v1:
-      return Dex.Spectrum
-    case Swap.Protocol.Splash_v1:
-      return Dex.SplashStable
-    default:
-      return Dex.Unsupported
-  }
-}
-
 export const transformersMaker = (config: MinswapApiConfig) => {
   const {isPrimaryToken, primaryTokenInfo, address, partner} = config
 
@@ -224,22 +189,15 @@ export const transformersMaker = (config: MinswapApiConfig) => {
       estimate: {
         request: ({
           amountIn,
-          blockedProtocols,
           slippage,
           tokenIn,
           tokenOut,
-          protocol,
         }: Swap.EstimateRequest): EstimateRequest => {
           const request: EstimateRequest = {
             token_in: toTokenId(tokenIn),
             token_out: toTokenId(tokenOut),
             amount: amountIn?.toString() ?? '0',
             slippage: slippage ?? 0,
-            exclude_protocols: blockedProtocols?.map((p) =>
-              mapProtocolToDex(p),
-            ),
-            include_protocols:
-              protocol !== undefined ? [mapProtocolToDex(protocol)] : undefined,
             amount_in_decimal: true, // Tell API that amounts are in decimal format
             ...(partner !== undefined && {partner}),
           }
@@ -251,12 +209,15 @@ export const transformersMaker = (config: MinswapApiConfig) => {
           const totalOutputWithoutSlippage = Number(data.amount_out)
           const deposits = Number(data.deposits ?? '0')
           const aggregatorFee = Number(data.aggregator_fee ?? '0')
-          const totalFee = Number(data.total_dex_fee ?? '0')
+          const dexFee = Number(data.total_dex_fee ?? '0')
+          // Convert to lovelace (integers) to avoid floating point precision issues
+          const totalFee =
+            (Math.round(aggregatorFee * 1e6) + Math.round(dexFee * 1e6)) / 1e6
 
           return freeze(
             {
               splits: transformPathsToSplits(data.paths),
-              batcherFee: totalFee,
+              batcherFee: dexFee,
               deposits,
               aggregatorFee,
               frontendFee: 0,
@@ -275,11 +236,9 @@ export const transformersMaker = (config: MinswapApiConfig) => {
       create: {
         request: ({
           amountIn,
-          blockedProtocols,
           slippage,
           tokenIn,
           tokenOut,
-          protocol,
           inputs,
         }: Swap.CreateRequest): CreateRequest => {
           const request = {
@@ -290,13 +249,6 @@ export const transformersMaker = (config: MinswapApiConfig) => {
               token_in: toTokenId(tokenIn),
               token_out: toTokenId(tokenOut),
               slippage: slippage || 1,
-              exclude_protocols: blockedProtocols?.map((p) =>
-                mapProtocolToDex(p),
-              ),
-              include_protocols:
-                protocol !== undefined
-                  ? [mapProtocolToDex(protocol)]
-                  : undefined,
               ...(partner !== undefined && {partner}),
             },
             amount_in_decimal: true, // Also set at the top level for build-tx

--- a/mobile/packages/swap/adapters/api/steelswap/api-maker.test.ts
+++ b/mobile/packages/swap/adapters/api/steelswap/api-maker.test.ts
@@ -1,0 +1,512 @@
+import {isLeft, isRight} from '@yoroi/common'
+import {Chain, Portfolio} from '@yoroi/types'
+
+import {steelswapApiMaker} from './api-maker'
+import {
+  BuildSwapResponse,
+  CancelResponse,
+  EstimateResponse,
+  OrderStatusResponse,
+  TokensResponse,
+} from './types'
+
+const mockConfig = {
+  address: 'addr1test',
+  network: Chain.Network.Mainnet as Chain.SupportedNetworks,
+  primaryTokenInfo: {
+    id: '.' as const,
+    name: 'Cardano',
+    ticker: 'ADA',
+    decimals: 6,
+    logo: null,
+    description: '',
+    website: '',
+    policyId: '',
+    fingerprint: '',
+    group: 'ADA',
+    kind: 'ft',
+    image: null,
+    icon: null,
+    symbol: 'ADA',
+    metadatas: {},
+    isPrimaryToken: true,
+    status: Portfolio.Token.Status.Valid,
+    application: Portfolio.Token.Application.General,
+    tag: '',
+    reference: '',
+    originalImage: '',
+    nature: Portfolio.Token.Nature.Primary,
+    type: Portfolio.Token.Type.FT,
+  } as Portfolio.Token.Info,
+  isPrimaryToken: (token: string | null | undefined) => token === '.',
+  request: jest.fn(),
+}
+
+describe('steelswapApiMaker', () => {
+  const mockTokensResponse: TokensResponse = [
+    {
+      ticker: 'USDA',
+      name: 'USDA',
+      policyId: 'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae456',
+      policyName: '55534441',
+      decimals: 6,
+    },
+  ]
+
+  const mockTokensApiResponse = {
+    tag: 'right' as const,
+    value: {
+      status: 200,
+      data: mockTokensResponse,
+    },
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should return proxy for non-mainnet networks', async () => {
+    const config = {
+      ...mockConfig,
+      network: Chain.Network.Preprod as Chain.SupportedNetworks,
+    }
+    const api = steelswapApiMaker(config)
+
+    const result = await api.tokens()
+    expect(isLeft(result)).toBe(true)
+    if (isLeft(result)) {
+      expect(result.error).toMatchObject({
+        status: -3,
+        message: 'Steelswap api only works on mainnet',
+      })
+    }
+  })
+
+  it('should create API instance for mainnet', () => {
+    const api = steelswapApiMaker(mockConfig)
+
+    expect(api).toBeDefined()
+    expect(typeof api.tokens).toBe('function')
+    expect(typeof api.orders).toBe('function')
+    expect(typeof api.estimate).toBe('function')
+    expect(typeof api.create).toBe('function')
+    expect(typeof api.cancel).toBe('function')
+  })
+
+  describe('tokens', () => {
+    it('should handle tokens request successfully', async () => {
+      const mockResponse: TokensResponse = [
+        {
+          ticker: 'USDA',
+          name: 'USDA',
+          policyId: 'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae456',
+          policyName: '55534441',
+          decimals: 6,
+        },
+      ]
+
+      mockConfig.request = jest.fn().mockResolvedValue({
+        tag: 'right' as const,
+        value: {
+          status: 200,
+          data: mockResponse,
+        },
+      })
+
+      const api = steelswapApiMaker(mockConfig)
+      const result = await api.tokens()
+
+      expect(isRight(result)).toBe(true)
+      if (isRight(result)) {
+        expect(result.value.data).toHaveLength(1)
+        expect(result.value.data[0]).toMatchObject({
+          ticker: 'USDA',
+          decimals: 6,
+        })
+      }
+    })
+
+    it('should handle tokens request error', async () => {
+      mockConfig.request = jest.fn().mockResolvedValue({
+        tag: 'left' as const,
+        error: {
+          status: 500,
+          message: 'Internal Server Error',
+          responseData: null,
+        },
+      })
+
+      const api = steelswapApiMaker(mockConfig)
+      const result = await api.tokens()
+
+      expect(isLeft(result)).toBe(true)
+    })
+  })
+
+  describe('orders', () => {
+    it('should handle orders request successfully', async () => {
+      const mockResponse: OrderStatusResponse = {
+        orders: [
+          {
+            source: 'MuesliSwap',
+            firstObserved: 1762266077000,
+            lastUpdated: 1762266077000,
+            totalSubmitted: {lovelace: 13200000},
+            totalRequested: {
+              fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae45655534441: 15000000,
+            },
+            totalReceived: {},
+            swaps: [
+              {
+                dex: 'MinswapV2',
+                orderType: 0,
+                txStatus: 'queued',
+                submitTxHash:
+                  '0788552a7f0bfe547d47be51e36f579cda23b4adfccefeb7f74ea90e395c8bd2',
+                submitTxIndex: 0,
+                submitTime: 1762266077000,
+                submitAssets: [{lovelace: 13200000}],
+                requestAssets: [
+                  {
+                    fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae45655534441: 15000000,
+                  },
+                ],
+                executeTxHash: null,
+                executeTxIndex: null,
+                executeTime: null,
+                receivedAssets: null,
+              },
+            ],
+          },
+        ],
+        page: 0,
+        lastPage: 0,
+      }
+
+      mockConfig.request = jest.fn().mockResolvedValue({
+        tag: 'right' as const,
+        value: {
+          status: 200,
+          data: mockResponse,
+        },
+      })
+
+      const api = steelswapApiMaker(mockConfig)
+      const result = await api.orders()
+
+      expect(isRight(result)).toBe(true)
+      if (isRight(result)) {
+        expect(result.value.data).toHaveLength(1)
+        expect(result.value.data[0]).toMatchObject({
+          txHash:
+            '0788552a7f0bfe547d47be51e36f579cda23b4adfccefeb7f74ea90e395c8bd2',
+          status: 'open',
+        })
+      }
+    })
+  })
+
+  describe('estimate', () => {
+    it('should handle estimate request successfully', async () => {
+      const mockResponse: EstimateResponse = {
+        tokenA: 'lovelace',
+        quantityA: 2000000, // Already in decimal format (isFloat=true)
+        tokenB:
+          'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae45655534441',
+        quantityB: 1089627, // Already in decimal format (isFloat=true)
+        totalFee: 0.1, // Already in ADA (isFloat=true)
+        totalDeposit: 0,
+        steelswapFee: 0,
+        bonusOut: 0,
+        price: 1.9311019603443615,
+        splitGroup: [
+          [
+            {
+              tokenA: 'lovelace',
+              quantityA: 2000000, // Already in decimal format (isFloat=true)
+              tokenB:
+                'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae45655534441',
+              quantityB: 1089627, // Already in decimal format (isFloat=true)
+              totalFee: 0.1, // Already in ADA (isFloat=true)
+              totalDeposit: 0,
+              steelswapFee: 0,
+              bonusOut: 0,
+              price: 1.9311019603443615,
+              pools: [
+                {
+                  dex: 'Splash',
+                  poolId: 'test-pool-id',
+                  quantityA: 2000000, // Already in decimal format (isFloat=true)
+                  quantityB: 1089627, // Already in decimal format (isFloat=true)
+                  batcherFee: 0.1, // Already in ADA (isFloat=true)
+                  deposit: 0,
+                  volumeFee: 1000, // Still in lovelace, will be converted
+                },
+              ],
+            },
+          ],
+        ],
+      }
+
+      mockConfig.request = jest.fn().mockResolvedValue({
+        tag: 'right' as const,
+        value: {
+          status: 200,
+          data: mockResponse,
+        },
+      })
+
+      const api = steelswapApiMaker(mockConfig)
+      const result = await api.estimate({
+        tokenIn: '.' as const,
+        tokenOut:
+          'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae456.55534441' as const,
+        amountIn: 2, // 2 ADA in decimal
+        slippage: 0.5,
+      })
+
+      expect(isRight(result)).toBe(true)
+      if (isRight(result)) {
+        expect(result.value.data.totalInput).toBe(2000000) // Already in decimal format (isFloat=true)
+        expect(result.value.data.totalOutput).toBe(1089627) // Already in decimal format (isFloat=true)
+      }
+    })
+
+    it('should handle estimate error', async () => {
+      mockConfig.request = jest
+        .fn()
+        .mockResolvedValueOnce(mockTokensApiResponse)
+        .mockResolvedValueOnce({
+          tag: 'left' as const,
+          error: {
+            status: 422,
+            message: 'Validation Error',
+            responseData: {
+              detail: 'Invalid token pair',
+            },
+          },
+        })
+
+      const api = steelswapApiMaker(mockConfig)
+      const result = await api.estimate({
+        tokenIn: '.' as const,
+        tokenOut: 'invalid.invalid' as const,
+        amountIn: 1000000,
+        slippage: 0.5,
+      })
+
+      expect(isLeft(result)).toBe(true)
+    })
+
+    it('should reject limit estimates (wantedPrice)', async () => {
+      const api = steelswapApiMaker(mockConfig)
+      const result = await api.estimate({
+        tokenIn: '.' as const,
+        tokenOut:
+          'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae456.55534441' as const,
+        amountIn: 2,
+        slippage: 0.5,
+        wantedPrice: 1.5, // Limit estimate - should be rejected
+      })
+
+      expect(isLeft(result)).toBe(true)
+      if (isLeft(result)) {
+        expect(result.error.message).toBe(
+          'Steelswap Aggregator only supports market',
+        )
+        expect(result.error.status).toBe(-1)
+      }
+    })
+
+    it('should handle estimate response with invalid structure', async () => {
+      const mockResponse = {
+        splitGroup: [[]],
+      }
+
+      mockConfig.request = jest
+        .fn()
+        .mockResolvedValueOnce(mockTokensApiResponse)
+        .mockResolvedValueOnce({
+          tag: 'right' as const,
+          value: {
+            status: 200,
+            data: mockResponse,
+          },
+        })
+
+      const api = steelswapApiMaker(mockConfig)
+      const result = await api.estimate({
+        tokenIn: '.' as const,
+        tokenOut: '.' as const,
+        amountIn: 1000000,
+        slippage: 0.5,
+      })
+
+      expect(isLeft(result)).toBe(true)
+      if (isLeft(result)) {
+        expect(result.error.message).toContain('No liquidity pools')
+      }
+    })
+  })
+
+  describe('create', () => {
+    it('should handle create request successfully', async () => {
+      const buildResponse: BuildSwapResponse = {
+        tx: 'test-cbor-hex',
+        p: false,
+      }
+
+      const estimateResponse: EstimateResponse = {
+        tokenA: 'lovelace',
+        quantityA: 2000000, // Already in decimal format (isFloat=true)
+        tokenB:
+          'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae45655534441',
+        quantityB: 1089627, // Already in decimal format (isFloat=true)
+        totalFee: 0.1, // Already in ADA (isFloat=true)
+        totalDeposit: 0,
+        steelswapFee: 0,
+        bonusOut: 0,
+        price: 1.9311019603443615,
+        splitGroup: [
+          [
+            {
+              tokenA: 'lovelace',
+              quantityA: 2000000, // Already in decimal format (isFloat=true)
+              tokenB:
+                'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae45655534441',
+              quantityB: 1089627, // Already in decimal format (isFloat=true)
+              totalFee: 0.1, // Already in ADA (isFloat=true)
+              totalDeposit: 0,
+              steelswapFee: 0,
+              bonusOut: 0,
+              price: 1.9311019603443615,
+              pools: [
+                {
+                  dex: 'Splash',
+                  poolId: 'test-pool-id',
+                  quantityA: 2000000, // Already in decimal format (isFloat=true)
+                  quantityB: 1089627, // Already in decimal format (isFloat=true)
+                  batcherFee: 0.1, // Already in ADA (isFloat=true)
+                  deposit: 0,
+                  volumeFee: 1000, // Still in lovelace, will be converted
+                },
+              ],
+            },
+          ],
+        ],
+      }
+
+      // Mock build request and estimate request (called internally)
+      mockConfig.request = jest
+        .fn()
+        .mockResolvedValueOnce({
+          tag: 'right' as const,
+          value: {
+            status: 200,
+            data: buildResponse,
+          },
+        })
+        .mockResolvedValueOnce({
+          tag: 'right' as const,
+          value: {
+            status: 200,
+            data: estimateResponse,
+          },
+        })
+
+      const api = steelswapApiMaker(mockConfig)
+      const result = await api.create({
+        tokenIn: '.' as const,
+        tokenOut:
+          'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae456.55534441' as const,
+        amountIn: 2, // 2 ADA in decimal
+        slippage: 0.5,
+        inputs: ['test-utxo'],
+      })
+
+      expect(isRight(result)).toBe(true)
+      if (isRight(result)) {
+        expect(result.value.data.cbor).toBe('test-cbor-hex')
+        expect(result.value.data.totalInput).toBe(2000000) // Already in decimal format (isFloat=true)
+        expect(result.value.data.totalOutput).toBe(1089627) // Already in decimal format (isFloat=true)
+        expect(result.value.data.totalFee).toBe(0.1) // 0.1 (batcher) + 0 (steelswap) = 0.1 ADA (already converted)
+      }
+    })
+
+    it('should handle create request when estimate fails', async () => {
+      const buildResponse: BuildSwapResponse = {
+        tx: 'test-cbor-hex',
+        p: false,
+      }
+
+      mockConfig.request = jest
+        .fn()
+        .mockResolvedValueOnce({
+          tag: 'right' as const,
+          value: {
+            status: 200,
+            data: buildResponse,
+          },
+        })
+        .mockResolvedValueOnce({
+          tag: 'left' as const,
+          error: {
+            status: 500,
+            message: 'Estimate failed',
+            responseData: null,
+          },
+        })
+
+      const api = steelswapApiMaker(mockConfig)
+      const result = await api.create({
+        tokenIn: '.' as const,
+        tokenOut: '.' as const,
+        amountIn: 2000000,
+        slippage: 0.5,
+        inputs: [],
+      })
+
+      expect(isRight(result)).toBe(true)
+      if (isRight(result)) {
+        expect(result.value.data.cbor).toBe('test-cbor-hex')
+        // Should have minimal data when estimate fails
+        expect(result.value.data.totalInput).toBe(0)
+      }
+    })
+  })
+
+  describe('cancel', () => {
+    it('should handle cancel request successfully', async () => {
+      const mockResponse: CancelResponse = 'test-cancel-cbor-hex'
+
+      mockConfig.request = jest.fn().mockResolvedValue({
+        tag: 'right' as const,
+        value: {
+          status: 200,
+          data: mockResponse,
+        },
+      })
+
+      const api = steelswapApiMaker(mockConfig)
+      const result = await api.cancel({
+        order: {
+          aggregator: 'steelswap' as any,
+          protocol: 'minswap-v2' as any,
+          status: 'open',
+          tokenIn: '.' as const,
+          tokenOut: '.' as const,
+          amountIn: 1000000,
+          expectedAmountOut: 2000000,
+          actualAmountOut: 2000000,
+          txHash: 'test-tx-hash',
+          outputIndex: 0,
+        },
+      })
+
+      expect(isRight(result)).toBe(true)
+      if (isRight(result)) {
+        expect(result.value.data.cbor).toBe('test-cancel-cbor-hex')
+      }
+    })
+  })
+})

--- a/mobile/packages/swap/adapters/api/steelswap/api-maker.ts
+++ b/mobile/packages/swap/adapters/api/steelswap/api-maker.ts
@@ -1,0 +1,330 @@
+import {fetchData, isLeft} from '@yoroi/common'
+import {Api, Chain, Left, Swap} from '@yoroi/types'
+
+import {freeze} from 'immer'
+
+import {transformersMaker} from './transformers'
+import {
+  BuildSwapResponse,
+  CancelResponse,
+  EstimateResponse,
+  OrderStatusResponse,
+  SteelswapApiConfig,
+  SwapHistoryRequest,
+  TokensResponse,
+} from './types'
+
+export const steelswapApiMaker = (
+  config: SteelswapApiConfig,
+): Readonly<Swap.Api> => {
+  const {address, network, request = fetchData} = config
+
+  if (network !== Chain.Network.Mainnet)
+    return new Proxy(
+      {},
+      {
+        get() {
+          return () =>
+            Promise.resolve(
+              freeze(
+                {
+                  tag: 'left',
+                  error: {
+                    status: -3,
+                    message: 'Steelswap api only works on mainnet',
+                  },
+                },
+                true,
+              ),
+            )
+        },
+      },
+    ) as Swap.Api
+
+  const headers = {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+    'token':
+      'yoroi-xEwoVRkAcYSn4fgxsx5kS2ZJRBxPzAe15GyyG8FZVJEgn7e9UHfVZ07FwUBUAbmM',
+  }
+
+  const baseUrl = baseUrls[network]
+
+  const transformers = transformersMaker({
+    ...config,
+  })
+
+  const api = freeze(
+    {
+      async tokens() {
+        const response = await request<TokensResponse>({
+          method: 'get',
+          url: `${baseUrl}${apiPaths.tokens}`,
+          headers,
+        })
+
+        if (isLeft(response)) return parseSteelswapError(response)
+
+        return freeze(
+          {
+            tag: 'right' as const,
+            value: {
+              status: response.value.status,
+              data: transformers.tokens.response(response.value.data),
+            },
+          },
+          true,
+        )
+      },
+
+      async orders() {
+        const requestBody: SwapHistoryRequest = {
+          addresses: [address],
+          txType: ['swap'],
+          page: 0,
+          pageSize: 100,
+          isFloat: true,
+        }
+
+        const response = await request<OrderStatusResponse>({
+          method: 'post',
+          url: `${baseUrl}${apiPaths.orders}`,
+          headers,
+          data: requestBody,
+        })
+
+        if (isLeft(response)) return parseSteelswapError(response)
+
+        try {
+          return freeze(
+            {
+              tag: 'right' as const,
+              value: {
+                status: 200,
+                data: transformers.orders
+                  .response(response.value.data)
+                  .sort(
+                    (
+                      {lastUpdate: A, placedAt: A2},
+                      {lastUpdate: B, placedAt: B2},
+                    ) => (B ?? B2 ?? 0) - (A ?? A2 ?? 0),
+                  ),
+              },
+            },
+            true,
+          )
+        } catch (e) {
+          return freeze(
+            {
+              tag: 'left' as const,
+              error: {
+                status: -3,
+                message: 'Failed to transform orders',
+                responseData: response.value.data,
+              },
+            },
+            true,
+          )
+        }
+      },
+
+      async limitOptions() {
+        return freeze<Left<Api.ResponseError>>(
+          {
+            tag: 'left',
+            error: {
+              status: -3,
+              message: 'Limit options not supported',
+              responseData: null,
+            },
+          },
+          true,
+        )
+      },
+
+      async estimate(body: Swap.EstimateRequest) {
+        // Reject limit estimates (wantedPrice) - not supported
+        if (body.wantedPrice !== undefined) {
+          return freeze({
+            tag: 'left' as const,
+            error: {
+              status: -1,
+              message: 'Steelswap Aggregator only supports market',
+              responseData: null,
+            },
+          })
+        }
+
+        const requestBody = transformers.estimate.request(body)
+
+        const response = await request<EstimateResponse>({
+          method: 'post',
+          url: `${baseUrl}${apiPaths.estimate}`,
+          headers,
+          data: requestBody,
+        })
+
+        if (isLeft(response)) return parseSteelswapError(response)
+
+        try {
+          return freeze(
+            {
+              tag: 'right' as const,
+              value: {
+                status: response.value.status,
+                data: transformers.estimate.response(response.value.data),
+              },
+            },
+            true,
+          )
+        } catch (e) {
+          return freeze(
+            {
+              tag: 'left' as const,
+              error: {
+                status: -3,
+                message: 'No liquidity pools satisfy the estimate requirements',
+                responseData: response.value.data,
+              },
+            },
+            true,
+          )
+        }
+      },
+
+      async create(body: Swap.CreateRequest) {
+        const requestBody = transformers.create.request(body)
+
+        const response = await request<BuildSwapResponse>({
+          method: 'post',
+          url: `${baseUrl}${apiPaths.create}`,
+          headers,
+          data: requestBody,
+        })
+
+        if (isLeft(response)) return parseSteelswapError(response)
+
+        // Make an estimate call to get the swap details (build endpoint doesn't return splits)
+        const estimateRequest: Swap.EstimateRequest = {
+          amountIn: body.amountIn,
+          tokenIn: body.tokenIn,
+          tokenOut: body.tokenOut,
+          slippage: body.slippage ?? 0,
+          blockedProtocols: body.blockedProtocols,
+          protocol: body.protocol,
+        }
+
+        const estimateResponse = await this.estimate(estimateRequest)
+
+        // If estimate fails, return the create response with minimal data
+        if (isLeft(estimateResponse)) {
+          return freeze(
+            {
+              tag: 'right' as const,
+              value: {
+                status: response.value.status,
+                data: transformers.create.response(response.value.data),
+              },
+            },
+            true,
+          )
+        }
+
+        // Merge the CBOR from create with the estimate data
+        const estimateData = estimateResponse.value.data
+        const mergedData: Swap.CreateResponse = {
+          ...estimateData,
+          cbor: response.value.data.tx,
+          aggregator: Swap.Aggregator.Steelswap,
+          totalInput: estimateData.totalInput ?? body.amountIn,
+        }
+
+        return freeze(
+          {
+            tag: 'right' as const,
+            value: {
+              status: response.value.status,
+              data: mergedData,
+            },
+          },
+          true,
+        )
+      },
+
+      async cancel(body: Swap.CancelRequest) {
+        const requestBody = transformers.cancel.request(body)
+
+        const response = await request<CancelResponse>({
+          method: 'post',
+          url: `${baseUrl}${apiPaths.cancel}`,
+          headers,
+          data: requestBody,
+        })
+
+        if (isLeft(response)) return parseSteelswapError(response)
+
+        return freeze(
+          {
+            tag: 'right' as const,
+            value: {
+              status: response.value.status,
+              data: transformers.cancel.response(response.value.data),
+            },
+          },
+          true,
+        )
+      },
+    },
+    true,
+  )
+
+  return api
+}
+
+type ValidationError = {
+  loc: Array<string | number>
+  msg: string
+  type: string
+}
+
+type ErrorResponse = {
+  detail: string | Array<ValidationError>
+}
+
+export const parseSteelswapError = ({tag, error}: Left<Api.ResponseError>) => {
+  const responseData = error.responseData as ErrorResponse | null
+  let message = 'Steelswap API error'
+
+  if (responseData) {
+    if (typeof responseData.detail === 'string') {
+      message = responseData.detail
+    } else if (Array.isArray(responseData.detail)) {
+      message = responseData.detail
+        .map((err) => `${err.loc.join('.')}: ${err.msg}`)
+        .join('; ')
+    }
+  }
+
+  return freeze<Left<Api.ResponseError>>(
+    {
+      tag,
+      error: {
+        ...error,
+        message,
+      },
+    },
+    true,
+  )
+}
+
+const baseUrls = freeze({
+  [Chain.Network.Mainnet]: 'https://yoroi.steelswap.io',
+} as const)
+
+const apiPaths = freeze({
+  tokens: '/tokens/list/',
+  orders: '/wallet/history/',
+  estimate: '/swap/estimate/',
+  create: '/swap/build/',
+  cancel: '/swap/cancel/',
+} as const)

--- a/mobile/packages/swap/adapters/api/steelswap/transformers.test.ts
+++ b/mobile/packages/swap/adapters/api/steelswap/transformers.test.ts
@@ -1,0 +1,487 @@
+import {Chain, Portfolio, Swap} from '@yoroi/types'
+
+import {transformersMaker} from './transformers'
+import {
+  BuildSwapResponse,
+  CancelResponse,
+  OrderStatusResponse,
+  SplitOutput,
+  TokensResponse,
+} from './types'
+
+const mockConfig = {
+  address: 'addr1test',
+  network: Chain.Network.Mainnet as Chain.SupportedNetworks,
+  primaryTokenInfo: {
+    id: '.' as const,
+    name: 'Cardano',
+    ticker: 'ADA',
+    decimals: 6,
+    logo: null,
+    description: '',
+    website: '',
+    policyId: '',
+    fingerprint: '',
+    group: 'ADA',
+    kind: 'ft',
+    image: null,
+    icon: null,
+    symbol: 'ADA',
+    metadatas: {},
+    isPrimaryToken: true,
+    status: Portfolio.Token.Status.Valid,
+    application: Portfolio.Token.Application.General,
+    tag: '',
+    reference: '',
+    originalImage: '',
+    nature: Portfolio.Token.Nature.Primary,
+    type: Portfolio.Token.Type.FT,
+  } as Portfolio.Token.Info,
+  isPrimaryToken: (token: string | null | undefined) => token === '.',
+  partner: 'yoroi-aggregator',
+}
+
+describe('transformersMaker', () => {
+  const transformers = transformersMaker(mockConfig)
+
+  describe('tokens', () => {
+    it('should transform tokens response correctly', () => {
+      const mockResponse: TokensResponse = [
+        {
+          ticker: 'ADA',
+          name: 'Cardano',
+          policyId: 'lovelace',
+          policyName: '',
+          decimals: 6,
+        },
+        {
+          ticker: 'USDA',
+          name: 'USDA',
+          policyId: 'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae456',
+          policyName: '55534441',
+          decimals: 6,
+        },
+      ]
+
+      const result = transformers.tokens.response(mockResponse)
+
+      expect(result).toHaveLength(1) // Primary token is filtered out
+      expect(result[0]).toMatchObject({
+        id: 'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae456.55534441',
+        ticker: 'USDA',
+        name: 'USDA',
+        decimals: 6,
+        status: Portfolio.Token.Status.Valid,
+      })
+    })
+
+    it('should filter out tokens with null decimals', () => {
+      const mockResponse: TokensResponse = [
+        {
+          ticker: 'TEST',
+          name: 'Test Token',
+          policyId: 'test123',
+          policyName: 'TEST',
+          decimals: null as any,
+        },
+      ]
+
+      const result = transformers.tokens.response(mockResponse)
+      expect(result).toHaveLength(0)
+    })
+  })
+
+  describe('orders', () => {
+    it('should transform orders response correctly', () => {
+      const mockResponse: OrderStatusResponse = {
+        orders: [
+          {
+            source: 'MuesliSwap',
+            firstObserved: 1762266077000,
+            lastUpdated: 1762266077000,
+            totalSubmitted: {lovelace: 13200000},
+            totalRequested: {
+              fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae45655534441: 15000000,
+            },
+            totalReceived: {},
+            swaps: [
+              {
+                dex: 'MinswapV2',
+                orderType: 0,
+                txStatus: 'queued',
+                submitTxHash:
+                  '0788552a7f0bfe547d47be51e36f579cda23b4adfccefeb7f74ea90e395c8bd2',
+                submitTxIndex: 0,
+                submitTime: 1762266077000,
+                submitAssets: [{lovelace: 13200000}],
+                requestAssets: [
+                  {
+                    fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae45655534441: 15000000,
+                  },
+                ],
+                executeTxHash: null,
+                executeTxIndex: null,
+                executeTime: null,
+                receivedAssets: null,
+              },
+            ],
+          },
+        ],
+        page: 1,
+        lastPage: 1,
+      }
+
+      const result = transformers.orders.response(mockResponse)
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({
+        status: 'open',
+        txHash:
+          '0788552a7f0bfe547d47be51e36f579cda23b4adfccefeb7f74ea90e395c8bd2',
+        outputIndex: 0,
+        tokenIn: '.',
+        tokenOut:
+          'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae456.55534441',
+        amountIn: 13200000, // Already in decimal format (isFloat=true)
+        expectedAmountOut: 15000000, // Already in decimal format (isFloat=true)
+        actualAmountOut: 15000000, // Already in decimal format (isFloat=true)
+        aggregator: Swap.Aggregator.Steelswap,
+        protocol: Swap.Protocol.Minswap_v2,
+      })
+    })
+
+    it('should map txStatus correctly', () => {
+      const statusMap: Record<string, Swap.Order['status']> = {
+        txPending: 'open',
+        queued: 'open',
+        executed: 'matched',
+        cancelled: 'canceled',
+      }
+
+      Object.entries(statusMap).forEach(([txStatus, expectedStatus]) => {
+        const mockResponse: OrderStatusResponse = {
+          orders: [
+            {
+              source: 'Test',
+              firstObserved: 0,
+              lastUpdated: 0,
+              totalSubmitted: {},
+              totalRequested: {},
+              totalReceived: {},
+              swaps: [
+                {
+                  dex: 'Minswap',
+                  orderType: 0,
+                  txStatus: txStatus as any,
+                  submitTxHash: 'test',
+                  submitTxIndex: 0,
+                  submitTime: 0,
+                  submitAssets: [{lovelace: 1000000}],
+                  requestAssets: [{lovelace: 2000000}],
+                  executeTxHash: null,
+                  executeTxIndex: null,
+                  executeTime: null,
+                  receivedAssets: null,
+                },
+              ],
+            },
+          ],
+          page: 1,
+          lastPage: 1,
+        }
+
+        const result = transformers.orders.response(mockResponse)
+        expect(result[0]?.status).toBe(expectedStatus)
+      })
+    })
+  })
+
+  describe('estimate', () => {
+    it('should transform estimate request correctly', () => {
+      const request = transformers.estimate.request({
+        tokenIn: '.' as const,
+        tokenOut:
+          'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae456.55534441' as const,
+        amountIn: 2, // 2 ADA in decimal
+        slippage: 0.5,
+        blockedProtocols: [Swap.Protocol.Minswap_v1],
+      })
+
+      expect(request).toMatchObject({
+        tokenA: 'lovelace',
+        tokenB:
+          'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae45655534441',
+        quantity: 2, // Already in decimal format (isFloat=true)
+        predictFromOutputAmount: false,
+        partner: 'yoroi-aggregator',
+        isFloat: true,
+      })
+    })
+
+    it('should handle amountOut instead of amountIn', () => {
+      const request = transformers.estimate.request({
+        tokenIn: '.' as const,
+        tokenOut:
+          'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae456.55534441' as const,
+        amountOut: 1, // 1 token in decimal
+        slippage: 0.5,
+      })
+
+      expect(request).toMatchObject({
+        quantity: 1, // Already in decimal format (isFloat=true)
+        predictFromOutputAmount: true,
+        isFloat: true,
+      })
+    })
+
+    it('should transform estimate response correctly (SplitOutput)', () => {
+      const mockResponse: SplitOutput = {
+        tokenA: 'lovelace',
+        quantityA: 2000000, // Already in decimal format (isFloat=true)
+        tokenB:
+          'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae45655534441',
+        quantityB: 1089627, // Already in decimal format (isFloat=true)
+        totalFee: 0.1, // Already in ADA (isFloat=true)
+        totalDeposit: 0,
+        steelswapFee: 0,
+        bonusOut: 0,
+        price: 1.9311019603443615,
+        pools: [
+          {
+            dex: 'Splash',
+            poolId: 'test-pool-id',
+            quantityA: 2000000, // Already in decimal format (isFloat=true)
+            quantityB: 1089627, // Already in decimal format (isFloat=true)
+            batcherFee: 0.1, // Already in ADA (isFloat=true)
+            deposit: 0,
+            volumeFee: 1000, // Already in decimal format (isFloat=true)
+          },
+        ],
+      }
+
+      const result = transformers.estimate.response(mockResponse)
+
+      expect(result).toMatchObject({
+        totalInput: 2000000, // Already in decimal format (isFloat=true)
+        totalOutput: 1089627, // Already in decimal format (isFloat=true)
+        totalFee: 0.1, // 100000 (batcher) + 0 (steelswap) = 0.1 ADA (already converted)
+        batcherFee: 0.1, // Already in ADA (isFloat=true)
+        deposits: 0,
+        aggregatorFee: 0,
+        frontendFee: 0,
+        netPrice: 0.5448135, // 1089627 / 2000000 = output/input
+        priceImpact: 0,
+        splits: [
+          {
+            amountIn: 2000000, // Already in decimal format (isFloat=true)
+            expectedOutput: 1089627, // Already in decimal format (isFloat=true)
+            batcherFee: 0.1, // Already in ADA (isFloat=true)
+            deposits: 0,
+            fee: 1000, // Already in decimal format (isFloat=true)
+            poolFee: 1000, // Already in decimal format (isFloat=true)
+            protocol: Swap.Protocol.Splash_v1,
+            aggregator: Swap.Aggregator.Steelswap,
+            aggregatorDexKey: 'Splash',
+            aggregatorPoolId: 'test-pool-id',
+          },
+        ],
+      })
+    })
+
+    it('should transform estimate response correctly (HopSplitOutput)', () => {
+      const mockResponse = {
+        tokenA: 'lovelace',
+        quantityA: 2000000, // Already in decimal format (isFloat=true)
+        tokenB:
+          'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae45655534441',
+        quantityB: 1089627, // Already in decimal format (isFloat=true)
+        totalFee: 0.1, // Already in ADA (isFloat=true)
+        totalDeposit: 0,
+        steelswapFee: 0,
+        bonusOut: 0,
+        price: 1.9311019603443615,
+        splitGroup: [
+          [
+            {
+              tokenA: 'lovelace',
+              quantityA: 2000000, // Already in decimal format (isFloat=true)
+              tokenB:
+                'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae45655534441',
+              quantityB: 1089627, // Already in decimal format (isFloat=true)
+              totalFee: 0.1, // Already in ADA (isFloat=true)
+              totalDeposit: 0,
+              steelswapFee: 0,
+              bonusOut: 0,
+              price: 1.9311019603443615,
+              pools: [
+                {
+                  dex: 'Splash',
+                  poolId: 'test-pool-id',
+                  quantityA: 2000000, // Already in decimal format (isFloat=true)
+                  quantityB: 1089627, // Already in decimal format (isFloat=true)
+                  batcherFee: 0.1, // Already in ADA (isFloat=true)
+                  deposit: 0,
+                  volumeFee: 1000, // Already in decimal format (isFloat=true)
+                },
+              ],
+            },
+          ],
+        ],
+      }
+
+      const result = transformers.estimate.response(mockResponse)
+
+      expect(result).toMatchObject({
+        totalInput: 2000000, // Already in decimal format (isFloat=true)
+        totalOutput: 1089627, // Already in decimal format (isFloat=true)
+        totalFee: 0.1, // 100000 (batcher) + 0 (steelswap) = 0.1 ADA (already converted)
+      })
+    })
+
+    it('should throw error for invalid estimate response', () => {
+      const mockResponse = {
+        splitGroup: [[]],
+      }
+
+      expect(() => {
+        transformers.estimate.response(mockResponse as any)
+      }).toThrow('Invalid estimate response')
+    })
+  })
+
+  describe('create', () => {
+    it('should transform create request correctly', () => {
+      const request = transformers.create.request({
+        tokenIn: '.' as const,
+        tokenOut:
+          'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae456.55534441' as const,
+        amountIn: 2, // 2 ADA in decimal
+        slippage: 0.5,
+        inputs: ['test-utxo-1', 'test-utxo-2'],
+        blockedProtocols: [Swap.Protocol.Minswap_v1],
+      })
+
+      expect(request).toMatchObject({
+        tokenA: 'lovelace',
+        tokenB:
+          'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae45655534441',
+        quantity: 2, // Already in decimal format (isFloat=true)
+        address: 'addr1test',
+        utxos: ['test-utxo-1', 'test-utxo-2'],
+        slippage: 50, // 0.5% = 50 basis points
+        partner: 'yoroi-aggregator',
+        isFloat: true,
+      })
+    })
+
+    it('should handle zero slippage', () => {
+      const request = transformers.create.request({
+        tokenIn: '.' as const,
+        tokenOut:
+          'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae456.55534441' as const,
+        amountIn: 2000000,
+        inputs: [],
+      })
+
+      expect(request.slippage).toBe(0)
+    })
+
+    it('should transform create response correctly', () => {
+      const mockResponse: BuildSwapResponse = {
+        tx: 'test-cbor-hex',
+        p: false,
+      }
+
+      const result = transformers.create.response(mockResponse)
+
+      expect(result).toMatchObject({
+        aggregator: Swap.Aggregator.Steelswap,
+        cbor: 'test-cbor-hex',
+        splits: [],
+        batcherFee: 0,
+        deposits: 0,
+        aggregatorFee: 0,
+        frontendFee: 0,
+        netPrice: 0,
+        priceImpact: 0,
+        totalFee: 0,
+        totalInput: 0,
+        totalOutput: 0,
+        totalOutputWithoutSlippage: 0,
+      })
+    })
+  })
+
+  describe('cancel', () => {
+    it('should transform cancel request correctly', () => {
+      const request = transformers.cancel.request({
+        order: {
+          aggregator: Swap.Aggregator.Steelswap,
+          protocol: Swap.Protocol.Minswap_v1,
+          status: 'open',
+          tokenIn: '.' as const,
+          tokenOut:
+            'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae456.55534441' as const,
+          amountIn: 1000000,
+          expectedAmountOut: 2000000,
+          actualAmountOut: 2000000,
+          txHash: 'test-tx-hash',
+          outputIndex: 0,
+        },
+      })
+
+      expect(request).toMatchObject({
+        txList: [
+          {
+            txHash: 'test-tx-hash',
+            txIndex: 0,
+          },
+        ],
+        ttl: 900,
+        partner: 'yoroi-aggregator',
+      })
+    })
+
+    it('should transform cancel response correctly', () => {
+      const mockResponse: CancelResponse = 'test-cancel-cbor-hex'
+
+      const result = transformers.cancel.response(mockResponse)
+
+      expect(result).toEqual({
+        cbor: 'test-cancel-cbor-hex',
+      })
+    })
+  })
+
+  describe('token ID conversion', () => {
+    it('should convert lovelace to primary token ID', () => {
+      const transformers = transformersMaker(mockConfig)
+      // Test through estimate request
+      const request = transformers.estimate.request({
+        tokenIn: '.' as const,
+        tokenOut: '.' as const,
+        amountIn: 1, // Already in decimal format (isFloat=true)
+        slippage: 0.5,
+      })
+
+      expect(request.tokenA).toBe('lovelace')
+      expect(request.tokenB).toBe('lovelace')
+    })
+
+    it('should convert hex token ID to portfolio format', () => {
+      const hexTokenId =
+        'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae45655534441'
+      const expectedPortfolioId =
+        'fe7c786ab321f41c654ef6c1af7b3250a613c24e4213e0425a7ae456.55534441'
+
+      const request = transformers.estimate.request({
+        tokenIn: expectedPortfolioId as Portfolio.Token.Id,
+        tokenOut: '.' as const,
+        amountIn: 1, // Already in decimal format (isFloat=true)
+        slippage: 0.5,
+      })
+
+      expect(request.tokenA).toBe(hexTokenId)
+    })
+  })
+})

--- a/mobile/packages/swap/adapters/api/steelswap/transformers.ts
+++ b/mobile/packages/swap/adapters/api/steelswap/transformers.ts
@@ -1,0 +1,371 @@
+import {Portfolio, Swap} from '@yoroi/types'
+
+import {
+  BuildSwapRequest,
+  BuildSwapResponse,
+  CancelRequest,
+  CancelResponse,
+  Dex,
+  EstimateResponse,
+  HopSplitOutput,
+  OrderStatusResponse,
+  SplitOutput,
+  SteelswapTransformersConfig,
+  SwapEstimateRequest,
+  TokensResponse,
+} from './types'
+
+export const transformersMaker = ({
+  primaryTokenInfo,
+  address,
+  isPrimaryToken,
+  partner,
+}: SteelswapTransformersConfig) => {
+  const fromTokenId = (tokenId: string): Portfolio.Token.Id => {
+    if (tokenId === 'lovelace' || tokenId === 'ADA') {
+      return primaryTokenInfo.id
+    }
+    // If already in format policyId.hexName, return as is
+    if (tokenId.includes('.')) {
+      return tokenId as Portfolio.Token.Id
+    }
+    // Steelswap uses hex-encoded format: policyId + hexName (no separator)
+    // PolicyId is always 56 characters, rest is hexName
+    return `${tokenId.slice(0, 56)}.${tokenId.slice(56)}`
+  }
+
+  const toTokenId = (tokenId: Portfolio.Token.Id): string => {
+    if (isPrimaryToken(tokenId)) {
+      return 'lovelace'
+    }
+    return tokenId.replace('.', '')
+  }
+
+  const parseAssets = (
+    assets: Array<Record<string, number>>,
+  ): {token: string; amount: number}[] => {
+    const result: {token: string; amount: number}[] = []
+    for (const asset of assets) {
+      for (const [token, amount] of Object.entries(asset)) {
+        // Amounts are already in decimal format (isFloat=true)
+        result.push({
+          token,
+          amount,
+        })
+      }
+    }
+    return result
+  }
+
+  return {
+    tokens: {
+      response: (res: TokensResponse): Array<Portfolio.Token.Info> =>
+        res
+          .map(({ticker, name, policyId, policyName, decimals}) => {
+            const hexName = policyName || ''
+            const id = `${policyId}.${hexName}`
+
+            // Filter out primary token (it's already known)
+            // Check if policyId is 'lovelace' or if the constructed id matches primaryTokenInfo.id
+            const isPrimary =
+              policyId === 'lovelace' || id === primaryTokenInfo.id
+            if (isPrimary) return null
+
+            if (decimals === null || decimals === undefined) return null
+
+            return {
+              status: Portfolio.Token.Status.Valid,
+              id,
+              ticker: ticker ?? '',
+              name: name ?? ticker ?? '',
+              type: Portfolio.Token.Type.FT,
+              nature: Portfolio.Token.Nature.Secondary,
+              application: Portfolio.Token.Application.General,
+              fingerprint: '',
+              decimals,
+              description: '',
+              originalImage: '',
+              symbol: '',
+              reference: '',
+              tag: '',
+              website: '',
+            }
+          })
+          .filter((v): v is Portfolio.Token.Info => !!v),
+    },
+
+    orders: {
+      response: (res: OrderStatusResponse): Array<Swap.Order> => {
+        const orders: Swap.Order[] = []
+
+        for (const orderStatus of res.orders) {
+          for (const swap of orderStatus.swaps) {
+            const submitAssets = swap.submitAssets
+              ? parseAssets(swap.submitAssets)
+              : []
+            const requestAssets = swap.requestAssets
+              ? parseAssets(swap.requestAssets)
+              : []
+            const receivedAssets = swap.receivedAssets
+              ? parseAssets(swap.receivedAssets)
+              : []
+
+            // Find tokenIn and tokenOut from assets
+            const tokenInAsset = submitAssets[0]
+            const tokenOutAsset = requestAssets[0]
+            const receivedAsset = receivedAssets[0]
+
+            if (!tokenInAsset || !tokenOutAsset) continue
+
+            const tokenIn = fromTokenId(tokenInAsset.token)
+            const tokenOut = fromTokenId(tokenOutAsset.token)
+            const amountIn = tokenInAsset.amount
+            const expectedAmountOut = tokenOutAsset.amount
+            const actualAmountOut = receivedAsset?.amount ?? expectedAmountOut
+
+            // Map txStatus to our status
+            const statusMap: Record<string, Swap.Order['status']> = {
+              txPending: 'open',
+              queued: 'open',
+              executed: 'matched',
+              cancelled: 'canceled',
+            }
+            const status = statusMap[swap.txStatus] ?? 'open'
+
+            orders.push({
+              status,
+              txHash: swap.submitTxHash,
+              outputIndex: swap.submitTxIndex,
+              tokenIn,
+              tokenOut,
+              updateTxHash: swap.executeTxHash ?? swap.submitTxHash,
+              placedAt: swap.submitTime ? swap.submitTime : undefined,
+              lastUpdate: swap.executeTime
+                ? swap.executeTime
+                : swap.submitTime
+                  ? swap.submitTime
+                  : undefined,
+              amountIn,
+              actualAmountOut,
+              expectedAmountOut,
+              aggregator: Swap.Aggregator.Steelswap,
+              protocol: toSwapProtocol(swap.dex),
+              customId: `${swap.submitTxHash}#${swap.submitTxIndex}`,
+            })
+          }
+        }
+
+        return orders
+      },
+    },
+
+    estimate: {
+      request: ({
+        tokenIn,
+        tokenOut,
+        amountIn,
+        amountOut,
+        slippage: _slippage,
+      }: Swap.EstimateRequest): SwapEstimateRequest => {
+        const tokenAId = toTokenId(tokenIn)
+        const tokenBId = toTokenId(tokenOut)
+
+        // Amounts are already in decimal format adjusted by token decimals (isFloat=true)
+        const quantity = amountIn ?? amountOut ?? 0
+
+        return {
+          tokenA: tokenAId,
+          tokenB: tokenBId,
+          quantity: Math.round(quantity),
+          predictFromOutputAmount: amountOut !== undefined,
+          ...(partner !== undefined && {partner}),
+          isFloat: true,
+        }
+      },
+      response: (data: EstimateResponse): Swap.EstimateResponse => {
+        // Handle both SplitOutput and HopSplitOutput
+        const isHopSplit = 'splitGroup' in data
+
+        // When isFloat=true, use top-level values for totals (they're in decimal format)
+        // But extract pools from splitGroup if it's a HopSplitOutput
+        const topLevelData = data as HopSplitOutput | SplitOutput
+        const splitOutput = isHopSplit
+          ? (data as HopSplitOutput).splitGroup?.[0]?.[0]
+          : (data as SplitOutput)
+
+        if (
+          !splitOutput ||
+          !splitOutput.pools ||
+          splitOutput.pools.length === 0
+        ) {
+          throw new Error(
+            'Invalid estimate response: missing split output or pools',
+          )
+        }
+
+        // When isFloat=true, all values are already in decimal format
+        const splits = splitOutput.pools.map((pool) => ({
+          amountIn: pool.quantityA, // Already in decimal format
+          batcherFee: pool.batcherFee, // Already in ADA
+          deposits: pool.deposit, // Already in ADA
+          protocol: toSwapProtocol(pool.dex as Dex),
+          expectedOutput: pool.quantityB, // Already in decimal format
+          expectedOutputWithoutSlippage: pool.quantityB, // Already in decimal format
+          fee: pool.volumeFee, // Already in decimal format (isFloat=true)
+          initialPrice:
+            pool.quantityA > 0 ? pool.quantityB / pool.quantityA : 0,
+          finalPrice: pool.quantityA > 0 ? pool.quantityB / pool.quantityA : 0,
+          poolFee: pool.volumeFee, // Already in decimal format (isFloat=true)
+          poolId: pool.poolId,
+          priceDistortion: 0,
+          priceImpact: 0,
+          aggregator: Swap.Aggregator.Steelswap,
+          aggregatorDexKey: pool.dex,
+          aggregatorPoolId: pool.poolId,
+        }))
+
+        // Use top-level values for totals (they're in decimal format when isFloat=true)
+        const totalInput = topLevelData.quantityA
+        const totalOutput = topLevelData.quantityB
+        const deposits = topLevelData.totalDeposit // Already in ADA
+        const totalFee = topLevelData.totalFee + topLevelData.steelswapFee
+        const batcherFee = topLevelData.totalFee // Already in ADA
+        const aggregatorFee = topLevelData.steelswapFee // Already in ADA
+
+        const netPrice = totalInput > 0 ? totalOutput / totalInput : 0
+
+        return {
+          splits,
+          batcherFee,
+          deposits,
+          aggregatorFee,
+          frontendFee: 0,
+          netPrice,
+          priceImpact: 0,
+          totalFee,
+          totalInput,
+          totalOutput,
+          totalOutputWithoutSlippage: totalOutput + topLevelData.bonusOut,
+        }
+      },
+    },
+
+    create: {
+      request: ({
+        tokenIn,
+        tokenOut,
+        amountIn,
+        slippage,
+        inputs,
+      }: Swap.CreateRequest): BuildSwapRequest => {
+        const tokenAId = toTokenId(tokenIn)
+
+        // AmountIn is already in decimal format adjusted by token decimals (isFloat=true)
+        const quantity = amountIn
+
+        return {
+          tokenA: tokenAId,
+          tokenB: toTokenId(tokenOut),
+          quantity: Math.round(quantity),
+          ...(partner !== undefined && {partner}),
+          address,
+          utxos: inputs ?? [],
+          slippage: slippage ? Math.round(slippage * 100) : 0, // Convert percentage to basis points
+          isFloat: true,
+        }
+      },
+      response: ({tx, p: _p}: BuildSwapResponse): Swap.CreateResponse => {
+        return {
+          aggregator: Swap.Aggregator.Steelswap,
+          cbor: tx,
+          splits: [],
+          batcherFee: 0,
+          deposits: 0,
+          aggregatorFee: 0,
+          frontendFee: 0,
+          netPrice: 0,
+          priceImpact: 0,
+          totalFee: 0,
+          totalInput: 0,
+          totalOutput: 0,
+          totalOutputWithoutSlippage: 0,
+        }
+      },
+    },
+
+    cancel: {
+      request: ({order}: Swap.CancelRequest): CancelRequest => ({
+        txList: [
+          {
+            txHash: order.txHash,
+            txIndex: order.outputIndex ?? 0,
+          },
+        ],
+        ttl: 900,
+        ...(partner !== undefined && {partner}),
+      }),
+      response: (txHex: CancelResponse): Swap.CancelResponse => ({
+        cbor: txHex,
+      }),
+    },
+  } as const
+}
+
+export const toSwapProtocol = (dex: string): Swap.Protocol => {
+  const dexUpper = dex.toUpperCase()
+  const dexMap: Record<string, Swap.Protocol> = {
+    CSWAP: Swap.Protocol.Cswap,
+    GENIUSYIELD: Swap.Protocol.Genius,
+    MINSWAP: Swap.Protocol.Minswap_v1,
+    MINSWAPV2: Swap.Protocol.Minswap_v2,
+    MINSWAPV2ROUTER: Swap.Protocol.Minswap_v2,
+    MUESLISWAP: Swap.Protocol.Muesliswap_v2,
+    SPECTRUM: Swap.Protocol.Spectrum_v1,
+    SPLASH: Swap.Protocol.Splash_v1,
+    SPLASHROUTER: Swap.Protocol.Splash_v1,
+    SUNDAESWAP: Swap.Protocol.Sundaeswap_v1,
+    SUNDAESWAPV3: Swap.Protocol.Sundaeswap_v3,
+    VYFI: Swap.Protocol.Vyfi_v1,
+    WINGRIDERS: Swap.Protocol.Wingriders_v1,
+    WINGRIDERSV2: Swap.Protocol.Wingriders_v2,
+  }
+
+  return dexMap[dexUpper] ?? Swap.Protocol.Unsupported
+}
+
+export const fromSwapProtocol = (dex: Swap.Protocol): Dex => {
+  const protocolMap: Record<Swap.Protocol, Dex> = {
+    [Swap.Protocol.Cswap]: Dex.CSWAP,
+    [Swap.Protocol.Genius]: Dex.GeniusYield,
+    [Swap.Protocol.Minswap_v1]: Dex.Minswap,
+    [Swap.Protocol.Minswap_v2]: Dex.MinswapV2,
+    [Swap.Protocol.Minswap_stable]: Dex.MinswapV2,
+    [Swap.Protocol.Muesliswap]: Dex.MuesliSwap,
+    [Swap.Protocol.Muesliswap_v1]: Dex.MuesliSwap,
+    [Swap.Protocol.Muesliswap_v2]: Dex.MuesliSwap,
+    [Swap.Protocol.Muesliswap_clp]: Dex.MuesliSwap,
+    [Swap.Protocol.Muesliswap_orderbook]: Dex.MuesliSwap,
+    [Swap.Protocol.Spectrum_v1]: Dex.Spectrum,
+    [Swap.Protocol.Splash_v1]: Dex.Splash,
+    [Swap.Protocol.Splash_v4]: Dex.Splash,
+    [Swap.Protocol.Splash_v5]: Dex.Splash,
+    [Swap.Protocol.Splash_v6]: Dex.Splash,
+    [Swap.Protocol.Sundaeswap_v1]: Dex.SundaeSwap,
+    [Swap.Protocol.Sundaeswap_v3]: Dex.SundaeSwapV3,
+    [Swap.Protocol.Vyfi_v1]: Dex.VyFi,
+    [Swap.Protocol.Wingriders_v1]: Dex.WingRiders,
+    [Swap.Protocol.Wingriders_v2]: Dex.WingRidersV2,
+    [Swap.Protocol.Wingriders_stable]: Dex.WingRidersV2,
+    [Swap.Protocol.Teddy_v1]: Dex.Unsupported,
+    [Swap.Protocol.Snekfun]: Dex.Unsupported,
+    [Swap.Protocol.Chadswap]: Dex.Unsupported,
+    [Swap.Protocol.Cerra]: Dex.Unsupported,
+    [Swap.Protocol.Unsupported]: Dex.Unsupported,
+  }
+
+  return protocolMap[dex] ?? Dex.Unsupported
+}
+
+export const SteelswapProtocols = Object.values(Dex)
+  .filter((p) => p !== Dex.Unsupported)
+  .map(toSwapProtocol)

--- a/mobile/packages/swap/adapters/api/steelswap/types.ts
+++ b/mobile/packages/swap/adapters/api/steelswap/types.ts
@@ -1,0 +1,193 @@
+import {FetchData} from '@yoroi/common'
+import {Chain, Portfolio} from '@yoroi/types'
+
+export const Dex = {
+  CSWAP: 'CSWAP',
+  GeniusYield: 'GeniusYield',
+  Minswap: 'Minswap',
+  MinswapV2: 'MinswapV2',
+  MinswapV2Router: 'MinswapV2Router',
+  MuesliSwap: 'MuesliSwap',
+  Spectrum: 'Spectrum',
+  Splash: 'Splash',
+  SplashRouter: 'SplashRouter',
+  SundaeSwap: 'SundaeSwap',
+  SundaeSwapV3: 'SundaeSwapV3',
+  VyFi: 'VyFi',
+  WingRiders: 'WingRiders',
+  WingRidersV2: 'WingRidersV2',
+  Unsupported: 'Unsupported',
+} as const
+
+export type Dex = (typeof Dex)[keyof typeof Dex]
+
+export type Partners =
+  | ''
+  | 'eternl-aggregator'
+  | 'eternl-browser'
+  | 'farmbot'
+  | 'lace-aggregator'
+  | 'yoroi-aggregator'
+  | string
+
+export type TxStatus = 'txPending' | 'queued' | 'executed' | 'cancelled'
+
+export type OrderType = 0 | 1 | 2
+
+export type Assets = Record<string, number>
+
+export type TokenSummary = {
+  ticker: string
+  name: string
+  policyId: string
+  policyName: string
+  decimals: number
+  priceNumerator?: number
+  priceDenominator?: number
+  sources?: string[]
+}
+
+export type TokensResponse = Array<TokenSummary>
+
+export type PoolOutput = {
+  dex: string
+  poolId: string
+  quantityA: number
+  quantityB: number
+  batcherFee: number
+  deposit: number
+  volumeFee: number
+}
+
+export type SplitOutput = {
+  tokenA: string
+  quantityA: number
+  tokenB: string
+  quantityB: number
+  totalFee: number
+  totalDeposit: number
+  steelswapFee: number
+  bonusOut: number
+  price: number
+  pools: Array<PoolOutput>
+}
+
+export type HopSplitOutput = {
+  tokenA: string
+  quantityA: number
+  tokenB: string
+  quantityB: number
+  totalFee: number
+  totalDeposit: number
+  steelswapFee: number
+  bonusOut: number
+  price: number
+  splitGroup: Array<Array<SplitOutput>>
+}
+
+export type EstimateResponse = SplitOutput | HopSplitOutput
+
+export type SwapEstimateRequest = {
+  tokenA: string
+  tokenB: string
+  quantity: number
+  predictFromOutputAmount?: boolean
+  ignoreDexes?: string[]
+  partner?: Partners | null
+  hop?: boolean
+  da?: Array<Record<string, number | string>> | string | null
+  isFloat?: boolean
+}
+
+export type BuildSwapRequest = {
+  tokenA: string
+  tokenB: string
+  quantity: number
+  predictFromOutputAmount?: boolean
+  ignoreDexes?: string[]
+  partner?: Partners | null
+  hop?: boolean
+  da?: Array<Record<string, number | string>> | string | null
+  address: string
+  forwardAddress?: string | null
+  utxos: string[]
+  collateral?: string[] | null
+  slippage: number
+  changeAddress?: string | null
+  pAddress?: string | null
+  feeAdust?: boolean
+  ttl?: number
+  isFloat?: boolean
+}
+
+export type BuildSwapResponse = {
+  tx: string
+  p: boolean
+}
+
+export type SwapStatus = {
+  dex: string
+  orderType: OrderType
+  txStatus: TxStatus
+  submitTxHash: string
+  submitTxIndex: number
+  submitTime: number
+  submitAssets: Array<Record<string, number>> | null
+  requestAssets: Array<Record<string, number>> | null
+  executeTxHash: string | null
+  executeTxIndex: number | null
+  executeTime: number | null
+  receivedAssets: Array<Record<string, number>> | null
+}
+
+export type OrderStatus = {
+  source: string
+  firstObserved: number
+  lastUpdated: number
+  totalSubmitted: Assets
+  totalRequested: Assets
+  totalReceived: Assets
+  swaps: Array<SwapStatus>
+}
+
+export type OrderStatusResponse = {
+  orders: Array<OrderStatus>
+  page: number
+  lastPage: number
+}
+
+export type SwapHistoryRequest = {
+  addresses: string[]
+  txType?: string[]
+  page?: number
+  pageSize?: number
+  isFloat?: boolean
+}
+
+export type TxRef = {
+  txHash: string
+  txIndex: number
+}
+
+export type CancelRequest = {
+  utxos?: string[] | null
+  txList: Array<TxRef>
+  collateralUtxo?: string | null
+  ttl: number
+  changeAddress?: string | null
+  partner?: Partners | null
+}
+
+export type CancelResponse = string
+
+export type SteelswapApiConfig = {
+  partner?: string
+  address: string
+  primaryTokenInfo: Portfolio.Token.Info
+  isPrimaryToken: (token: string | null | undefined) => boolean
+  network: Chain.SupportedNetworks
+  request?: FetchData
+}
+
+// Internal config for transformers
+export type SteelswapTransformersConfig = SteelswapApiConfig

--- a/mobile/packages/swap/adapters/docs/steelswap.api.md
+++ b/mobile/packages/swap/adapters/docs/steelswap.api.md
@@ -1,0 +1,28 @@
+# Steelswap API Documentation
+
+**Base API URL:** `https://yoroi.steelswap.io`
+
+**Authentication:** All requests must include the `token` header with the partner token:
+
+```
+token: yoroi-xEwoVRkAcYSn4fgxsx5kS2ZJRBxPzAe15GyyG8FZVJEgn7e9UHfVZ07FwUBUAbmM
+```
+
+## Supported DEXes
+
+The following DEXes are supported by Steelswap:
+
+- CSWAP
+- GeniusYield
+- Minswap
+- MinswapV2
+- MinswapV2Router
+- MuesliSwap
+- Spectrum
+- Splash
+- SplashRouter
+- SundaeSwap
+- SundaeSwapV3
+- VyFi
+- WingRiders
+- WingRidersV2

--- a/mobile/packages/swap/manager.ts
+++ b/mobile/packages/swap/manager.ts
@@ -6,6 +6,7 @@ import {freeze} from 'immer'
 import {dexhunterApiMaker} from './adapters/api/dexhunter/api-maker'
 import {minswapApiMaker} from './adapters/api/minswap/api-maker'
 import {muesliswapApiMaker} from './adapters/api/muesliswap/api-maker'
+import {steelswapApiMaker} from './adapters/api/steelswap/api-maker'
 import {getBestSwap} from './helpers/getBestSwap'
 import {getPtPrice} from './helpers/getPtPrice'
 
@@ -42,6 +43,13 @@ export const swapManagerMaker: Swap.ManagerMaker = ({
     isPrimaryToken,
     partner: partners?.[Swap.Aggregator.Minswap],
   })
+  const steelswapApi = steelswapApiMaker({
+    address,
+    network,
+    primaryTokenInfo,
+    isPrimaryToken,
+    partner: partners?.[Swap.Aggregator.Steelswap],
+  })
 
   const settings: Swap.ManagerSettings = {
     routingPreference: 'auto',
@@ -58,12 +66,23 @@ export const swapManagerMaker: Swap.ManagerMaker = ({
 
   storage.settings.read().then(assignSettings)
 
+  // Only include adapters that have a partner code in the partners object
+  const adapters: Partial<Record<Swap.Aggregator, Swap.Api>> = {}
+  if (partners?.[Swap.Aggregator.Dexhunter]) {
+    adapters[Swap.Aggregator.Dexhunter] = dexhunterApi
+  }
+  if (partners?.[Swap.Aggregator.Muesliswap]) {
+    adapters[Swap.Aggregator.Muesliswap] = muesliswapApi
+  }
+  if (partners?.[Swap.Aggregator.Minswap]) {
+    adapters[Swap.Aggregator.Minswap] = minswapApi
+  }
+  if (partners?.[Swap.Aggregator.Steelswap]) {
+    adapters[Swap.Aggregator.Steelswap] = steelswapApi
+  }
+
   const api = apiManagerMaker(
-    {
-      [Swap.Aggregator.Dexhunter]: dexhunterApi,
-      [Swap.Aggregator.Muesliswap]: muesliswapApi,
-      [Swap.Aggregator.Minswap]: minswapApi,
-    },
+    adapters as Record<Swap.Aggregator, Swap.Api>,
     settings,
     getPtPrice(primaryTokenInfo, dexhunterApi),
   )
@@ -77,7 +96,7 @@ export const swapManagerMaker: Swap.ManagerMaker = ({
 }
 
 const apiManagerMaker = (
-  adapters: Record<Swap.Aggregator, Swap.Api>,
+  adapters: Partial<Record<Swap.Aggregator, Swap.Api>>,
   settings: Swap.ManagerSettings,
   getPrice: (id: Portfolio.Token.Id) => Promise<number>,
 ): Swap.Api => {
@@ -86,7 +105,10 @@ const apiManagerMaker = (
     if (settings.routingPreference === 'auto') {
       return Object.keys(adapters) as Swap.Aggregator[]
     }
-    return settings.routingPreference
+    // Filter to only include aggregators that exist in adapters
+    return settings.routingPreference.filter(
+      (agg) => adapters[agg] !== undefined,
+    )
   }
 
   return freeze(
@@ -95,7 +117,9 @@ const apiManagerMaker = (
         const enabledAggregators = getEnabledAggregators()
 
         const settledResults = await Promise.allSettled(
-          enabledAggregators.map((aggregator) => adapters[aggregator].tokens()),
+          enabledAggregators.map((aggregator) =>
+            adapters[aggregator]!.tokens(),
+          ),
         )
 
         const responses: Array<Api.Response<Portfolio.Token.Info[]>> = []
@@ -140,10 +164,14 @@ const apiManagerMaker = (
       },
 
       async orders() {
-        const enabledAggregators = Object.keys(adapters) as Swap.Aggregator[]
+        const enabledAggregators = Object.keys(adapters).filter(
+          (agg) => adapters[agg as Swap.Aggregator] !== undefined,
+        ) as Swap.Aggregator[]
 
         const responses: Array<Api.Response<Swap.Order[]>> = await Promise.all(
-          enabledAggregators.map((aggregator) => adapters[aggregator].orders()),
+          enabledAggregators.map((aggregator) =>
+            adapters[aggregator]!.orders(),
+          ),
         )
 
         warnAllLeft(...responses)
@@ -191,7 +219,7 @@ const apiManagerMaker = (
         const responses: Array<Api.Response<Swap.LimitOptionsResponse>> =
           await Promise.all(
             enabledAggregators.map((aggregator) =>
-              adapters[aggregator].limitOptions(body),
+              adapters[aggregator]!.limitOptions(body),
             ),
           )
 
@@ -240,7 +268,7 @@ const apiManagerMaker = (
         const settledResults = await Promise.allSettled(
           enabledAggregators.map(async (aggregator) => {
             // If amountOut is provided and adapter supports reverse estimate, rely on adapter implementation.
-            const response = await adapters[aggregator].estimate(body)
+            const response = await adapters[aggregator]!.estimate(body)
             return response
           }),
         )
@@ -315,7 +343,7 @@ const apiManagerMaker = (
         const responses: Array<Api.Response<Swap.CreateResponse>> =
           await Promise.all(
             enabledAggregators.map((aggregator) =>
-              adapters[aggregator].create(body),
+              adapters[aggregator]!.create(body),
             ),
           )
 
@@ -358,10 +386,14 @@ const apiManagerMaker = (
         // First, try the appropriate adapter based on aggregator
         const initialAdapter =
           body.order.aggregator === Swap.Aggregator.Muesliswap
-            ? adapters.muesliswap
+            ? adapters[Swap.Aggregator.Muesliswap]
             : body.order.aggregator === Swap.Aggregator.Minswap
-              ? adapters.minswap
-              : adapters.dexhunter
+              ? adapters[Swap.Aggregator.Minswap]
+              : body.order.aggregator === Swap.Aggregator.Steelswap
+                ? adapters[Swap.Aggregator.Steelswap]
+                : adapters[Swap.Aggregator.Dexhunter]
+
+        if (!initialAdapter) return invalid
 
         const initialResponse = await initialAdapter.cancel(body)
 

--- a/mobile/packages/types/swap/aggregator.ts
+++ b/mobile/packages/types/swap/aggregator.ts
@@ -2,6 +2,7 @@ export const SwapAggregator = Object.freeze({
   Muesliswap: 'muesliswap',
   Dexhunter: 'dexhunter',
   Minswap: 'minswap',
+  Steelswap: 'steelswap',
 } as const)
 
 export type SwapAggregator =

--- a/mobile/packages/types/swap/protocol.ts
+++ b/mobile/packages/types/swap/protocol.ts
@@ -16,7 +16,7 @@ export const SwapProtocol = Object.freeze({
   Wingriders_v1: 'wingriders-v1',
   Wingriders_v2: 'wingriders-v2',
   Wingriders_stable: 'wingriders-stable',
-  Splash_v1: 'splash-v1',
+  Splash_v1: 'splash',
   Splash_v4: 'splash-v4',
   Splash_v5: 'splash-v5',
   Splash_v6: 'splash-v6',

--- a/mobile/src/features/Discover/common/helpers.ts
+++ b/mobile/src/features/Discover/common/helpers.ts
@@ -50,6 +50,74 @@ export interface DAppItem {
 }
 
 const googleDappId = 'google_search'
+const directUrlId = 'direct_url'
+
+/**
+ * Checks if a string looks like a URL
+ * Matches patterns like:
+ * - example.com
+ * - www.example.com
+ * - http://example.com
+ * - https://example.com
+ * - example.com/path
+ */
+export const looksLikeUrl = (str: string): boolean => {
+  if (!str || str.trim() === '') return false
+
+  const trimmed = str.trim()
+
+  // Check if it already has a protocol
+  if (hasProtocol(trimmed)) {
+    try {
+      const url = new URL(trimmed)
+      return !!url
+    } catch {
+      return false
+    }
+  }
+
+  // Check for domain-like patterns (contains a dot and looks like a domain)
+  // Matches: example.com, www.example.com, subdomain.example.com
+  // But not: just words, single word, or strings without dots
+  const domainPattern =
+    /^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}(\/.*)?$/
+
+  // Also check for localhost patterns
+  const localhostPattern = /^localhost(:\d+)?(\/.*)?$/i
+
+  return domainPattern.test(trimmed) || localhostPattern.test(trimmed)
+}
+
+export const getDirectUrlItem = (url: string): DAppItem => {
+  const normalizedUrl = urlWithProtocol(url)
+  try {
+    const parsedUrl = new URL(normalizedUrl)
+    const domainName = parsedUrl.hostname.replace(/^www\./, '')
+
+    return {
+      id: directUrlId,
+      name: domainName,
+      description: 'Navigate to URL',
+      category: 'url',
+      logo: '',
+      uri: normalizedUrl,
+      origins: [parsedUrl.origin],
+      isSingleAddress: false,
+    }
+  } catch {
+    // Fallback if URL parsing fails
+    return {
+      id: directUrlId,
+      name: url,
+      description: 'Navigate to URL',
+      category: 'url',
+      logo: '',
+      uri: normalizedUrl,
+      origins: [],
+      isSingleAddress: false,
+    }
+  }
+}
 
 export const getGoogleSearchItem = (searchQuery: string): DAppItem => ({
   id: googleDappId,
@@ -63,6 +131,7 @@ export const getGoogleSearchItem = (searchQuery: string): DAppItem => ({
 })
 
 export const isGoogleSearchItem = (dApp: DAppItem) => dApp.id === googleDappId
+export const isDirectUrlItem = (dApp: DAppItem) => dApp.id === directUrlId
 
 type CreateDappConnectorOptions = {
   appStorage: App.Storage

--- a/mobile/src/features/Discover/useCases/SearchDappInBrowser/SearchDappInBrowserScreen.tsx
+++ b/mobile/src/features/Discover/useCases/SearchDappInBrowser/SearchDappInBrowserScreen.tsx
@@ -7,7 +7,12 @@ import {v4} from 'uuid'
 
 import {useBrowser} from '~/features/Discover/common/BrowserProvider'
 
-import {getGoogleSearchItem, urlWithProtocol} from '../../common/helpers'
+import {
+  getDirectUrlItem,
+  getGoogleSearchItem,
+  looksLikeUrl,
+  urlWithProtocol,
+} from '../../common/helpers'
 import {useNavigateTo} from '../../common/useNavigateTo'
 import {BrowserSearchToolbar} from '../BrowseDapp/BrowserSearchToolbar'
 import {DAppListItem} from '../SelectDappFromList/DAppListItem/DAppListItem'
@@ -27,6 +32,8 @@ export const SearchDappInBrowserScreen = () => {
   const tabActive = tabs[tabActiveIndex]
   const [searchValue, setSearchValue] = React.useState('')
   const isFocused = useIsFocused()
+  const isUrl = looksLikeUrl(searchValue)
+  const directUrlItem = isUrl ? getDirectUrlItem(searchValue) : null
   const googleItem = getGoogleSearchItem(searchValue)
 
   const handleGoBack = () => {
@@ -79,12 +86,22 @@ export const SearchDappInBrowserScreen = () => {
 
       <ScrollView style={[a.p_lg]}>
         {searchValue !== '' && (
-          <DAppListItem
-            key={googleItem.id}
-            dApp={googleItem}
-            connected={false}
-            onPress={() => handleSubmit(true)}
-          />
+          <>
+            {isUrl && directUrlItem && (
+              <DAppListItem
+                key={directUrlItem.id}
+                dApp={directUrlItem}
+                connected={false}
+                onPress={() => handleSubmit(false)}
+              />
+            )}
+            <DAppListItem
+              key={googleItem.id}
+              dApp={googleItem}
+              connected={false}
+              onPress={() => handleSubmit(true)}
+            />
+          </>
         )}
       </ScrollView>
     </View>

--- a/mobile/src/features/Discover/useCases/SelectDappFromList/DAppListItem/DAppListItem.tsx
+++ b/mobile/src/features/Discover/useCases/SelectDappFromList/DAppListItem/DAppListItem.tsx
@@ -30,6 +30,7 @@ import {WarningBanner} from '~/ui/WarningBanner/WarningBanner'
 import {
   type DAppItem,
   getDappFallbackLogo,
+  isDirectUrlItem,
   isGoogleSearchItem,
 } from '../../../common/helpers'
 
@@ -97,7 +98,7 @@ export const DAppListItem = ({dApp, connected, onPress}: Props) => {
   const handlePress = () => {
     if (onPress) return onPress()
 
-    if (!connected || isGoogleSearchItem(dApp)) {
+    if (!connected || isGoogleSearchItem(dApp) || isDirectUrlItem(dApp)) {
       return handleOpenDApp()
     }
 
@@ -167,6 +168,8 @@ export const DAppListItem = ({dApp, connected, onPress}: Props) => {
       <View style={[{flexDirection: 'row', gap: 12}]}>
         {isGoogleSearchItem(dApp) ? (
           <Icon.Google />
+        ) : isDirectUrlItem(dApp) ? (
+          <Icon.Globe />
         ) : (
           <Image
             source={{uri: logo}}
@@ -202,7 +205,7 @@ export const DAppListItem = ({dApp, connected, onPress}: Props) => {
 
             {dApp.isSingleAddress && <LabelSingleAddress />}
 
-            {!isGoogleSearchItem(dApp) && (
+            {!isGoogleSearchItem(dApp) && !isDirectUrlItem(dApp) && (
               <LabelCategoryDApp category={dApp.category} />
             )}
           </View>

--- a/mobile/src/features/Notifications/common/tools.ts
+++ b/mobile/src/features/Notifications/common/tools.ts
@@ -227,7 +227,7 @@ const handleInternalNavigation = async (
           walletNavigation.navigateToGovernanceCentre()
           break
         case 'discover':
-          walletNavigation.navigateToDiscoverBrowserDapp()
+          walletNavigation.navigateToDiscoverDappSelection()
           break
       }
     } catch (error) {

--- a/mobile/src/features/Settings/ui/screens/ChangeApplicationSettingsScreen/AboutScreen/useFCMToken.ts
+++ b/mobile/src/features/Settings/ui/screens/ChangeApplicationSettingsScreen/AboutScreen/useFCMToken.ts
@@ -3,10 +3,12 @@ import {useQuery} from '@tanstack/react-query'
 import * as Notifications from 'expo-notifications'
 import * as React from 'react'
 
-import {isDev, isNightly} from '~/kernel/constants'
+import {useAuth} from '~/features/Auth/context/AuthProvider'
+import {isNightly} from '~/kernel/constants'
 
 export const useFCMToken = () => {
   const [hasPermission, setHasPermission] = React.useState(false)
+  const {isAuthDev} = useAuth()
 
   React.useEffect(() => {
     Notifications.getPermissionsAsync().then(({status}) => {
@@ -15,9 +17,9 @@ export const useFCMToken = () => {
   }, [])
 
   const {data: FCMToken} = useQuery({
-    queryKey: ['fcmToken'],
+    queryKey: ['fcmToken', isAuthDev],
     queryFn: () => getToken(getMessaging()),
-    enabled: (isNightly || isDev) && hasPermission,
+    enabled: (isNightly || isAuthDev) && hasPermission,
   })
 
   return FCMToken

--- a/mobile/src/features/Staking/Governance/common/useGovernanceVoteFlow.ts
+++ b/mobile/src/features/Staking/Governance/common/useGovernanceVoteFlow.ts
@@ -1,0 +1,148 @@
+import {Wallet} from '@yoroi/types'
+
+import {Certificate} from '@emurgo/cross-csl-core'
+import * as React from 'react'
+
+import {useCreateGovernanceTx} from '~/features/Staking/hooks/useCreateGovernanceTx'
+import {UsePromiseOptionsWithoutPromise} from '~/hooks/usePromise'
+import {YoroiWallet} from '~/wallets/cardano/types'
+import {YoroiUnsignedTx} from '~/wallets/types/yoroi'
+
+import {useGovernanceActions} from './helpers'
+
+type PendingVote = 'abstain' | 'no-confidence' | 'delegate' | null
+
+type DelegateOptions = {
+  hash: string
+  type: 'key' | 'script'
+  CIP105: boolean
+}
+
+type PendingAction =
+  | {type: 'delegate'; options: DelegateOptions}
+  | {type: 'abstain'}
+  | {type: 'no-confidence'}
+  | null
+
+type UseGovernanceVoteFlowOptions = UsePromiseOptionsWithoutPromise<
+  YoroiUnsignedTx,
+  [{certificates: Certificate[]; addressMode: Wallet.AddressMode}]
+>
+
+export const useGovernanceVoteFlow = ({
+  wallet,
+  addressMode,
+  options,
+}: {
+  wallet: YoroiWallet
+  addressMode: Wallet.AddressMode
+  options?: UseGovernanceVoteFlowOptions
+}) => {
+  const governanceActions = useGovernanceActions()
+
+  const [pendingVote, setPendingVote] = React.useState<PendingVote>(null)
+  const pendingActionRef = React.useRef<PendingAction>(null)
+  const {
+    onSuccess: optionsOnSuccess,
+    onError: optionsOnError,
+    ...rest
+  } = options ?? {}
+
+  const resetPendingState = () => {
+    setPendingVote(null)
+    pendingActionRef.current = null
+  }
+
+  const createGovernanceTxMutation = useCreateGovernanceTx(wallet, {
+    ...rest,
+    onSuccess: (unsignedTx) => {
+      if (pendingActionRef.current?.type === 'delegate') {
+        const {hash, type, CIP105} = pendingActionRef.current.options
+        governanceActions.handleDelegateAction({
+          unsignedTx,
+          hash,
+          type,
+          CIP105,
+        })
+        resetPendingState()
+        optionsOnSuccess?.(unsignedTx)
+        return
+      }
+
+      if (pendingActionRef.current?.type === 'abstain') {
+        governanceActions.handleAbstainAction({
+          unsignedTx,
+        })
+        resetPendingState()
+        optionsOnSuccess?.(unsignedTx)
+        return
+      }
+
+      if (pendingActionRef.current?.type === 'no-confidence') {
+        governanceActions.handleNoConfidenceAction({
+          unsignedTx,
+        })
+        resetPendingState()
+        optionsOnSuccess?.(unsignedTx)
+        return
+      }
+
+      resetPendingState()
+      optionsOnSuccess?.(unsignedTx)
+    },
+    onError: (error) => {
+      resetPendingState()
+      optionsOnError?.(error)
+    },
+  })
+
+  const setDelegatePending = (options: DelegateOptions) => {
+    setPendingVote('delegate')
+    pendingActionRef.current = {type: 'delegate', options}
+  }
+
+  const setAbstainPending = () => {
+    setPendingVote('abstain')
+    pendingActionRef.current = {type: 'abstain'}
+  }
+
+  const setNoConfidencePending = () => {
+    setPendingVote('no-confidence')
+    pendingActionRef.current = {type: 'no-confidence'}
+  }
+
+  const submitDelegate = (
+    certificates: Certificate[],
+    options: DelegateOptions,
+  ) => {
+    setDelegatePending(options)
+    createGovernanceTxMutation.resolve({
+      certificates,
+      addressMode,
+    })
+  }
+
+  const submitAbstain = (certificates: Certificate[]) => {
+    setAbstainPending()
+    createGovernanceTxMutation.resolve({
+      certificates,
+      addressMode,
+    })
+  }
+
+  const submitNoConfidence = (certificates: Certificate[]) => {
+    setNoConfidencePending()
+    createGovernanceTxMutation.resolve({
+      certificates,
+      addressMode,
+    })
+  }
+
+  return {
+    pendingVote,
+    isCreatingTx: createGovernanceTxMutation.isPending,
+    submitDelegate,
+    submitAbstain,
+    submitNoConfidence,
+  } as const
+}

--- a/mobile/src/features/Staking/Governance/useCases/ChangeVote/ChangeVoteScreen.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/ChangeVote/ChangeVoteScreen.tsx
@@ -16,7 +16,6 @@ import {ScrollView} from 'react-native-gesture-handler'
 import {useRemoteConfig} from '~/features/RemoteConfig/hooks/useRemoteConfig'
 import {LearnMoreLink} from '~/features/Staking/Governance/common/LearnMoreLink/LearnMoreLink'
 import {YoroiRecordLink} from '~/features/Staking/Governance/common/YoroiRecordLink/YoroiRecordLink'
-import {useCreateGovernanceTx} from '~/features/Staking/hooks/useCreateGovernanceTx'
 import {useStakingKey} from '~/features/Staking/hooks/useStakingKey'
 import {useSelectedWallet} from '~/features/WalletManager/hooks/useSelectedWallet'
 import {useStrings} from '~/kernel/i18n/useStrings'
@@ -24,10 +23,8 @@ import {useModal} from '~/ui/Modal/context/ModalContext'
 import {Space} from '~/ui/Space/Space'
 
 import {Action} from '../../common/Action/Action'
-import {
-  mapStakingKeyStateToGovernanceAction,
-  useGovernanceActions,
-} from '../../common/helpers'
+import {mapStakingKeyStateToGovernanceAction} from '../../common/helpers'
+import {useGovernanceVoteFlow} from '../../common/useGovernanceVoteFlow'
 import {EnterDrepIdModal} from '../EnterDrepIdModal/EnterDrepIdModal'
 
 export const ChangeVoteScreen = () => {
@@ -43,47 +40,24 @@ export const ChangeVoteScreen = () => {
     : null
   const {openModal} = useModal()
   const {manager} = useGovernance()
-  const [pendingVote, setPendingVote] = React.useState<
-    | 'abstain'
-    | 'no-confidence'
-    | 'delegate-to-yoroi'
-    | 'delegate-not-yoroi'
-    | null
-  >(null)
-  const governanceActions = useGovernanceActions()
 
   const createDelegationCertificate = useDelegationCertificate()
   const createVotingCertificate = useVotingCertificate()
 
-  const createGovernanceTxMutation = useCreateGovernanceTx(wallet)
-  const [pendingDelegateOptions, setPendingDelegateOptions] = React.useState<{
-    hash: string
-    type: 'key' | 'script'
-    CIP105: boolean
-  } | null>(null)
-
-  React.useEffect(() => {
-    if (
-      pendingDelegateOptions &&
-      createGovernanceTxMutation.value &&
-      !createGovernanceTxMutation.isPending
-    ) {
-      governanceActions.handleDelegateAction({
-        unsignedTx: createGovernanceTxMutation.value,
-        hash: pendingDelegateOptions.hash,
-        type: pendingDelegateOptions.type,
-        CIP105: pendingDelegateOptions.CIP105,
-      })
-      setPendingDelegateOptions(null)
-    }
-  }, [
-    pendingDelegateOptions,
-    createGovernanceTxMutation.value,
-    createGovernanceTxMutation.isPending,
-    governanceActions,
-  ])
+  const {
+    pendingVote,
+    isCreatingTx,
+    submitDelegate,
+    submitAbstain,
+    submitNoConfidence,
+  } = useGovernanceVoteFlow({
+    wallet,
+    addressMode: meta.addressMode,
+  })
 
   if (!isNonNullable(action)) throw new Error('User has never voted')
+
+  const isPending = isCreatingTx || pendingVote !== null
 
   const openDRepIdModal = (
     onSubmit: (options: {
@@ -104,10 +78,9 @@ export const ChangeVoteScreen = () => {
   }
 
   const handleDelegate = () => {
+    if (isPending) return
     openDRepIdModal(async (options) => {
       const stakingKey = wallet.getStakingKey()
-
-      setPendingVote('delegate-not-yoroi')
 
       const certificate = await createDelegationCertificate({
         hash: options.hash,
@@ -115,23 +88,19 @@ export const ChangeVoteScreen = () => {
         stakingKey,
       })
 
-      setPendingDelegateOptions({
-        hash: options.hash,
-        type: options.type,
-        CIP105: options.CIP105,
-      })
-
-      createGovernanceTxMutation.resolve({
-        certificates: [certificate],
-        addressMode: meta.addressMode,
-      })
+      submitDelegate([certificate], options)
     })
   }
 
   const handleDelegateToYoroi = async () => {
+    if (isPending) return
     const stakingKey = wallet.getStakingKey()
 
-    setPendingVote('delegate-to-yoroi')
+    const options = {
+      hash: GOVERNANCE_YOROI_DREP_ID_HEX,
+      type: 'key' as const,
+      CIP105: false,
+    }
 
     const certificate = await createDelegationCertificate({
       hash: GOVERNANCE_YOROI_DREP_ID_HEX,
@@ -139,67 +108,36 @@ export const ChangeVoteScreen = () => {
       stakingKey,
     })
 
-    createGovernanceTxMutation.resolve({
-      certificates: [certificate],
-      addressMode: meta.addressMode,
-    })
-
-    if (createGovernanceTxMutation.value) {
-      governanceActions.handleDelegateAction({
-        unsignedTx: createGovernanceTxMutation.value,
-        hash: GOVERNANCE_YOROI_DREP_ID_HEX,
-        type: 'key',
-        CIP105: false,
-      })
-    }
+    submitDelegate([certificate], options)
   }
 
   const handleAbstain = async () => {
+    if (isPending) return
     const stakingKey = wallet.getStakingKey()
-    setPendingVote('abstain')
 
     const certificate = await createVotingCertificate({
       vote: 'abstain',
       stakingKey,
     })
 
-    createGovernanceTxMutation.resolve({
-      certificates: [certificate],
-      addressMode: meta.addressMode,
-    })
-
-    if (createGovernanceTxMutation.value) {
-      governanceActions.handleAbstainAction({
-        unsignedTx: createGovernanceTxMutation.value,
-      })
-    }
+    submitAbstain([certificate])
   }
 
   const handleNoConfidence = async () => {
+    if (isPending) return
     const stakingKey = wallet.getStakingKey()
-    setPendingVote('no-confidence')
 
     const certificate = await createVotingCertificate({
       vote: 'no-confidence',
       stakingKey,
     })
 
-    createGovernanceTxMutation.resolve({
-      certificates: [certificate],
-      addressMode: meta.addressMode,
-    })
-
-    if (createGovernanceTxMutation.value) {
-      governanceActions.handleNoConfidenceAction({
-        unsignedTx: createGovernanceTxMutation.value,
-      })
-    }
+    submitNoConfidence([certificate])
   }
 
   const voteKind = action?.kind
   const voteHash =
     voteKind === 'delegate' && action != null ? action.hash : undefined
-  const isCreatingTx = createGovernanceTxMutation.isPending
   const isDelegatingNotToYoroiDrep =
     voteKind === 'delegate' && voteHash !== GOVERNANCE_YOROI_DREP_ID_HEX
 
@@ -220,7 +158,7 @@ export const ChangeVoteScreen = () => {
               title={strings.staking.delegateToAYoroiDrep}
               description={strings.staking.delegateToAYoroiDRepDescription}
               onPress={handleDelegateToYoroi}
-              pending={isCreatingTx && pendingVote === 'delegate-to-yoroi'}
+              pending={isCreatingTx && pendingVote === 'delegate'}
               showGradient
             >
               <YoroiRecordLink />
@@ -232,7 +170,7 @@ export const ChangeVoteScreen = () => {
             title={strings.staking.actionDelegateToADRepTitle}
             description={strings.staking.actionDelegateToADRepDescription}
             onPress={handleDelegate}
-            pending={isCreatingTx && pendingVote === 'delegate-not-yoroi'}
+            pending={isCreatingTx && pendingVote === 'delegate'}
           />
         )}
 
@@ -241,7 +179,7 @@ export const ChangeVoteScreen = () => {
             title={strings.staking.changeDRep}
             description={strings.staking.actionDelegateToADRepDescription}
             onPress={handleDelegate}
-            pending={isCreatingTx && pendingVote === 'delegate-not-yoroi'}
+            pending={isCreatingTx && pendingVote === 'delegate'}
           />
         )}
 

--- a/mobile/src/features/Staking/Governance/useCases/Home/HomeScreen.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/Home/HomeScreen.tsx
@@ -11,7 +11,7 @@ import {
 import {ThemedPalette, atoms as a, useTheme} from '@yoroi/theme'
 
 import {NotEnoughMoneyToSendError} from '@emurgo/yoroi-lib/dist/errors'
-import React, {type ReactNode} from 'react'
+import * as React from 'react'
 import {Text, View} from 'react-native'
 import {ScrollView} from 'react-native-gesture-handler'
 
@@ -19,7 +19,6 @@ import {useRemoteConfig} from '~/features/RemoteConfig/hooks/useRemoteConfig'
 import {LearnMoreLink} from '~/features/Staking/Governance/common/LearnMoreLink/LearnMoreLink'
 import {YoroiRecordLink} from '~/features/Staking/Governance/common/YoroiRecordLink/YoroiRecordLink'
 import {formatDrepHashToCIP129Format} from '~/features/Staking/Governance/common/drep'
-import {useCreateGovernanceTx} from '~/features/Staking/hooks/useCreateGovernanceTx'
 import {useStakingInfo} from '~/features/Staking/hooks/useStakingInfo'
 import {useStakingKey} from '~/features/Staking/hooks/useStakingKey'
 import {useTransactionInfos} from '~/features/Transactions/hooks/useTransactionInfos'
@@ -31,11 +30,9 @@ import {Space} from '~/ui/Space/Space'
 import {TransactionInfo} from '~/wallets/types/other'
 
 import {Action} from '../../common/Action/Action'
-import {
-  mapStakingKeyStateToGovernanceAction,
-  useGovernanceActions,
-} from '../../common/helpers'
+import {mapStakingKeyStateToGovernanceAction} from '../../common/helpers'
 import {useNavigateTo} from '../../common/navigation'
+import {useGovernanceVoteFlow} from '../../common/useGovernanceVoteFlow'
 import {GovernanceVote} from '../../types'
 import {EnterDrepIdModal} from '../EnterDrepIdModal/EnterDrepIdModal'
 
@@ -231,7 +228,7 @@ const ParticipatingInGovernanceVariant = ({
 
 const formattingOptions = (p: ThemedPalette) => {
   return {
-    b: (text: ReactNode) => {
+    b: (text: React.ReactNode) => {
       return (
         <Text
           style={[
@@ -244,7 +241,7 @@ const formattingOptions = (p: ThemedPalette) => {
         </Text>
       )
     },
-    textComponent: (text: ReactNode) => (
+    textComponent: (text: React.ReactNode) => (
       <Text style={[a.body_1_lg_regular, {color: p.text_gray_medium}]}>
         {text}
       </Text>
@@ -262,14 +259,6 @@ const NeverParticipatedInGovernanceVariant = () => {
   const {manager} = useGovernance()
   const {openModal} = useModal()
   const stakingInfo = useStakingInfo(wallet)
-  const [pendingVote, setPendingVote] = React.useState<
-    | 'abstain'
-    | 'no-confidence'
-    | 'delegate-to-yoroi'
-    | 'delegate-not-yoroi'
-    | null
-  >(null)
-  const governanceActions = useGovernanceActions()
 
   const hasStakingKeyRegistered = stakingInfo?.data?.status !== 'not-registered'
   useWalletEvent(wallet, 'utxos', stakingInfo.refetch)
@@ -278,17 +267,28 @@ const NeverParticipatedInGovernanceVariant = () => {
   const createDelegationCertificate = useDelegationCertificate()
   const createVotingCertificate = useVotingCertificate()
 
-  const createGovernanceTxMutation = useCreateGovernanceTx(wallet, {
-    shouldThrow: false,
-    onError: (error) => {
-      if (error instanceof NotEnoughMoneyToSendError) {
-        navigateTo.noFunds()
-      } else {
-        // Re-throw other errors to trigger error boundary
+  const {
+    pendingVote,
+    isCreatingTx,
+    submitDelegate,
+    submitAbstain,
+    submitNoConfidence,
+  } = useGovernanceVoteFlow({
+    wallet,
+    addressMode: meta.addressMode,
+    options: {
+      shouldThrow: false,
+      onError: (error) => {
+        if (error instanceof NotEnoughMoneyToSendError) {
+          navigateTo.noFunds()
+          return
+        }
         throw error
-      }
+      },
     },
   })
+
+  const isPending = isCreatingTx || pendingVote !== null
 
   const openDRepIdModal = (
     onSubmit: (options: {
@@ -309,12 +309,11 @@ const NeverParticipatedInGovernanceVariant = () => {
   }
 
   const handleDelegate = () => {
+    if (isPending) return
     openDRepIdModal(async (options) => {
       const stakingKey = wallet.getStakingKey()
 
-      setPendingVote('delegate-not-yoroi')
-
-      const certificate = createDelegationCertificate({
+      const certificate = await createDelegationCertificate({
         hash: options.hash,
         type: options.type,
         stakingKey,
@@ -325,28 +324,21 @@ const NeverParticipatedInGovernanceVariant = () => {
       const certs =
         stakeCert !== null ? [stakeCert, certificate] : [certificate]
 
-      createGovernanceTxMutation.resolve({
-        certificates: certs,
-        addressMode: meta.addressMode,
-      })
-
-      if (createGovernanceTxMutation.value) {
-        governanceActions.handleDelegateAction({
-          unsignedTx: createGovernanceTxMutation.value,
-          hash: options.hash,
-          type: options.type,
-          CIP105: options.CIP105,
-        })
-      }
+      submitDelegate(certs, options)
     })
   }
 
-  const handleDelegateToYoroi = () => {
+  const handleDelegateToYoroi = async () => {
+    if (isPending) return
     const stakingKey = wallet.getStakingKey()
 
-    setPendingVote('delegate-to-yoroi')
+    const options = {
+      hash: GOVERNANCE_YOROI_DREP_ID_HEX,
+      type: 'key' as const,
+      CIP105: false,
+    }
 
-    const certificate = createDelegationCertificate({
+    const certificate = await createDelegationCertificate({
       hash: GOVERNANCE_YOROI_DREP_ID_HEX,
       type: 'key',
       stakingKey,
@@ -356,26 +348,14 @@ const NeverParticipatedInGovernanceVariant = () => {
       : null
     const certs = stakeCert !== null ? [stakeCert, certificate] : [certificate]
 
-    createGovernanceTxMutation.resolve({
-      certificates: certs,
-      addressMode: meta.addressMode,
-    })
-
-    if (createGovernanceTxMutation.value) {
-      governanceActions.handleDelegateAction({
-        unsignedTx: createGovernanceTxMutation.value,
-        hash: GOVERNANCE_YOROI_DREP_ID_HEX,
-        type: 'key',
-        CIP105: false,
-      })
-    }
+    submitDelegate(certs, options)
   }
 
-  const handleAbstain = () => {
+  const handleAbstain = async () => {
+    if (isPending) return
     const stakingKey = wallet.getStakingKey()
-    setPendingVote('abstain')
 
-    const certificate = createVotingCertificate({
+    const certificate = await createVotingCertificate({
       vote: 'abstain',
       stakingKey,
     })
@@ -384,23 +364,14 @@ const NeverParticipatedInGovernanceVariant = () => {
       : null
     const certs = stakeCert !== null ? [stakeCert, certificate] : [certificate]
 
-    createGovernanceTxMutation.resolve({
-      certificates: certs,
-      addressMode: meta.addressMode,
-    })
-
-    if (createGovernanceTxMutation.value) {
-      governanceActions.handleAbstainAction({
-        unsignedTx: createGovernanceTxMutation.value,
-      })
-    }
+    submitAbstain(certs)
   }
 
-  const handleNoConfidence = () => {
+  const handleNoConfidence = async () => {
+    if (isPending) return
     const stakingKey = wallet.getStakingKey()
-    setPendingVote('no-confidence')
 
-    const certificate = createVotingCertificate({
+    const certificate = await createVotingCertificate({
       vote: 'no-confidence',
       stakingKey,
     })
@@ -409,19 +380,8 @@ const NeverParticipatedInGovernanceVariant = () => {
       : null
     const certs = stakeCert !== null ? [stakeCert, certificate] : [certificate]
 
-    createGovernanceTxMutation.resolve({
-      certificates: certs,
-      addressMode: meta.addressMode,
-    })
-
-    if (createGovernanceTxMutation.value) {
-      governanceActions.handleNoConfidenceAction({
-        unsignedTx: createGovernanceTxMutation.value,
-      })
-    }
+    submitNoConfidence(certs)
   }
-
-  const isCreatingTx = createGovernanceTxMutation.isPending
 
   return (
     <ScrollView style={[a.px_lg, a.flex_1, ta.bg_color_max]}>
@@ -439,7 +399,7 @@ const NeverParticipatedInGovernanceVariant = () => {
             title={strings.staking.delegateToAYoroiDrep}
             description={strings.staking.delegateToAYoroiDRepDescription}
             onPress={handleDelegateToYoroi}
-            pending={isCreatingTx && pendingVote === 'delegate-to-yoroi'}
+            pending={isCreatingTx && pendingVote === 'delegate'}
             showGradient
           >
             <YoroiRecordLink />
@@ -450,7 +410,7 @@ const NeverParticipatedInGovernanceVariant = () => {
           title={strings.staking.actionDelegateToADRepTitle}
           description={strings.staking.actionDelegateToADRepDescription}
           onPress={handleDelegate}
-          pending={isCreatingTx && pendingVote === 'delegate-not-yoroi'}
+          pending={isCreatingTx && pendingVote === 'delegate'}
         />
 
         <Action

--- a/mobile/src/features/Swap/common/EstimateSummary/EstimateSummary.tsx
+++ b/mobile/src/features/Swap/common/EstimateSummary/EstimateSummary.tsx
@@ -2,6 +2,7 @@ import {parseNumberFromText} from '@yoroi/common'
 import {atoms as a, useTheme} from '@yoroi/theme'
 import {Swap} from '@yoroi/types'
 
+import _ from 'lodash'
 import * as React from 'react'
 import {Text, View} from 'react-native'
 
@@ -41,6 +42,7 @@ export const EstimateSummary = () => {
 
   const protocol = swapForm.estimate?.splits[0]?.protocol
   const fallbackImageUrl = swapForm.estimate?.splits[0]?.aggregatorImageUrl
+  const aggregator = swapForm.estimate?.splits[0]?.aggregator
   const nameOverride =
     protocol === Swap.Protocol.Unsupported
       ? swapForm.estimate?.splits[0]?.aggregatorDexKey
@@ -62,6 +64,16 @@ export const EstimateSummary = () => {
       ),
     })
 
+  // Build append text: show aggregator if available, or "..." for multiple splits
+  const appendText =
+    aggregator != null
+      ? ` ${strings.swap.via} ${_.upperFirst(aggregator)}${
+          (swapForm.estimate?.splits.length ?? 0) > 1 ? '...' : ''
+        }`
+      : (swapForm.estimate?.splits.length ?? 0) > 1
+        ? '...'
+        : undefined
+
   return (
     <View style={a.p_lg}>
       <Row
@@ -79,9 +91,7 @@ export const EstimateSummary = () => {
                     ? navigateTo.selectProtocol
                     : expand
                 }
-                {...((swapForm.estimate?.splits.length ?? 0) > 1 && {
-                  append: '...',
-                })}
+                {...(appendText && {append: appendText})}
               />
             </View>
           )

--- a/mobile/src/features/Swap/useCases/SwapSettings/SwapSettings.tsx
+++ b/mobile/src/features/Swap/useCases/SwapSettings/SwapSettings.tsx
@@ -7,6 +7,7 @@ import * as React from 'react'
 import {ScrollView, Text, TouchableOpacity, View} from 'react-native'
 import {SafeAreaView} from 'react-native-safe-area-context'
 
+import {useRemoteConfig} from '~/features/RemoteConfig/hooks/useRemoteConfig'
 import {useSwap} from '~/features/Swap/common/useSwap'
 import {useLanguage} from '~/kernel/i18n/LanguageProvider'
 import {useStrings} from '~/kernel/i18n/useStrings'
@@ -57,11 +58,24 @@ const toggleAggregator = (
   }
 }
 
+// Map aggregator keys to display names
+const getAggregatorDisplayName = (aggregator: Swap.Aggregator): string => {
+  const displayNames: Record<Swap.Aggregator, string> = {
+    [Swap.Aggregator.Dexhunter]: 'DexHunter',
+    [Swap.Aggregator.Muesliswap]: 'MuesliSwap',
+    [Swap.Aggregator.Minswap]: 'Minswap',
+    [Swap.Aggregator.Steelswap]: 'SteelSwap',
+  }
+  return displayNames[aggregator] ?? aggregator
+}
+
 export const SwapSettings = () => {
   const {numberLocale} = useLanguage()
   const {palette: p} = useTheme()
+  const {config} = useRemoteConfig()
 
   const swapForm = useSwap()
+  const partners = config?.swap?.partners ?? {}
   const [aggregator, setAggregator] = React.useState(
     swapForm.managerSettings.routingPreference,
   )
@@ -229,59 +243,47 @@ export const SwapSettings = () => {
 
               <SettingsSwitch
                 value={aggregator === 'auto'}
-                onValueChange={() =>
+                onValueChange={() => {
+                  // Build list of enabled aggregators based on partners keys
+                  const enabledAggregators = Object.keys(partners).filter(
+                    (key): key is Swap.Aggregator =>
+                      partners[key as Swap.Aggregator] !== undefined,
+                  ) as Swap.Aggregator[]
                   assignAggregator(
-                    aggregator === 'auto'
-                      ? ['muesliswap', 'dexhunter', 'minswap']
-                      : 'auto',
+                    aggregator === 'auto' ? enabledAggregators : 'auto',
                   )
-                }
+                }}
               />
             </View>
 
             {aggregator !== 'auto' && (
               <>
-                <View style={[a.flex_row, a.justify_between, a.align_center]}>
-                  <Text style={[a.body_1_lg_regular, {color: p.text_gray_max}]}>
-                    DexHunter
-                  </Text>
+                {Object.keys(partners).map((key) => {
+                  const aggregatorKey = key as Swap.Aggregator
+                  return (
+                    <View
+                      key={aggregatorKey}
+                      style={[a.flex_row, a.justify_between, a.align_center]}
+                    >
+                      <Text
+                        style={[a.body_1_lg_regular, {color: p.text_gray_max}]}
+                      >
+                        {getAggregatorDisplayName(aggregatorKey)}
+                      </Text>
 
-                  <SettingsSwitch
-                    value={aggregator.includes('dexhunter')}
-                    onValueChange={() => {
-                      const next = toggleAggregator(aggregator, 'dexhunter')
-                      assignAggregator(next.length === 0 ? 'auto' : next)
-                    }}
-                  />
-                </View>
-
-                <View style={[a.flex_row, a.justify_between, a.align_center]}>
-                  <Text style={[a.body_1_lg_regular, {color: p.text_gray_max}]}>
-                    MuesliSwap
-                  </Text>
-
-                  <SettingsSwitch
-                    value={aggregator.includes('muesliswap')}
-                    onValueChange={() => {
-                      const next = toggleAggregator(aggregator, 'muesliswap')
-                      assignAggregator(next.length === 0 ? 'auto' : next)
-                    }}
-                  />
-                </View>
-
-                <View style={[a.flex_row, a.justify_between, a.align_center]}>
-                  <Text style={[a.body_1_lg_regular, {color: p.text_gray_max}]}>
-                    Minswap
-                  </Text>
-
-                  <SettingsSwitch
-                    value={aggregator.includes('minswap')}
-                    onValueChange={() => {
-                      const next = toggleAggregator(aggregator, 'minswap')
-                      assignAggregator(next.length === 0 ? 'auto' : next)
-                    }}
-                  />
-                </View>
+                      <SettingsSwitch
+                        value={aggregator.includes(aggregatorKey)}
+                        onValueChange={() => {
+                          const next = toggleAggregator(
+                            aggregator,
+                            aggregatorKey,
+                          )
+                          assignAggregator(next.length === 0 ? 'auto' : next)
+                        }}
+                      />
+                    </View>
+                  )
+                })}
               </>
             )}
           </View>

--- a/mobile/src/features/Transactions/TxHistoryNavigator.tsx
+++ b/mobile/src/features/Transactions/TxHistoryNavigator.tsx
@@ -27,7 +27,11 @@ import {SwapNavigator} from '~/features/Swap/navigator'
 import {useSelectedWallet} from '~/features/WalletManager/hooks/useSelectedWallet'
 import {WithWalletOpened} from '~/features/WalletManager/ui/shared/WithWalletOpened'
 import {useStrings} from '~/kernel/i18n/useStrings'
-import {defaultStackNavigationOptions} from '~/kernel/navigation/common/helpers'
+import {
+  BackButton,
+  defaultStackNavigationOptions,
+} from '~/kernel/navigation/common/helpers'
+import {useWalletNavigation} from '~/kernel/navigation/hooks/useWalletNavigation'
 import {TxHistoryRoutes} from '~/kernel/navigation/types'
 
 import {UtxoConsolidation} from '../Transactions/useCases/UtxoConsolidation/UtxoConsolidation/UtxoConsolidation'
@@ -42,6 +46,7 @@ export const TxHistoryNavigator = () => {
   const strings = useStrings()
   const {palette: p, atoms: ta} = useTheme()
   const {meta} = useSelectedWallet()
+  const walletNavigation = useWalletNavigation()
 
   const screenOptions: StackNavigationOptions = React.useMemo(
     () => ({
@@ -55,6 +60,12 @@ export const TxHistoryNavigator = () => {
     () => ({
       title: meta.name,
       headerRight: () => <HeaderRightHistory />,
+      headerLeft: () => (
+        <BackButton
+          onPress={() => walletNavigation.resetToWalletSelection()}
+          color={ta.text_gray_max.color}
+        />
+      ),
       headerTransparent: true,
       headerStyle: {
         ...a.bg_transparent,
@@ -66,7 +77,7 @@ export const TxHistoryNavigator = () => {
       },
       headerTintColor: ta.text_gray_max.color,
     }),
-    [meta.name, ta.text_gray_max.color],
+    [meta.name, ta.text_gray_max.color, walletNavigation],
   )
 
   return (

--- a/mobile/src/features/Transactions/useCases/TxHistory/ActionsBanner.tsx
+++ b/mobile/src/features/Transactions/useCases/TxHistory/ActionsBanner.tsx
@@ -25,7 +25,7 @@ import {Text} from '~/ui/Text/Text'
 export const ActionsBanner = (props: {disabled: boolean}) => {
   const strings = useStrings()
   const {config, isLoading} = useRemoteConfig()
-  const tokenOutId = config?.swap?.initialPair.tokenOut
+  const tokenOutId = config?.swap?.initialPair?.tokenOut
   const disabled = props.disabled || isLoading
   const navigateTo = useWalletNavigation()
   const {atoms: ta} = useTheme()

--- a/mobile/src/features/Transactions/useCases/TxHistory/TxHistory.tsx
+++ b/mobile/src/features/Transactions/useCases/TxHistory/TxHistory.tsx
@@ -1,8 +1,9 @@
 import {atoms as a, useTheme} from '@yoroi/theme'
 
+import {useNavigation} from '@react-navigation/native'
 import {LinearGradient} from 'expo-linear-gradient'
 import * as React from 'react'
-import {LayoutAnimation, Text, View} from 'react-native'
+import {BackHandler, LayoutAnimation, Platform, Text, View} from 'react-native'
 
 import infoIcon from '~/assets/img/icon/info-light-green.png'
 import {useBuyCryptoBanner} from '~/features/Exchange/common/useBuyCryptoBanner'
@@ -13,6 +14,7 @@ import {useSelectedWallet} from '~/features/WalletManager/hooks/useSelectedWalle
 import {useSync} from '~/features/WalletManager/hooks/useSync'
 import {features} from '~/kernel/features'
 import {useStrings} from '~/kernel/i18n/useStrings'
+import {useWalletNavigation} from '~/kernel/navigation/hooks/useWalletNavigation'
 import {Space, SpaceHeight} from '~/ui/Space/Space'
 
 import {TxList} from '../TxList/TxList'
@@ -31,6 +33,8 @@ export const TxHistory = () => {
 
   const strings = useStrings()
   const {atoms: ta, palette: p, isDark} = useTheme()
+  const navigation = useNavigation()
+  const walletNavigation = useWalletNavigation()
 
   useGetImportantAlertsModal({enabled: features.pushNotifications})
 
@@ -50,6 +54,49 @@ export const TxHistory = () => {
   })
 
   const handleOnRefresh = () => sync()
+
+  // Handle back navigation - always reset to wallet selection when on history-list
+  React.useEffect(() => {
+    // Handle OS back button (Android) - only when on history-list screen
+    if (Platform.OS === 'android') {
+      const backHandler = BackHandler.addEventListener(
+        'hardwareBackPress',
+        () => {
+          // Check if we can go back in the current stack
+          // If not, we're at the root (history-list) and should reset to wallet selection
+          if (!navigation.canGoBack()) {
+            walletNavigation.resetToWalletSelection()
+            return true // Prevent default back behavior
+          }
+          // Otherwise, let normal navigation handle it (go back to previous screen in stack)
+          return false
+        },
+      )
+
+      return () => backHandler.remove()
+    }
+    return undefined
+  }, [navigation, walletNavigation])
+
+  // Handle navigation back button (header button and gesture)
+  // This only fires when trying to remove history-list from the stack
+  // Only intercept user-initiated back navigation (GO_BACK), not programmatic navigation
+  React.useEffect(() => {
+    const unsubscribe = navigation.addListener('beforeRemove', (e) => {
+      // Only intercept user-initiated back navigation
+      // Allow programmatic navigation (RESET, NAVIGATE, etc.) to proceed normally
+      if (e.data.action.type === 'GO_BACK') {
+        // Prevent default behavior
+        e.preventDefault()
+
+        // Reset to wallet selection
+        walletNavigation.resetToWalletSelection()
+      }
+      // For other action types (RESET, NAVIGATE, etc.), let them proceed normally
+    })
+
+    return unsubscribe
+  }, [navigation, walletNavigation])
 
   return (
     <LinearGradient

--- a/mobile/src/kernel/navigation/hooks/useWalletNavigation.ts
+++ b/mobile/src/kernel/navigation/hooks/useWalletNavigation.ts
@@ -297,6 +297,18 @@ export const useWalletNavigation = () => {
       })
     },
 
+    navigateToDiscoverDappSelection: () => {
+      navigation.navigate('manage-wallets', {
+        screen: 'main-wallet-routes',
+        params: {
+          screen: 'discover',
+          params: {
+            screen: 'discover-select-dapp-from-list',
+          },
+        },
+      })
+    },
+
     navigateToSwap: () => {
       const currentNetwork = selectedNetworkRef.current.network
 

--- a/mobile/src/kernel/navigation/hooks/useWalletNavigation.ts
+++ b/mobile/src/kernel/navigation/hooks/useWalletNavigation.ts
@@ -349,6 +349,7 @@ export const useWalletNavigation = () => {
                         {
                           name: 'history',
                           state: {
+                            index: 1,
                             routes: [
                               {name: 'history-list'},
                               {
@@ -386,6 +387,7 @@ export const useWalletNavigation = () => {
                       {
                         name: 'history',
                         state: {
+                          index: 1,
                           routes: [
                             {name: 'history-list'},
                             {

--- a/mobile/src/kernel/navigation/types.tsx
+++ b/mobile/src/kernel/navigation/types.tsx
@@ -372,6 +372,7 @@ export type WalletNavigation = {
   navigateToAnalyticsSettings: () => void
   navigateToGovernanceCentre: () => void
   navigateToDiscoverBrowserDapp: () => void
+  navigateToDiscoverDappSelection: () => void
   navigateToSwap: () => void
   resetToSwapWithToken: () => void
   navigateToExchange: () => void

--- a/mobile/src/wallets/types/yoroi.ts
+++ b/mobile/src/wallets/types/yoroi.ts
@@ -59,66 +59,71 @@ export type YoroiNftModerationStatus =
   | 'manual_review'
 
 export type YoroiConfig = Readonly<{
-  pushLinkKeys: Readonly<{
-    internal: Readonly<{
-      catalystRegistration: Readonly<{
-        mobile: string
-        extension: string
+  pushLinkKeys?: Readonly<{
+    internal?: Readonly<{
+      catalystRegistration?: Readonly<{
+        mobile?: string
+        extension?: string
       }>
     }>
-    external: Readonly<{
-      yoroiWebsite: string
+    external?: Readonly<{
+      yoroiWebsite?: string
     }>
   }>
-  banners: Readonly<{
-    midnightAnnouncement: Readonly<{
-      display: boolean
+  banners?: Readonly<{
+    midnightAnnouncement?: Readonly<{
+      display?: boolean
     }>
-    yoroiDrep: Readonly<{
-      display: boolean
+    midnightPhase2Announcement?: Readonly<{
+      display?: boolean
     }>
-  }>
-  popups: Readonly<{
-    midnightDistribution: Readonly<{
-      display: boolean
-    }>
-    generalFeaturesAnnouncement: Readonly<{
-      display: boolean
-    }>
-    poolTransitionDialog: Readonly<{
-      display: boolean
-    }>
-    cardanoCardAnnouncement: Readonly<{
-      display: boolean
+    yoroiDrep?: Readonly<{
+      display?: boolean
     }>
   }>
-  features: Readonly<{
-    airdrop: Readonly<{
-      enabled: boolean
+  popups?: Readonly<{
+    midnightDistribution?: Readonly<{
+      display?: boolean
+    }>
+    generalFeaturesAnnouncement?: Readonly<{
+      display?: boolean
+    }>
+    poolTransitionDialog?: Readonly<{
+      display?: boolean
+    }>
+    cardanoCardAnnouncement?: Readonly<{
+      display?: boolean
+    }>
+    firefoxSupportAnnouncement?: Readonly<{
+      display?: boolean
     }>
   }>
-  dapps: Readonly<{
-    banned: ReadonlyArray<string>
-    recommended: ReadonlyArray<YoroiConfigRecommendedDapp>
-    filters: Readonly<{
-      Media: ReadonlyArray<string>
-      Investment: ReadonlyArray<string>
-      Trading: ReadonlyArray<string>
-      Community: ReadonlyArray<string>
+  features?: Readonly<Record<string, unknown>>
+  dapps?: Readonly<{
+    banned?: ReadonlyArray<string>
+    recommended?: ReadonlyArray<YoroiConfigRecommendedDapp>
+    filters?: Readonly<{
+      Media?: ReadonlyArray<string>
+      Investment?: ReadonlyArray<string>
+      Trading?: ReadonlyArray<string>
+      Community?: ReadonlyArray<string>
     }>
   }>
-  swap: Readonly<{
-    initialPair: Readonly<{
-      tokenIn: Portfolio.Token.Id
-      tokenOut: Portfolio.Token.Id
+  swap?: Readonly<{
+    initialPair?: Readonly<{
+      tokenIn?: Portfolio.Token.Id
+      tokenOut?: Portfolio.Token.Id
     }>
-    excludedTokens: ReadonlyArray<Portfolio.Token.Id>
-    verifiedTokens: ReadonlyArray<Portfolio.Token.Id>
-    partners: Readonly<{
-      dexhunter: string
-      muesliswap: string
+    excludedTokens?: ReadonlyArray<Portfolio.Token.Id>
+    verifiedTokens?: ReadonlyArray<Portfolio.Token.Id>
+    partners?: Readonly<{
+      dexhunter?: string
+      muesliswap?: string
+      minswap?: string
+      steelswap?: string
     }>
   }>
+  enableTrezorAirdrop?: boolean
 }>
 
 export type YoroiConfigRecommendedDapp = {

--- a/scripts/packages/swap/package-lock.json
+++ b/scripts/packages/swap/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yoroi/swap",
-  "version": "7.0.2",
+  "version": "7.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yoroi/swap",
-      "version": "7.0.2",
+      "version": "7.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.26.0",

--- a/scripts/packages/swap/package.json
+++ b/scripts/packages/swap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoroi/swap",
-  "version": "7.0.3",
+  "version": "7.2.0",
   "description": "The Swap package of Yoroi SDK",
   "keywords": [
     "yoroi",

--- a/scripts/packages/types/package.json
+++ b/scripts/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoroi/types",
-  "version": "6.1.1",
+  "version": "6.2.1",
   "description": "The Yoroi Types package of Yoroi SDK",
   "keywords": [
     "yoroi",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Integrates the Steelswap aggregator and dynamic aggregator routing, adds direct-URL dApp search, refactors governance voting flow, adjusts back navigation, and refines Minswap/Swap UI and config/types.
> 
> - **Swap Aggregators**
>   - **Steelswap**: New adapter (`steelswap/api-maker.ts`, `transformers.ts`, `types.ts`), tests, and docs; integrated into `swap/manager.ts` and enabled via partners; added to `@yoroi/types` (`SwapAggregator`, config partners).
>   - **Dynamic Routing**: Settings UI now lists aggregators based on remote config partners; manager only loads adapters with partner codes.
>   - **Minswap**: Simplified requests (removed `exclude_protocols/include_protocols`), fee handling adjusted (separate dex vs total), Splash protocol id normalized to `splash`.
>   - **UI**: Estimate summary shows protocol route “via <Aggregator> …”.
> - **Discover**
>   - **Direct URL**: Detects URL-like input, creates a direct navigation item, shows globe icon, and opens directly; notification “discover” action routes to dApp selection.
> - **Governance**
>   - **Vote Flow Hook**: New `useGovernanceVoteFlow` centralizes tx creation and action handling; `Home` and `ChangeVote` screens refactored to use it.
> - **Navigation**
>   - **Tx History Back**: Header and Android back now reset to wallet selection; added explicit back button.
> - **Notifications/Settings**
>   - FCM token fetching gated by `isAuthDev` (instead of `isDev`).
> - **Types/Config**
>   - `YoroiConfig` fields relaxed to optional; added `steelswap` partner; versions bumped in `@yoroi/swap` and `@yoroi/types`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69f71d8ce01fe68fc3ba7e1eddd7e285a9252732. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->