### PR TITLE
fix: prevent clipping of drep id in review screen

### DIFF
--- a/mobile/src/features/ReviewTx/common/operations.tsx
+++ b/mobile/src/features/ReviewTx/common/operations.tsx
@@ -226,14 +226,18 @@ export const VoteDelegationOperation = ({
           style={[
             a.body_2_md_regular,
             {color: p.text_gray_medium},
+            a.flex_shrink,
+            a.text_right,
             strike && {textDecorationLine: 'line-through'},
           ]}
+          numberOfLines={2}
+          ellipsizeMode="middle"
         >
           {CIP129label}
         </Text>
       </View>
 
-      <Space.Height.sm />
+      <Space.Height.md />
 
       <View style={[a.flex, a.flex_row, a.align_center, a.justify_between]}>
         <Label
@@ -248,8 +252,12 @@ export const VoteDelegationOperation = ({
           style={[
             a.body_2_md_regular,
             {color: p.text_gray_medium},
+            a.flex_shrink,
+            a.text_right,
             strike && {textDecorationLine: 'line-through'},
           ]}
+          numberOfLines={2}
+          ellipsizeMode="middle"
         >
           {CIP105label}
         </Text>

--- a/mobile/src/features/ReviewTx/common/operations.tsx
+++ b/mobile/src/features/ReviewTx/common/operations.tsx
@@ -12,6 +12,7 @@ import {
 import {usePoolInfo} from '~/features/Staking/hooks/usePoolInfo'
 import {useSelectedWallet} from '~/features/WalletManager/hooks/useSelectedWallet'
 import {useStrings} from '~/kernel/i18n/useStrings'
+import {Copiable} from '~/ui/Copiable/Copiable'
 import {Icon} from '~/ui/Icon'
 import {useModal} from '~/ui/Modal/context/ModalContext'
 import {Space} from '~/ui/Space/Space'
@@ -213,7 +214,7 @@ export const VoteDelegationOperation = ({
 
   return (
     <>
-      <View style={[a.flex, a.flex_row, a.align_center, a.justify_between]}>
+      <View style={[a.flex, a.flex_row, a.align_center]}>
         <Label
           label={strings.txReview.operations.delegateVotingToDRep}
           showWarning={showWarning}
@@ -222,24 +223,26 @@ export const VoteDelegationOperation = ({
 
         <Space.Width.lg />
 
-        <Text
-          style={[
-            a.body_2_md_regular,
-            {color: p.text_gray_medium},
-            a.flex_shrink,
-            a.text_right,
-            strike && {textDecorationLine: 'line-through'},
-          ]}
-          numberOfLines={2}
-          ellipsizeMode="middle"
-        >
-          {CIP129label}
-        </Text>
+        <Copiable text={CIP129label} style={{flex: 1}}>
+          <View style={{flex: 1}}>
+            <Text
+              style={[
+                a.body_2_md_regular,
+                {color: p.text_gray_medium},
+                strike && {textDecorationLine: 'line-through'},
+              ]}
+              numberOfLines={1}
+              ellipsizeMode="middle"
+            >
+              {CIP129label}
+            </Text>
+          </View>
+        </Copiable>
       </View>
 
-      <Space.Height.md />
+      <Space.Height.sm />
 
-      <View style={[a.flex, a.flex_row, a.align_center, a.justify_between]}>
+      <View style={[a.flex, a.flex_row, a.align_center]}>
         <Label
           label={strings.txReview.operations.delegateVotingToDRepSpecified}
           showWarning={showWarning}
@@ -248,19 +251,21 @@ export const VoteDelegationOperation = ({
 
         <Space.Width.lg />
 
-        <Text
-          style={[
-            a.body_2_md_regular,
-            {color: p.text_gray_medium},
-            a.flex_shrink,
-            a.text_right,
-            strike && {textDecorationLine: 'line-through'},
-          ]}
-          numberOfLines={2}
-          ellipsizeMode="middle"
-        >
-          {CIP105label}
-        </Text>
+        <Copiable text={CIP105label} style={{flex: 1}}>
+          <View style={{flex: 1}}>
+            <Text
+              style={[
+                a.body_2_md_regular,
+                {color: p.text_gray_medium},
+                strike && {textDecorationLine: 'line-through'},
+              ]}
+              numberOfLines={1}
+              ellipsizeMode="middle"
+            >
+              {CIP105label}
+            </Text>
+          </View>
+        </Copiable>
       </View>
     </>
   )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prevents DRep ID overflow in the review screen by middle-ellipsizing and wrapping IDs in a copyable component.
> 
> - **ReviewTx UI (VoteDelegationOperation)**
>   - Wrap `CIP129` and `CIP105` DRep IDs with `Copiable` to enable copying.
>   - Apply single-line, middle-ellipsis truncation to prevent overflow/clipping.
>   - Adjust layout to let ID text flex (remove `justify_between`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a570514abe9f17c7f96fc0bdf5ba55e76a2f5272. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->