### PR TITLE
fix(mobile): governance revamp

### DIFF
--- a/mobile/src/features/Staking/Governance/common/OtherDrepCard/OtherDrepCard.tsx
+++ b/mobile/src/features/Staking/Governance/common/OtherDrepCard/OtherDrepCard.tsx
@@ -160,6 +160,7 @@ export const OtherDrepCard = ({
       <Button
         title={strings.staking.delegateToOtherDrep}
         type={ButtonType.Secondary}
+        size="S"
         onPress={onDelegate}
         disabled={pending}
       />

--- a/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
@@ -50,30 +50,26 @@ export const EnterDrepIdModal = ({onSubmit}: Props) => {
     }
   }, [])
 
-  const scheduleHeightChange = React.useCallback(
-    (height: number) => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current)
-      timeoutRef.current = setTimeout(() => setHeight(height), 150)
-    },
-    [setHeight],
-  )
+  const scheduleHeightChange = (height: number) => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    timeoutRef.current = setTimeout(() => setHeight(height), 150)
+  }
 
-  const handleFocus = React.useCallback(() => {
+  const handleFocus = () => {
     setShowCard(false)
     scheduleHeightChange(HEIGHT_WITHOUT_CARD)
-  }, [scheduleHeightChange])
+  }
 
-  const handleBlur = React.useCallback(() => {
+  const handleBlur = () => {
     if (drepIdSelected.length === 0) {
       setShowCard(true)
       scheduleHeightChange(HEIGHT_WITH_CARD)
     }
-  }, [drepIdSelected.length, scheduleHeightChange])
+  }
 
-  const handleDrepIdChange = React.useCallback(
-    (text: string) => setDrepIdSelected(text),
-    [],
-  )
+  const handleDrepIdChange = (text: string) => {
+    setDrepIdSelected(text)
+  }
 
   const {error, isFetched, isFetching} = useIsValidDRepID(drepIdSelected, {
     retry: false,

--- a/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
@@ -25,6 +25,9 @@ export type Props = {
   }) => void
 }
 
+export const HEIGHT_WITH_CARD = 660
+export const HEIGHT_WITHOUT_CARD = 350
+
 const FIND_DREPS_LINKS: Record<Chain.SupportedNetworks, string> = {
   [Chain.Network.Preprod]: 'https://preprod.cexplorer.io/drep',
   [Chain.Network.Mainnet]: 'https://beta.cexplorer.io/drep',
@@ -33,48 +36,71 @@ const FIND_DREPS_LINKS: Record<Chain.SupportedNetworks, string> = {
 
 export const EnterDrepIdModal = ({onSubmit}: Props) => {
   const strings = useStrings()
-  const {atoms: ta, palette: p} = useTheme()
-  const [drepId, setDrepId] = React.useState('')
   const {closeModal, setHeight} = useModal()
-  const {
-    wallet: {
-      networkManager: {network},
-    },
-  } = useSelectedWallet()
+  const {wallet} = useSelectedWallet()
+  const network = wallet.networkManager.network
 
-  const {error, isFetched, isFetching} = useIsValidDRepID(drepId, {
+  const [showCard, setShowCard] = React.useState(true)
+  const [drepIdSelected, setDrepIdSelected] = React.useState('')
+  const timeoutRef = React.useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  React.useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    }
+  }, [])
+
+  const scheduleHeightChange = React.useCallback(
+    (height: number) => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+      timeoutRef.current = setTimeout(() => setHeight(height), 150)
+    },
+    [setHeight],
+  )
+
+  const handleFocus = React.useCallback(() => {
+    setShowCard(false)
+    scheduleHeightChange(HEIGHT_WITHOUT_CARD)
+  }, [scheduleHeightChange])
+
+  const handleBlur = React.useCallback(() => {
+    if (drepIdSelected.length === 0) {
+      setShowCard(true)
+      scheduleHeightChange(HEIGHT_WITH_CARD)
+    }
+  }, [drepIdSelected.length, scheduleHeightChange])
+
+  const handleDrepIdChange = React.useCallback(
+    (text: string) => setDrepIdSelected(text),
+    [],
+  )
+
+  const {error, isFetched, isFetching} = useIsValidDRepID(drepIdSelected, {
     retry: false,
-    enabled: drepId.length > 0,
+    enabled: drepIdSelected.length > 0,
   })
 
-  const {showCard, handleFocus, handleBlur, updateHasInput} =
-    useCardVisibility(setHeight)
+  const isSubmitDisabled =
+    isNonNullable(error) ||
+    drepIdSelected.length === 0 ||
+    !isFetched ||
+    isFetching
 
-  const handleDrepIdChange = (text: string) => {
-    setDrepId(text)
-    updateHasInput(text)
-  }
-
-  const handleOnPress = () => {
+  const handleSubmit = () => {
     try {
-      const {hash, type} = parseDrepId(drepId, CardanoMobile)
-      onSubmit?.({hash, type, CIP105: !error && drepId.length === 56})
+      const {hash, type} = parseDrepId(drepIdSelected, CardanoMobile)
+      const isCIP105 = !error && drepIdSelected.length === 56
+      onSubmit?.({hash, type, CIP105: isCIP105})
       closeModal()
-    } catch (e) {
+    } catch {
       Alert.alert(strings.global.error, strings.staking.invalidDRepId)
     }
   }
 
-  const handleOnLinkPress = () => {
-    Linking.openURL(FIND_DREPS_LINKS[network])
-  }
+  const handleFindDRepLink = () => Linking.openURL(FIND_DREPS_LINKS[network])
 
   const handleDelegateToYoroi = () => {
-    onSubmit?.({
-      hash: getYoroiDrepIdHex(network),
-      type: 'key',
-      CIP105: false,
-    })
+    onSubmit?.({hash: getYoroiDrepIdHex(network), type: 'key', CIP105: false})
     closeModal()
   }
 
@@ -82,14 +108,12 @@ export const EnterDrepIdModal = ({onSubmit}: Props) => {
     <Modal.Content>
       <Space.Height.sm />
 
-      <Text style={[a.text_center, a.body_1_lg_regular, ta.text_gray_medium]}>
-        {strings.staking.enterDrepIDInfo}
-      </Text>
+      <Description />
 
       <Space.Height.lg />
 
       <TextInput
-        value={drepId}
+        value={drepIdSelected}
         onChangeText={handleDrepIdChange}
         onFocus={handleFocus}
         onBlur={handleBlur}
@@ -111,93 +135,79 @@ export const EnterDrepIdModal = ({onSubmit}: Props) => {
       />
 
       {showCard && (
-        <>
-          <Space.Height.lg />
-
-          <View style={[a.flex_row, a.justify_center, a.flex_wrap]}>
-            <Text
-              style={[a.body_1_lg_regular, ta.text_gray_medium, a.text_center]}
-            >
-              {strings.staking.dontHaveAnID}{' '}
-            </Text>
-
-            <Text
-              style={[
-                a.body_1_lg_regular,
-                {color: p.primary_500, textDecorationLine: 'underline'},
-              ]}
-              onPress={handleOnLinkPress}
-            >
-              {strings.staking.findDRepHere}
-            </Text>
-          </View>
-
-          <Space.Height.xs />
-
-          <Text
-            style={[a.body_1_lg_regular, ta.text_gray_medium, a.text_center]}
-          >
-            {strings.staking.orDelegateToYoroiDrepBelow}
-          </Text>
-
-          <Space.Height.lg />
-
-          <YoroiDrepCard
-            onDelegate={handleDelegateToYoroi}
-            truncateId
-            variant="plain"
-          />
-        </>
+        <FindDRepSection
+          onLinkPress={handleFindDRepLink}
+          onDelegateToYoroi={handleDelegateToYoroi}
+        />
       )}
 
       <Space.Height.lg />
 
       <Button
         title={strings.staking.confirm}
-        disabled={
-          isNonNullable(error) ||
-          drepId.length === 0 ||
-          !isFetched ||
-          isFetching
-        }
-        onPress={handleOnPress}
+        disabled={isSubmitDisabled}
+        onPress={handleSubmit}
       />
     </Modal.Content>
   )
 }
 
-export const HEIGHT_WITH_CARD = 660
-export const HEIGHT_WITHOUT_CARD = 350
+const Description = () => {
+  const strings = useStrings()
+  const {atoms: ta} = useTheme()
 
-const useCardVisibility = (setHeight: (height: number) => void) => {
-  const [showCard, setShowCard] = React.useState(true)
-  const [hasInput, setHasInput] = React.useState(false)
-  const timeoutRef = React.useRef<ReturnType<typeof setTimeout>>(undefined)
-
-  React.useEffect(
-    () => () => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current)
-    },
-    [],
+  return (
+    <Text style={[a.text_center, a.body_1_lg_regular, ta.text_gray_medium]}>
+      {strings.staking.enterDrepIDInfo}
+    </Text>
   )
+}
 
-  const handleFocus = React.useCallback(() => {
-    setShowCard(false)
-    if (timeoutRef.current) clearTimeout(timeoutRef.current)
-    timeoutRef.current = setTimeout(() => setHeight(HEIGHT_WITHOUT_CARD), 150)
-  }, [setHeight])
+type FindDRepSectionProps = {
+  onLinkPress: () => void
+  onDelegateToYoroi: () => void
+}
 
-  const handleBlur = React.useCallback(() => {
-    if (!hasInput) {
-      setShowCard(true)
-      if (timeoutRef.current) clearTimeout(timeoutRef.current)
-      timeoutRef.current = setTimeout(() => setHeight(HEIGHT_WITH_CARD), 150)
-    }
-  }, [hasInput, setHeight])
+const FindDRepSection = ({
+  onLinkPress,
+  onDelegateToYoroi,
+}: FindDRepSectionProps) => {
+  const strings = useStrings()
+  const {atoms: ta, palette} = useTheme()
 
-  const updateHasInput = React.useCallback((text: string) => {
-    setHasInput(text.length > 0)
-  }, [])
+  return (
+    <>
+      <Space.Height.lg />
 
-  return {showCard, handleFocus, handleBlur, updateHasInput}
+      <View style={[a.flex_row, a.justify_center, a.flex_wrap]}>
+        <Text style={[a.body_1_lg_regular, ta.text_gray_medium, a.text_center]}>
+          {strings.staking.dontHaveAnID}{' '}
+        </Text>
+
+        <Text
+          style={[
+            a.body_1_lg_regular,
+            {color: palette.primary_500, textDecorationLine: 'underline'},
+          ]}
+          onPress={onLinkPress}
+        >
+          {strings.staking.findDRepHere}
+        </Text>
+      </View>
+
+      <Space.Height.xs />
+
+      <Text style={[a.body_1_lg_regular, ta.text_gray_medium, a.text_center]}>
+        {strings.staking.orDelegateToYoroiDrepBelow}
+      </Text>
+
+      <Space.Height.lg />
+
+      <YoroiDrepCard
+        onDelegate={onDelegateToYoroi}
+        truncateId
+        variant="plain"
+      />
+    </>
+  )
 }

--- a/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
@@ -31,14 +31,10 @@ const FIND_DREPS_LINKS: Record<Chain.SupportedNetworks, string> = {
   [Chain.Network.Preview]: 'https://preview.cexplorer.io/drep',
 }
 
-export const HEIGHT_WITH_CARD = 660
-export const HEIGHT_WITHOUT_CARD = 350
-
 export const EnterDrepIdModal = ({onSubmit}: Props) => {
   const strings = useStrings()
   const {atoms: ta, palette: p} = useTheme()
   const [drepId, setDrepId] = React.useState('')
-  const [showCard, setShowCard] = React.useState(true)
   const {closeModal, setHeight} = useModal()
   const {
     wallet: {
@@ -51,20 +47,12 @@ export const EnterDrepIdModal = ({onSubmit}: Props) => {
     enabled: drepId.length > 0,
   })
 
-  const handleFocus = React.useCallback(() => {
-    setShowCard(false)
-    setTimeout(() => setHeight(HEIGHT_WITHOUT_CARD), 150)
-  }, [setHeight])
-
-  const handleBlur = React.useCallback(() => {
-    if (drepId.length === 0) {
-      setShowCard(true)
-      setTimeout(() => setHeight(HEIGHT_WITH_CARD), 150)
-    }
-  }, [drepId.length, setHeight])
+  const {showCard, handleFocus, handleBlur, updateHasInput} =
+    useCardVisibility(setHeight)
 
   const handleDrepIdChange = (text: string) => {
     setDrepId(text)
+    updateHasInput(text)
   }
 
   const handleOnPress = () => {
@@ -176,4 +164,40 @@ export const EnterDrepIdModal = ({onSubmit}: Props) => {
       />
     </Modal.Content>
   )
+}
+
+export const HEIGHT_WITH_CARD = 660
+export const HEIGHT_WITHOUT_CARD = 350
+
+const useCardVisibility = (setHeight: (height: number) => void) => {
+  const [showCard, setShowCard] = React.useState(true)
+  const [hasInput, setHasInput] = React.useState(false)
+  const timeoutRef = React.useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  React.useEffect(
+    () => () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    },
+    [],
+  )
+
+  const handleFocus = React.useCallback(() => {
+    setShowCard(false)
+    if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    timeoutRef.current = setTimeout(() => setHeight(HEIGHT_WITHOUT_CARD), 150)
+  }, [setHeight])
+
+  const handleBlur = React.useCallback(() => {
+    if (!hasInput) {
+      setShowCard(true)
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+      timeoutRef.current = setTimeout(() => setHeight(HEIGHT_WITH_CARD), 150)
+    }
+  }, [hasInput, setHeight])
+
+  const updateHasInput = React.useCallback((text: string) => {
+    setHasInput(text.length > 0)
+  }, [])
+
+  return {showCard, handleFocus, handleBlur, updateHasInput}
 }

--- a/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
@@ -1,12 +1,12 @@
 import {isNonNullable} from '@yoroi/common'
 import {getYoroiDrepIdHex, parseDrepId, useIsValidDRepID} from '@yoroi/staking'
 import {atoms as a, useTheme} from '@yoroi/theme'
+import {Chain} from '@yoroi/types'
 
 import * as React from 'react'
 import {Alert, Linking, Text, View} from 'react-native'
 
 import {useSelectedWallet} from '~/features/WalletManager/hooks/useSelectedWallet'
-import {useIsKeyboardOpen} from '~/hooks/useIsKeyboardOpen'
 import {useStrings} from '~/kernel/i18n/useStrings'
 import {Button} from '~/ui/Button/Button'
 import {useModal} from '~/ui/Modal/context/ModalContext'
@@ -25,16 +25,20 @@ export type Props = {
   }) => void
 }
 
-const FIND_DREPS_LINK = 'https://beta.cexplorer.io/drep'
+const FIND_DREPS_LINKS: Record<Chain.SupportedNetworks, string> = {
+  [Chain.Network.Preprod]: 'https://preprod.cexplorer.io/drep',
+  [Chain.Network.Mainnet]: 'https://beta.cexplorer.io/drep',
+  [Chain.Network.Preview]: 'https://preview.cexplorer.io/drep',
+}
 
 export const HEIGHT_WITH_CARD = 660
 export const HEIGHT_WITHOUT_CARD = 350
-export const HEIGHT_KEYBOARD_OPEN = 350
 
 export const EnterDrepIdModal = ({onSubmit}: Props) => {
   const strings = useStrings()
   const {atoms: ta, palette: p} = useTheme()
   const [drepId, setDrepId] = React.useState('')
+  const [showCard, setShowCard] = React.useState(true)
   const {closeModal, setHeight} = useModal()
   const {
     wallet: {
@@ -47,35 +51,20 @@ export const EnterDrepIdModal = ({onSubmit}: Props) => {
     enabled: drepId.length > 0,
   })
 
-  const showYoroiDrepOption = drepId.length === 0
-  const showYoroiDrepOptionRef = React.useRef(showYoroiDrepOption)
-  showYoroiDrepOptionRef.current = showYoroiDrepOption
+  const handleFocus = React.useCallback(() => {
+    setShowCard(false)
+    setTimeout(() => setHeight(HEIGHT_WITHOUT_CARD), 150)
+  }, [setHeight])
 
-  const handleKeyboardChange = React.useCallback(
-    (isOpen: boolean) => {
-      if (isOpen) {
-        setHeight(HEIGHT_KEYBOARD_OPEN)
-      } else {
-        setHeight(
-          showYoroiDrepOptionRef.current
-            ? HEIGHT_WITH_CARD
-            : HEIGHT_WITHOUT_CARD,
-        )
-      }
-    },
-    [setHeight],
-  )
-
-  const isKeyboardOpen = useIsKeyboardOpen({
-    onKeyboardChange: handleKeyboardChange,
-  })
+  const handleBlur = React.useCallback(() => {
+    if (drepId.length === 0) {
+      setShowCard(true)
+      setTimeout(() => setHeight(HEIGHT_WITH_CARD), 150)
+    }
+  }, [drepId.length, setHeight])
 
   const handleDrepIdChange = (text: string) => {
     setDrepId(text)
-    if (!isKeyboardOpen) {
-      const shouldShowCard = text.length === 0
-      setHeight(shouldShowCard ? HEIGHT_WITH_CARD : HEIGHT_WITHOUT_CARD)
-    }
   }
 
   const handleOnPress = () => {
@@ -89,7 +78,7 @@ export const EnterDrepIdModal = ({onSubmit}: Props) => {
   }
 
   const handleOnLinkPress = () => {
-    Linking.openURL(FIND_DREPS_LINK)
+    Linking.openURL(FIND_DREPS_LINKS[network])
   }
 
   const handleDelegateToYoroi = () => {
@@ -114,6 +103,8 @@ export const EnterDrepIdModal = ({onSubmit}: Props) => {
       <TextInput
         value={drepId}
         onChangeText={handleDrepIdChange}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
         multiline
         errorDelay={1000}
         errorText={error?.message}
@@ -131,7 +122,7 @@ export const EnterDrepIdModal = ({onSubmit}: Props) => {
         }}
       />
 
-      {showYoroiDrepOption && (
+      {showCard && (
         <>
           <Space.Height.lg />
 

--- a/mobile/src/kernel/i18n/locales/en-US.json
+++ b/mobile/src/kernel/i18n/locales/en-US.json
@@ -158,7 +158,7 @@
   "components.governance.drepKey": "DRep Key",
   "components.governance.enterADrepIDAndPassword": "Enter a Drep ID and password to sign this transaction",
   "components.governance.enterDRepID": "Choose your Drep",
-  "components.governance.enterDrepIDInfo": "Find your preferred DRep and enter their ID or ADA handle below to delegate your vote:",
+  "components.governance.enterDrepIDInfo": "Find your preferred DRep and enter their ID below to delegate your vote:",
   "components.governance.enterPassword": "Enter password to sign this transaction",
   "components.governance.findDRepHere": "Find a DRep here",
   "components.governance.invalidDRepId": "Invalid DRep ID",

--- a/mobile/src/kernel/i18n/messages/staking.ts
+++ b/mobile/src/kernel/i18n/messages/staking.ts
@@ -431,7 +431,8 @@ export const stakingMessages = defineMessages({
   },
   enterDrepIDInfo: {
     id: 'components.governance.enterDrepIDInfo',
-    defaultMessage: '!!!Enter Drep ID Info',
+    defaultMessage:
+      '!!!Find your preferred DRep and enter their ID below to delegate your vote:',
   },
   goToStaking: {
     id: 'components.governance.goToStaking',

--- a/mobile/src/ui/Modal/ui/shared/ModalContentWrapper.tsx
+++ b/mobile/src/ui/Modal/ui/shared/ModalContentWrapper.tsx
@@ -16,6 +16,7 @@ export const ModalContentWrapper = ({
       contentContainerStyle={StyleSheet.flatten([a.flex_grow, a.px_lg, style])}
       bounces={false}
       focusable
+      keyboardShouldPersistTaps="handled"
       {...rest}
     >
       {children}


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YW-136
https://emurgo.atlassian.net/browse/YW-221

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the DRep entry modal with focus-based UI/height behavior and network-specific DRep links, updates copy, and tweaks keyboard handling and button sizing.
> 
> - **Governance UI**:
>   - **`EnterDrepIdModal`**: Refactors UX to toggle Yoroi card on input focus/blur and adjust modal height with a short delay; simplifies state (`drepIdSelected`) and submit/validation (`isSubmitDisabled`, `handleSubmit`); adds network-aware DRep finder links; extracts `Description` and `FindDRepSection` components.
> - **i18n**:
>   - Updates `components.governance.enterDrepIDInfo` text to remove ADA handle mention.
> - **UI tweaks**:
>   - `ui/Modal/.../ModalContentWrapper`: enable `keyboardShouldPersistTaps="handled"`.
>   - `OtherDrepCard`: set delegate button `size="S"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1561d8992a0a9260f4d1ac1069c4c0e07e7bdb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->