### PR TITLE
fix: add delay for transport layer to settle for usb connection

### DIFF
--- a/mobile/src/wallets/cardano/hw/hw.ts
+++ b/mobile/src/wallets/cardano/hw/hw.ts
@@ -196,6 +196,8 @@ const connectionHandler = async (
     }
 
     const appAda = new AppAda(transport)
+    // Ensure transport is settled before first APDU
+    await new Promise((resolve) => setTimeout(resolve, 50))
     const versionResp: GetVersionResponse = await appAda.getVersion()
 
     logger.debug('connectionHandler: AppAda version', {versionResp})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Insert a 50ms settle delay before calling `getVersion()` on `AppAda` to stabilize the Ledger transport connection.
> 
> - **Hardware wallet (Cardano)** in `mobile/src/wallets/cardano/hw/hw.ts`:
>   - Add 50ms delay after instantiating `AppAda` and before first APDU (`getVersion()`), allowing BLE/USB transport to settle during `connectionHandler()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac056e77ba75663f58f354f06df4d59c30409ede. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->