### PR TITLE
feat: add manual development EAS build workflow

### DIFF
--- a/.github/workflows/development-eas-build.yml
+++ b/.github/workflows/development-eas-build.yml
@@ -1,0 +1,55 @@
+name: Create development build for devices with EAS
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: 'Platform to build for'
+        required: true
+        type: choice
+        options:
+          - all
+          - ios
+          - android
+        default: 'all'
+      branch:
+        description: 'Branch to build from'
+        required: false
+        type: string
+        default: 'develop'
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  development-build:
+    runs-on: macos-latest
+    steps:
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch || 'develop' }}
+
+      - name: 🏗 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: mobile/package-lock.json
+
+      - name: 🏗 Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+          packager: npm
+
+      - name: 📦 Install Dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        working-directory: mobile
+        run: npm ci
+
+      - name: 🚀 Create development build
+        working-directory: mobile
+        run: eas build --profile development --platform ${{ inputs.platform }} --no-wait --non-interactive
+


### PR DESCRIPTION
Add workflow_dispatch workflow to trigger development builds on demand from GitHub Actions UI. Allows selecting platform (all/ios/android) and branch (defaults to develop).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a GitHub Actions workflow to trigger EAS development builds on demand with selectable platform and branch.
> 
> - **CI/CD**: New workflow `/.github/workflows/development-eas-build.yml`
>   - `workflow_dispatch` with inputs: `platform` (all/ios/android) and `branch` (default `develop`).
>   - Job `development-build` on `macos-latest`:
>     - Checkout selected ref.
>     - Setup Node.js 22 with npm cache (`mobile/package-lock.json`).
>     - Setup EAS (latest) using `EXPO_TOKEN`.
>     - Install mobile deps via `npm ci` in `mobile`.
>     - Run `eas build --profile development --platform <input> --no-wait --non-interactive`.
>   - Uses `GITHUB_TOKEN` env for steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97e6b48afcea3a85d7a2460ff31f62ec29273935. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->