### PR TITLE
fix: sentry environments

### DIFF
--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -11,7 +11,7 @@
         "ANDROID_NDK_VERSION": "27.0.12077973",
 
         "EXPO_PUBLIC_BUILD_VARIANT": "NIGHTLY",
-        "EXPO_PUBLIC_SENTRY_DSN": "https://59637d7dcb274b6a9e9f708e0082b3d5@o1138840.ingest.sentry.io/6260389",
+        "EXPO_PUBLIC_SENTRY_DSN": "https://1c8e470242fe70b819c8809b435e0ba1@o1138840.ingest.us.sentry.io/4510102171353088",
         "EXPO_PUBLIC_DISABLE_LOGBOX": "true",
 
         "EXPO_PUBLIC_BANXA_TEST_WALLET": "addr1qyfuspldlchc5kechfe5jzdrr9jms2s9w0tq4hggy9zgkhxssydveuc8xyx4zh27fwcmr62mraeezjwf24hzkyejwfmq7yptmd",

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -41,6 +41,7 @@
     "development": {
       "extends": "base",
       "env": {
+        "EXPO_PUBLIC_BUILD_VARIANT": "DEV",
         "EXPO_PUBLIC_POSTHOG_KEY": "phc_zUcStVLHhwXBHajxusEvlwS77zBVAEQWhpZDx5Ef8oj",
         "EXPO_PUBLIC_POSTHOG_HOST": "https://eu.i.posthog.com"
       },
@@ -51,7 +52,6 @@
     "preview": {
       "extends": "base",
       "env": {
-        "EXPO_PUBLIC_SENTRY_DSN": "https://fb3745d47d994059917e358dae581466@o1138840.ingest.sentry.io/4505319746764800",
         "EXPO_PUBLIC_USE_TESTNET": "true",
         "EXPO_PUBLIC_WALLET_1_MNEMONIC": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon address",
         "EXPO_PUBLIC_WALLET_1_NETWORK_ID": "300",
@@ -72,7 +72,6 @@
       "extends": "base",
       "env": {
         "EXPO_PUBLIC_BUILD_VARIANT": "PROD",
-        "EXPO_PUBLIC_SENTRY_DSN": "https://7f7c6cb60a6f429facd34f491dfc5133@o1138840.ingest.sentry.io/6783228",
         "EXPO_PUBLIC_FRONTEND_FEE_ADDRESS_MAINNET": "addr1q9ry6jfdgm0lcrtfpgwrgxg7qfahv80jlghhrthy6w8hmyjuw9ngccy937pm7yw0jjnxasm7hzxjrf8rzkqcj26788lqws5fke",
         "EXPO_PUBLIC_FRONTEND_FEE_ADDRESS_PREPROD": "addr_test1qrgpjmyy8zk9nuza24a0f4e7mgp9gd6h3uayp0rqnjnkl54v4dlyj0kwfs0x4e38a7047lymzp37tx0y42glslcdtzhqzp57km",
         "EXPO_PUBLIC_UNSTOPPABLE_API_KEY": "czsajliz-wxgu6tujd1zqq7hey_pclfqhdjsqolsxjfsurgh",

--- a/mobile/src/kernel/constants.ts
+++ b/mobile/src/kernel/constants.ts
@@ -17,14 +17,16 @@ export const disableLogbox = Boolean(process.env.EXPO_PUBLIC_DISABLE_LOGBOX)
 
 // Runtime
 export const isNightly = buildVariant === 'NIGHTLY'
+export const isPreview = buildVariant === 'PREVIEW'
 export const isProduction = buildVariant === 'PROD'
 export const isDev = __DEV__
 
-export const environment = isNightly
-  ? 'nightly'
-  : isProduction
-    ? 'production'
-    : 'development'
+export const environment =
+  isNightly || isPreview
+    ? 'preview'
+    : isProduction
+      ? 'production'
+      : 'development'
 export const version = Device.osVersion ?? ''
 export const release = isProduction ? version : 'dev'
 export const build = Device.osBuildId ?? ''


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Map NIGHTLY and PREVIEW to a unified 'preview' environment, add PREVIEW handling, set DEV build variant for development, and centralize Sentry DSN in base config.
> 
> - **Runtime constants (`mobile/src/kernel/constants.ts`)**:
>   - Add `isPreview` and map `NIGHTLY`/`PREVIEW` to `environment = 'preview'`.
> - **Build config (`mobile/eas.json`)**:
>   - Set `EXPO_PUBLIC_BUILD_VARIANT` to `DEV` for `development` profile.
>   - Remove `EXPO_PUBLIC_SENTRY_DSN` from `preview` and `production` profiles to inherit from `base`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b7de175cea83020176e2aacdb82d5670d4ac22a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->