### PR TITLE
fix(mobile): gov loading and swap push notification redirection

### DIFF
--- a/mobile/src/features/Notifications/common/PushNotificationNavigationHandler.tsx
+++ b/mobile/src/features/Notifications/common/PushNotificationNavigationHandler.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react'
+import {AppState, AppStateStatus, InteractionManager} from 'react-native'
+
+import {useWalletManager} from '~/features/WalletManager/context/WalletManagerProvider'
+import {isAndroid} from '~/kernel/constants'
+import {useWalletNavigation} from '~/kernel/navigation/hooks/useWalletNavigation'
+
+import {pushNotificationsManager} from './notification-manager'
+import {
+  handleNotificationInternalNavigationAction,
+  shouldHandleNotificationInternalNavigationAction,
+} from './tools'
+
+export const PushNotificationNavigationHandler = () => {
+  const walletNavigation = useWalletNavigation()
+  const {selected} = useWalletManager()
+  const isCheckingRef = React.useRef(false)
+
+  React.useEffect(() => {
+    const handleAppStateChange = async (nextAppState: AppStateStatus) => {
+      if (nextAppState !== 'active' || isCheckingRef.current) return
+
+      isCheckingRef.current = true
+
+      try {
+        const delay = isAndroid ? 3000 : 500
+        await new Promise((resolve) => setTimeout(resolve, delay))
+
+        const shouldHandle =
+          await shouldHandleNotificationInternalNavigationAction()
+
+        if (shouldHandle && selected.wallet?.id) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, isAndroid ? 300 : 0),
+          )
+          InteractionManager.runAfterInteractions(async () => {
+            await handleNotificationInternalNavigationAction(
+              pushNotificationsManager,
+              walletNavigation,
+            )
+          })
+        }
+      } finally {
+        isCheckingRef.current = false
+      }
+    }
+
+    const subscription = AppState.addEventListener(
+      'change',
+      handleAppStateChange,
+    )
+
+    return () => subscription.remove()
+  }, [walletNavigation, selected.wallet?.id])
+
+  return null
+}

--- a/mobile/src/features/Notifications/common/PushNotificationNavigationHandler.tsx
+++ b/mobile/src/features/Notifications/common/PushNotificationNavigationHandler.tsx
@@ -11,6 +11,20 @@ import {
   shouldHandleNotificationInternalNavigationAction,
 } from './tools'
 
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const runAfterInteractions = (callback: () => Promise<void>): Promise<void> => {
+  return new Promise<void>((resolve) => {
+    InteractionManager.runAfterInteractions(async () => {
+      try {
+        await callback()
+      } finally {
+        resolve()
+      }
+    })
+  })
+}
+
 export const PushNotificationNavigationHandler = () => {
   const walletNavigation = useWalletNavigation()
   const {selected} = useWalletManager()
@@ -23,23 +37,22 @@ export const PushNotificationNavigationHandler = () => {
       isCheckingRef.current = true
 
       try {
-        const delay = isAndroid ? 3000 : 500
-        await new Promise((resolve) => setTimeout(resolve, delay))
+        const initialDelay = isAndroid ? 3000 : 500
+        await delay(initialDelay)
 
         const shouldHandle =
           await shouldHandleNotificationInternalNavigationAction()
 
-        if (shouldHandle && selected.wallet?.id) {
-          await new Promise((resolve) =>
-            setTimeout(resolve, isAndroid ? 300 : 0),
+        if (!shouldHandle || !selected.wallet?.id) return
+
+        if (isAndroid) await delay(300)
+
+        await runAfterInteractions(async () => {
+          await handleNotificationInternalNavigationAction(
+            pushNotificationsManager,
+            walletNavigation,
           )
-          InteractionManager.runAfterInteractions(async () => {
-            await handleNotificationInternalNavigationAction(
-              pushNotificationsManager,
-              walletNavigation,
-            )
-          })
-        }
+        })
       } finally {
         isCheckingRef.current = false
       }

--- a/mobile/src/features/Staking/Governance/common/useGovernanceVoteFlow.ts
+++ b/mobile/src/features/Staking/Governance/common/useGovernanceVoteFlow.ts
@@ -1,3 +1,4 @@
+import {GOVERNANCE_YOROI_DREP_ID_HEX} from '@yoroi/staking'
 import {Wallet} from '@yoroi/types'
 
 import {Certificate} from '@emurgo/cross-csl-core'
@@ -10,7 +11,12 @@ import {YoroiUnsignedTx} from '~/wallets/types/yoroi'
 
 import {useGovernanceActions} from './helpers'
 
-type PendingVote = 'abstain' | 'no-confidence' | 'delegate' | null
+type PendingVote =
+  | 'abstain'
+  | 'no-confidence'
+  | 'delegate-yoroi'
+  | 'delegate-other'
+  | null
 
 type DelegateOptions = {
   hash: string
@@ -97,7 +103,11 @@ export const useGovernanceVoteFlow = ({
   })
 
   const setDelegatePending = (options: DelegateOptions) => {
-    setPendingVote('delegate')
+    const pendingVoteValue =
+      options.hash === GOVERNANCE_YOROI_DREP_ID_HEX
+        ? 'delegate-yoroi'
+        : 'delegate-other'
+    setPendingVote(pendingVoteValue)
     pendingActionRef.current = {type: 'delegate', options}
   }
 

--- a/mobile/src/features/Staking/Governance/useCases/ChangeVote/ChangeVoteScreen.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/ChangeVote/ChangeVoteScreen.tsx
@@ -158,7 +158,7 @@ export const ChangeVoteScreen = () => {
               title={strings.staking.delegateToAYoroiDrep}
               description={strings.staking.delegateToAYoroiDRepDescription}
               onPress={handleDelegateToYoroi}
-              pending={isCreatingTx && pendingVote === 'delegate'}
+              pending={isCreatingTx && pendingVote === 'delegate-yoroi'}
               showGradient
             >
               <YoroiRecordLink />
@@ -170,7 +170,7 @@ export const ChangeVoteScreen = () => {
             title={strings.staking.actionDelegateToADRepTitle}
             description={strings.staking.actionDelegateToADRepDescription}
             onPress={handleDelegate}
-            pending={isCreatingTx && pendingVote === 'delegate'}
+            pending={isCreatingTx && pendingVote === 'delegate-other'}
           />
         )}
 
@@ -179,7 +179,7 @@ export const ChangeVoteScreen = () => {
             title={strings.staking.changeDRep}
             description={strings.staking.actionDelegateToADRepDescription}
             onPress={handleDelegate}
-            pending={isCreatingTx && pendingVote === 'delegate'}
+            pending={isCreatingTx && pendingVote === 'delegate-other'}
           />
         )}
 

--- a/mobile/src/features/Staking/Governance/useCases/Home/HomeScreen.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/Home/HomeScreen.tsx
@@ -399,7 +399,7 @@ const NeverParticipatedInGovernanceVariant = () => {
             title={strings.staking.delegateToAYoroiDrep}
             description={strings.staking.delegateToAYoroiDRepDescription}
             onPress={handleDelegateToYoroi}
-            pending={isCreatingTx && pendingVote === 'delegate'}
+            pending={isCreatingTx && pendingVote === 'delegate-yoroi'}
             showGradient
           >
             <YoroiRecordLink />
@@ -410,7 +410,7 @@ const NeverParticipatedInGovernanceVariant = () => {
           title={strings.staking.actionDelegateToADRepTitle}
           description={strings.staking.actionDelegateToADRepDescription}
           onPress={handleDelegate}
-          pending={isCreatingTx && pendingVote === 'delegate'}
+          pending={isCreatingTx && pendingVote === 'delegate-other'}
         />
 
         <Action

--- a/mobile/src/features/WalletManager/ui/screens/SelectWalletFromListScreen/SelectWalletFromListScreen.tsx
+++ b/mobile/src/features/WalletManager/ui/screens/SelectWalletFromListScreen/SelectWalletFromListScreen.tsx
@@ -44,25 +44,9 @@ export const SelectWalletFromList = () => {
   const {scrollViewRef} = useScrollView()
   const navigation = useNavigation()
   const walletMetas = useWalletMetas()
-  const {walletManager, selected} = useWalletManager()
+  const {walletManager} = useWalletManager()
   const walletNavigation = useWalletNavigation()
   const {isAuthDev} = useAuth()
-
-  useFocusEffect(
-    React.useCallback(() => {
-      const checkPendingNavigation = async () => {
-        const shouldHandle =
-          await shouldHandleNotificationInternalNavigationAction()
-        if (shouldHandle && selected.wallet?.id) {
-          await handleNotificationInternalNavigationAction(
-            pushNotificationsManager,
-            walletNavigation,
-          )
-        }
-      }
-      setTimeout(() => checkPendingNavigation(), 300)
-    }, [selected.wallet?.id, walletNavigation]),
-  )
 
   const handleOnSelect = React.useCallback(
     async (walletMeta: Wallet.Meta) => {

--- a/mobile/src/features/WalletManager/ui/screens/SelectWalletFromListScreen/SelectWalletFromListScreen.tsx
+++ b/mobile/src/features/WalletManager/ui/screens/SelectWalletFromListScreen/SelectWalletFromListScreen.tsx
@@ -2,7 +2,7 @@ import {useSetupWallet} from '@yoroi/setup-wallet'
 import {atoms as a, useTheme} from '@yoroi/theme'
 import {Wallet} from '@yoroi/types'
 
-import {useFocusEffect, useNavigation} from '@react-navigation/native'
+import {useNavigation} from '@react-navigation/native'
 import * as React from 'react'
 import {Linking, Text, TouchableOpacity} from 'react-native'
 

--- a/mobile/src/kernel/navigation/AppNavigator.tsx
+++ b/mobile/src/kernel/navigation/AppNavigator.tsx
@@ -24,6 +24,7 @@ import {LegalAgreement} from '~/features/Legal/common/types'
 import {useLegalAgreement} from '~/features/Legal/hooks/useLegalAgreement'
 import {useDeepLinkWatcher} from '~/features/Links/hooks/useDeepLinkWatcher'
 import {useLinksRequestAction} from '~/features/Links/hooks/useLinksRequestAction'
+import {PushNotificationNavigationHandler} from '~/features/Notifications/common/PushNotificationNavigationHandler'
 import {useInitNotifications} from '~/features/Notifications/common/hooks'
 import {NotificationUIHandler} from '~/features/Notifications/useCases/NotificationUIHandler'
 import {NotificationsDevScreen} from '~/features/Notifications/useCases/NotificationsDevScreen'
@@ -172,6 +173,7 @@ export const AppNavigator = () => {
       </Stack.Navigator>
 
       <NotificationUIHandler />
+      {isLoggedIn && <PushNotificationNavigationHandler />}
     </>
   )
 }

--- a/mobile/src/kernel/navigation/WalletTabNavigator.tsx
+++ b/mobile/src/kernel/navigation/WalletTabNavigator.tsx
@@ -7,7 +7,7 @@ import {
   createBottomTabNavigator,
 } from '@react-navigation/bottom-tabs'
 import * as React from 'react'
-import {AppState} from 'react-native'
+import {AppState, InteractionManager} from 'react-native'
 
 import {DiscoverNavigator} from '~/features/Discover/DiscoverNavigator'
 import {MenuNavigator} from '~/features/Menu/Menu'
@@ -47,10 +47,12 @@ export const WalletTabNavigator = () => {
         const shouldHandle =
           await shouldHandleNotificationInternalNavigationAction()
         if (shouldHandle) {
-          await handleNotificationInternalNavigationAction(
-            pushNotificationsManager,
-            walletNavigation,
-          )
+          InteractionManager.runAfterInteractions(async () => {
+            await handleNotificationInternalNavigationAction(
+              pushNotificationsManager,
+              walletNavigation,
+            )
+          })
         }
       }
     }

--- a/mobile/src/kernel/navigation/WalletTabNavigator.tsx
+++ b/mobile/src/kernel/navigation/WalletTabNavigator.tsx
@@ -7,15 +7,9 @@ import {
   createBottomTabNavigator,
 } from '@react-navigation/bottom-tabs'
 import * as React from 'react'
-import {AppState, InteractionManager} from 'react-native'
 
 import {DiscoverNavigator} from '~/features/Discover/DiscoverNavigator'
 import {MenuNavigator} from '~/features/Menu/Menu'
-import {pushNotificationsManager} from '~/features/Notifications/common/notification-manager'
-import {
-  handleNotificationInternalNavigationAction,
-  shouldHandleNotificationInternalNavigationAction,
-} from '~/features/Notifications/common/tools'
 import {PortfolioNavigator} from '~/features/Portfolio/PortfolioNavigator'
 import {useGovernanceManagerMaker} from '~/features/Staking/Governance/common/helpers'
 import {PoolTransitionProvider} from '~/features/Staking/Staking/PoolTransition/PoolTransitionProvider'
@@ -25,7 +19,6 @@ import {useStrings} from '~/kernel/i18n/useStrings'
 import {Icon} from '~/ui/Icon'
 
 import {shouldShowTabBarForRoutes} from './common/helpers'
-import {useWalletNavigation} from './hooks/useWalletNavigation'
 import {WalletTabRoutes} from './types'
 
 const Tab = createBottomTabNavigator<WalletTabRoutes>()
@@ -39,31 +32,6 @@ export const WalletTabNavigator = () => {
   const {palette: p, atoms: ta} = useTheme()
   const strings = useStrings()
   const manager = useGovernanceManagerMaker()
-  const walletNavigation = useWalletNavigation()
-
-  React.useEffect(() => {
-    const handleAppStateChange = async (nextAppState: string) => {
-      if (nextAppState === 'active') {
-        const shouldHandle =
-          await shouldHandleNotificationInternalNavigationAction()
-        if (shouldHandle) {
-          InteractionManager.runAfterInteractions(async () => {
-            await handleNotificationInternalNavigationAction(
-              pushNotificationsManager,
-              walletNavigation,
-            )
-          })
-        }
-      }
-    }
-
-    const subscription = AppState.addEventListener(
-      'change',
-      handleAppStateChange,
-    )
-
-    return () => subscription.remove()
-  }, [walletNavigation])
 
   return (
     <SwapProvider>


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YV-863

https://emurgo.atlassian.net/browse/YV-864


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes push notification redirection via a new app-wide handler and distinguishes governance delegate pending states (Yoroi vs other) with corresponding UI updates.
> 
> - **Notifications / Navigation**:
>   - Add `PushNotificationNavigationHandler` to process pending push notification navigation on app foreground, with platform-specific delays and interaction gating.
>   - Mount handler in `kernel/navigation/AppNavigator` when `isLoggedIn`.
>   - Remove ad-hoc AppState/focus effects for notification navigation from `WalletTabNavigator` and `SelectWalletFromListScreen`.
>   - Keep notification deep-link handling on wallet selection in `SelectWalletFromListScreen`.
> - **Governance Voting**:
>   - Split `PendingVote` `delegate` into `delegate-yoroi` and `delegate-other` in `useGovernanceVoteFlow`, auto-setting based on `GOVERNANCE_YOROI_DREP_ID_HEX`.
>   - Update `ChangeVoteScreen` and `HomeScreen` to reflect new pending states for action buttons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edec6ce3d70355ffd5a4f6abda84de3c9f66aec1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->