### PR TITLE
feature(mobile): governance drep modal revamp

### DIFF
--- a/mobile/src/ui/Modal/ui/screens/Modal/Modal.tsx
+++ b/mobile/src/ui/Modal/ui/screens/Modal/Modal.tsx
@@ -132,7 +132,8 @@ const Modal = () => {
         duration: time.seconds(0.2),
       })
     }
-  }, [height, isOpen, isFull, modalHeight])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [height, isFull, modalHeight])
 
   React.useEffect(() => {
     isExpanded.value = hasExpandedEnabled


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YV-768

Base branch is: https://github.com/Emurgo/yoroi/pull/4378


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Yoroi quick-delegate option to the DRep ID modal with dynamic height, updates modal system to support runtime height changes, adjusts screens to use the taller modal, and refines i18n and tests.
> 
> - **Governance UI**:
>   - `EnterDrepIdModal`: adds Yoroi quick-delegate (`YoroiDrepCard`) when input is empty, external DRep link, and dynamic height switching (`650`/`340`); supports direct delegation to `GOVERNANCE_YOROI_DREP_ID_HEX`.
>   - `YoroiDrepCard`: new `variant` prop (`gradient` | `plain`) and conditional gradient rendering.
>   - `HomeScreen`, `ChangeVoteScreen`, `VotingOptionsScreen`: open DRep ID modal with height `650`.
> - **Modal System**:
>   - `ui/Modal/context/ModalContext`: adds `setHeight` action and reducer handling.
>   - `ui/Modal/ui/screens/Modal/Modal`: cleans effect deps and animates height changes when open.
> - **i18n**:
>   - Updates `enterDrepIDInfo` and adds `dontHaveAnID`, `orDelegateToYoroiDrepBelow`; exposes them via `useStrings`.
> - **Tests**:
>   - Cleans up redundant checks in `mobile/packages/swap/adapters/api/minswap/transformers.test.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 021f2958fc971e90ebd65a982350978fa199fbf6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->