### PR TITLE
chore: bump app version 6.2.1

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Yoroi",
     "slug": "yoroi",
     "owner": "emurgo",
-    "version": "6.2.0",
+    "version": "6.2.1",
     "orientation": "portrait",
     "icon": "./assets/yoroi/icon.png",
     "userInterfaceStyle": "automatic",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "yoroi-v2",
-      "version": "6.2.0",
+      "version": "6.2.1",
       "hasInstallScript": true,
       "dependencies": {
         "@cardano-foundation/ledgerjs-hw-app-cardano": "7.1.4",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi-v2",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi-v2",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "main": "index.ts",
   "scripts": {
     "postinstall": "patch-package",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps mobile app version from 6.2.0 to 6.2.1 across `mobile/app.json`, `mobile/package.json`, and `mobile/package-lock.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9925ed8ce5e83c3cfcee0a39716b581db4fb6de2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->