### PR TITLE
chore(mobile): add Firebase production config injection via EAS secrets

### DIFF
--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -48,3 +48,7 @@ yarn-error.*
 
 .env.local
 .pnpm-lock.yaml
+
+# Production Firebase configs (should be injected via EAS secrets)
+# Keep dev configs in repo, but ignore production ones
+firebase/production/

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -32,7 +32,6 @@ Before you begin, ensure you have the following installed:
 
   **Note**: Use asdf to install all dependencies from .tool-versions:\*\*
 
-
 ### Platform-Specific Requirements
 
 #### For iOS Development
@@ -264,6 +263,46 @@ The project uses Expo Application Services (EAS) for cloud builds:
 - EAS CLI: `npm install -g eas-cli`
 - EAS account: `eas login`
 
+#### Firebase Production Configuration
+
+**Important**: Production builds require Firebase configuration files to be set up as EAS secrets. Development and preview builds use Firebase configs from the repository.
+
+**Before your first production build:**
+
+1. **Place production Firebase configs** in `firebase/production/`:
+
+   - `google-services-production.json` (Android)
+   - `GoogleService-Info-production.plist` (iOS)
+
+2. **Encode the configs** using the provided script:
+
+   ```bash
+   ./scripts/encode-firebase-configs.sh
+   ```
+
+   This will output base64-encoded strings ready to copy.
+
+3. **Create EAS secrets** via Expo Dashboard:
+
+   - Go to https://expo.dev → Your Project → Secrets
+   - Create `FIREBASE_GOOGLE_SERVICES_PROD` with the Android base64 string
+   - Create `FIREBASE_GOOGLE_SERVICES_IOS_PROD` with the iOS base64 string
+   - Set scope to **Project**
+
+   Or use EAS CLI:
+
+   ```bash
+   cat firebase/production/google-services-production.b64 | \
+     eas secret:create --scope project --name FIREBASE_GOOGLE_SERVICES_PROD --value-file -
+
+   cat firebase/production/GoogleService-Info-production.b64 | \
+     eas secret:create --scope project --name FIREBASE_GOOGLE_SERVICES_IOS_PROD --value-file -
+   ```
+
+4. **Verify setup**: Production builds will automatically inject Firebase configs from secrets during the build process.
+
+For detailed instructions, see [Firebase Production Setup Guide](docs/firebase-production-setup.md).
+
 #### Build Commands
 
 ```bash
@@ -275,7 +314,7 @@ eas build --platform android --profile development
 eas build --platform ios --profile preview
 eas build --platform android --profile preview
 
-# Production build
+# Production build (requires Firebase secrets configured)
 eas build --platform ios --profile production
 eas build --platform android --profile production
 
@@ -285,9 +324,28 @@ eas build --platform all --profile production
 
 #### Build Profiles
 
-- **development** - Development client with debugging
-- **preview** - Internal testing build
-- **production** - App Store/Play Store ready build
+- **development** - Development client with debugging (uses repo Firebase configs)
+- **preview** - Internal testing build (uses repo Firebase configs)
+- **production** - App Store/Play Store ready build (uses Firebase configs from EAS secrets)
+
+#### Automated Production Deployments
+
+Production builds are automatically triggered via GitHub Actions when PRs are merged to the `production` branch:
+
+- **Workflow**: `.github/workflows/production-eas-build.yml`
+- **Process**:
+  1. Creates production builds for iOS and Android using EAS
+  2. Automatically submits iOS build to TestFlight
+  3. Automatically submits Android build to Google Play Store
+
+**Prerequisites for CI/CD:**
+
+- EAS secrets must be configured in Expo Dashboard (including Firebase production configs)
+- GitHub secrets must be configured:
+  - `EXPO_TOKEN` - EAS authentication token
+- App Store Connect API key and Google Play service account must be configured in EAS
+
+The Firebase production configs are automatically injected during CI builds via the pre-build hook script (`scripts/eas-firebase-config.sh`).
 
 ### Local Builds
 

--- a/mobile/scripts/eas-firebase-config.sh
+++ b/mobile/scripts/eas-firebase-config.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Script to inject production Firebase config files from EAS secrets
+# This script runs during EAS builds to replace dev Firebase configs with production ones
+
+echo "EAS Firebase Config Injection: Starting..."
+
+# Determine build profile
+BUILD_PROFILE="${EAS_BUILD_PROFILE:-development}"
+echo "Build profile: ${BUILD_PROFILE}"
+
+# Only inject production configs for production builds
+if [[ "${BUILD_PROFILE}" != "production" ]]; then
+  echo "Skipping Firebase config injection (profile: ${BUILD_PROFILE})"
+  echo "Using development Firebase configs from repository"
+  exit 0
+fi
+
+echo "Production build detected - injecting production Firebase configs..."
+
+# Get project root (script is in scripts/, so go up one level)
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "${PROJECT_ROOT}"
+
+# Check if secrets are available (these are set as environment variables from EAS secrets)
+if [[ -z "${FIREBASE_GOOGLE_SERVICES_PROD:-}" ]]; then
+  echo "WARNING: FIREBASE_GOOGLE_SERVICES_PROD secret not found"
+  echo "Production Firebase config will not be injected. Using dev configs from repository."
+  exit 0
+fi
+
+if [[ -z "${FIREBASE_GOOGLE_SERVICES_IOS_PROD:-}" ]]; then
+  echo "WARNING: FIREBASE_GOOGLE_SERVICES_IOS_PROD secret not found"
+  echo "Production Firebase config will not be injected. Using dev configs from repository."
+  exit 0
+fi
+
+# Decode and write Android Firebase config
+echo "Creating google-services.json from secret..."
+echo "${FIREBASE_GOOGLE_SERVICES_PROD}" | base64 -d > google-services.json
+
+# Verify Android config was created
+if [[ ! -f "google-services.json" ]]; then
+  echo "ERROR: Failed to create google-services.json"
+  exit 1
+fi
+echo "✓ Created google-services.json"
+
+# Decode and write iOS Firebase config
+echo "Creating GoogleService-Info.plist from secret..."
+echo "${FIREBASE_GOOGLE_SERVICES_IOS_PROD}" | base64 -d > GoogleService-Info.plist
+
+# Verify iOS config was created
+if [[ ! -f "GoogleService-Info.plist" ]]; then
+  echo "ERROR: Failed to create GoogleService-Info.plist"
+  exit 1
+fi
+echo "✓ Created GoogleService-Info.plist"
+
+echo "EAS Firebase Config Injection: Complete"
+echo "Production Firebase configs are now in place for build"
+

--- a/mobile/scripts/eas-firebase-config.sh
+++ b/mobile/scripts/eas-firebase-config.sh
@@ -25,15 +25,21 @@ cd "${PROJECT_ROOT}"
 
 # Check if secrets are available (these are set as environment variables from EAS secrets)
 if [[ -z "${FIREBASE_GOOGLE_SERVICES_PROD:-}" ]]; then
-  echo "WARNING: FIREBASE_GOOGLE_SERVICES_PROD secret not found"
-  echo "Production Firebase config will not be injected. Using dev configs from repository."
-  exit 0
+  echo "ERROR: FIREBASE_GOOGLE_SERVICES_PROD secret not found"
+  echo "Production builds require Firebase config secrets to be set in EAS."
+  echo "Please create the secret via:"
+  echo "  eas env:create production --scope project --name FIREBASE_GOOGLE_SERVICES_PROD --type string --visibility secret"
+  echo "Or via Expo Dashboard: https://expo.dev → Your Project → Secrets"
+  exit 1
 fi
 
 if [[ -z "${FIREBASE_GOOGLE_SERVICES_IOS_PROD:-}" ]]; then
-  echo "WARNING: FIREBASE_GOOGLE_SERVICES_IOS_PROD secret not found"
-  echo "Production Firebase config will not be injected. Using dev configs from repository."
-  exit 0
+  echo "ERROR: FIREBASE_GOOGLE_SERVICES_IOS_PROD secret not found"
+  echo "Production builds require Firebase config secrets to be set in EAS."
+  echo "Please create the secret via:"
+  echo "  eas env:create production --scope project --name FIREBASE_GOOGLE_SERVICES_IOS_PROD --type string --visibility secret"
+  echo "Or via Expo Dashboard: https://expo.dev → Your Project → Secrets"
+  exit 1
 fi
 
 # Decode and write Android Firebase config

--- a/mobile/scripts/eas-post-install.sh
+++ b/mobile/scripts/eas-post-install.sh
@@ -5,7 +5,9 @@ set -euo pipefail
 if [[ "${EAS_BUILD_PROFILE:-}" == "production" ]]; then
   echo "Running Firebase config injection for production build..."
   bash ./scripts/eas-firebase-config.sh || {
-    echo "WARNING: Firebase config injection failed, continuing with dev configs"
+    echo "ERROR: Firebase config injection failed"
+    echo "Production builds require Firebase config secrets. Build cannot continue."
+    exit 1
   }
 fi
 

--- a/mobile/scripts/eas-post-install.sh
+++ b/mobile/scripts/eas-post-install.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Inject Firebase production configs if this is a production build
+if [[ "${EAS_BUILD_PROFILE:-}" == "production" ]]; then
+  echo "Running Firebase config injection for production build..."
+  bash ./scripts/eas-firebase-config.sh || {
+    echo "WARNING: Firebase config injection failed, continuing with dev configs"
+  }
+fi
+
 echo "EAS post-install: Android Rust setup/build"
 
 # Only run on Android builds

--- a/mobile/scripts/encode-firebase-configs.sh
+++ b/mobile/scripts/encode-firebase-configs.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Script to encode Firebase production config files as base64
+# Output can be copied directly into EAS Dashboard secrets
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+FIREBASE_DIR="${PROJECT_ROOT}/firebase/production"
+
+echo "Firebase Config Encoder"
+echo "======================"
+echo ""
+
+# Check if production configs exist
+if [[ ! -f "${FIREBASE_DIR}/google-services-production.json" ]]; then
+  echo "ERROR: Production Android config not found at:"
+  echo "  ${FIREBASE_DIR}/google-services-production.json"
+  exit 1
+fi
+
+if [[ ! -f "${FIREBASE_DIR}/GoogleService-Info-production.plist" ]]; then
+  echo "ERROR: Production iOS config not found at:"
+  echo "  ${FIREBASE_DIR}/GoogleService-Info-production.plist"
+  exit 1
+fi
+
+echo "Encoding Firebase production configs..."
+echo ""
+
+# Encode Android config
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "ANDROID CONFIG (FIREBASE_GOOGLE_SERVICES_PROD)"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+ANDROID_B64=$(base64 -i "${FIREBASE_DIR}/google-services-production.json" | tr -d '\n')
+echo "${ANDROID_B64}"
+echo ""
+echo ""
+
+# Encode iOS config
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "iOS CONFIG (FIREBASE_GOOGLE_SERVICES_IOS_PROD)"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+IOS_B64=$(base64 -i "${FIREBASE_DIR}/GoogleService-Info-production.plist" | tr -d '\n')
+echo "${IOS_B64}"
+echo ""
+echo ""
+
+# Save to files for easy copying
+OUTPUT_DIR="${PROJECT_ROOT}/firebase/production"
+ANDROID_OUTPUT="${OUTPUT_DIR}/google-services-production.b64"
+IOS_OUTPUT="${OUTPUT_DIR}/GoogleService-Info-production.b64"
+
+echo "${ANDROID_B64}" > "${ANDROID_OUTPUT}"
+echo "${IOS_B64}" > "${IOS_OUTPUT}"
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "SUCCESS!"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "Base64-encoded configs have been saved to:"
+echo "  Android: ${ANDROID_OUTPUT}"
+echo "  iOS:     ${IOS_OUTPUT}"
+echo ""
+echo "To create EAS secrets:"
+echo ""
+echo "1. Copy the Android base64 string above (or from ${ANDROID_OUTPUT})"
+echo "2. Go to https://expo.dev → Your Project → Secrets"
+echo "3. Create secret:"
+echo "   Name:  FIREBASE_GOOGLE_SERVICES_PROD"
+echo "   Value: [paste Android base64 string]"
+echo "   Scope: Project"
+echo ""
+echo "4. Copy the iOS base64 string above (or from ${IOS_OUTPUT})"
+echo "5. Create secret:"
+echo "   Name:  FIREBASE_GOOGLE_SERVICES_IOS_PROD"
+echo "   Value: [paste iOS base64 string]"
+echo "   Scope: Project"
+echo ""
+echo "Or use EAS CLI:"
+echo "  cat ${ANDROID_OUTPUT} | eas secret:create --scope project --name FIREBASE_GOOGLE_SERVICES_PROD --value-file -"
+echo "  cat ${IOS_OUTPUT} | eas secret:create --scope project --name FIREBASE_GOOGLE_SERVICES_IOS_PROD --value-file -"
+echo ""
+


### PR DESCRIPTION
- Add scripts/eas-firebase-config.sh to decode and inject Firebase configs from EAS secrets during production builds
- Add scripts/encode-firebase-configs.sh to encode Firebase config files as base64 for EAS secrets
- Integrate Firebase config injection into eas-post-install.sh hook
- Update .gitignore to exclude firebase/production/ directory
- Update README.md with Firebase production configuration setup instructions

Firebase production configs are now stored as EAS secrets and automatically injected during production builds, while dev/preview builds continue using configs from the repository.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add scripts to encode/inject Firebase production configs via EAS secrets and wire into EAS build hooks, with README and .gitignore updates.
> 
> - **Build scripts**:
>   - Add `scripts/eas-firebase-config.sh` to decode/inject production Firebase configs from EAS secrets during `production` builds.
>   - Update `scripts/eas-post-install.sh` to run Firebase config injection for `production` profile before Android setup.
>   - Add `scripts/encode-firebase-configs.sh` to base64-encode production Firebase configs for creating EAS secrets.
> - **Docs**:
>   - Update `README.md` with Firebase production setup using EAS secrets, adjusted build commands/profiles, and CI automation notes; reference `scripts/eas-firebase-config.sh`.
> - **Repo config**:
>   - Update `.gitignore` to ignore `firebase/production/` (keep dev configs tracked).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00617d6340ea93ccc41eaade08832c98ef2091f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->