### PR TITLE
Fix: change gov title + improvements

### DIFF
--- a/mobile/src/features/ReviewTx/common/operations.tsx
+++ b/mobile/src/features/ReviewTx/common/operations.tsx
@@ -222,21 +222,15 @@ export const VoteDelegationOperation = ({
 
         <Space.Width.lg />
 
-        <View
-          style={[a.flex_shrink, {maxWidth: '60%', alignItems: 'flex-end'}]}
+        <Text
+          style={[
+            a.body_2_md_regular,
+            {color: p.text_gray_medium},
+            strike && {textDecorationLine: 'line-through'},
+          ]}
         >
-          <Text
-            style={[
-              a.body_2_md_regular,
-              {color: p.text_gray_medium, textAlign: 'right'},
-              strike && {textDecorationLine: 'line-through'},
-            ]}
-            ellipsizeMode="middle"
-            numberOfLines={1}
-          >
-            {CIP129label}
-          </Text>
-        </View>
+          {CIP129label}
+        </Text>
       </View>
 
       <Space.Height.sm />
@@ -250,21 +244,15 @@ export const VoteDelegationOperation = ({
 
         <Space.Width.lg />
 
-        <View
-          style={[a.flex_shrink, {maxWidth: '60%', alignItems: 'flex-end'}]}
+        <Text
+          style={[
+            a.body_2_md_regular,
+            {color: p.text_gray_medium},
+            strike && {textDecorationLine: 'line-through'},
+          ]}
         >
-          <Text
-            style={[
-              a.body_2_md_regular,
-              {color: p.text_gray_medium, textAlign: 'right'},
-              strike && {textDecorationLine: 'line-through'},
-            ]}
-            ellipsizeMode="middle"
-            numberOfLines={1}
-          >
-            {CIP105label}
-          </Text>
-        </View>
+          {CIP105label}
+        </Text>
       </View>
     </>
   )

--- a/mobile/src/features/ReviewTx/common/operations.tsx
+++ b/mobile/src/features/ReviewTx/common/operations.tsx
@@ -222,15 +222,21 @@ export const VoteDelegationOperation = ({
 
         <Space.Width.lg />
 
-        <Text
-          style={[
-            a.body_2_md_regular,
-            {color: p.text_gray_medium},
-            strike && {textDecorationLine: 'line-through'},
-          ]}
+        <View
+          style={[a.flex_shrink, {maxWidth: '60%', alignItems: 'flex-end'}]}
         >
-          {CIP129label}
-        </Text>
+          <Text
+            style={[
+              a.body_2_md_regular,
+              {color: p.text_gray_medium, textAlign: 'right'},
+              strike && {textDecorationLine: 'line-through'},
+            ]}
+            ellipsizeMode="middle"
+            numberOfLines={1}
+          >
+            {CIP129label}
+          </Text>
+        </View>
       </View>
 
       <Space.Height.sm />
@@ -244,15 +250,21 @@ export const VoteDelegationOperation = ({
 
         <Space.Width.lg />
 
-        <Text
-          style={[
-            a.body_2_md_regular,
-            {color: p.text_gray_medium},
-            strike && {textDecorationLine: 'line-through'},
-          ]}
+        <View
+          style={[a.flex_shrink, {maxWidth: '60%', alignItems: 'flex-end'}]}
         >
-          {CIP105label}
-        </Text>
+          <Text
+            style={[
+              a.body_2_md_regular,
+              {color: p.text_gray_medium, textAlign: 'right'},
+              strike && {textDecorationLine: 'line-through'},
+            ]}
+            ellipsizeMode="middle"
+            numberOfLines={1}
+          >
+            {CIP105label}
+          </Text>
+        </View>
       </View>
     </>
   )

--- a/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
@@ -150,7 +150,7 @@ export const EnterDrepIdModal = ({onSubmit}: Props) => {
       type: 'key',
       CIP105: false,
     })
-    closeModal()
+    requestCloseModal()
   }
 
   return (

--- a/mobile/src/kernel/i18n/locales/en-US.json
+++ b/mobile/src/kernel/i18n/locales/en-US.json
@@ -165,7 +165,7 @@
   "components.governance.goToGovernance": "Go to Governance",
   "components.governance.goToStaking": "Go to staking",
   "components.governance.goToWallet": "Go to wallet",
-  "components.governance.governanceCentreTitle": "Dashboard",
+  "components.governance.governanceCentreTitle": "Governance Dashboard",
   "components.governance.hardwareWalletSupportComingSoon": "Hardware wallet support coming soon",
   "components.governance.learnMoreAboutGovernance": "Learn more About Governance",
   "components.governance.operations": "Operations",

--- a/mobile/src/kernel/i18n/messages/staking.ts
+++ b/mobile/src/kernel/i18n/messages/staking.ts
@@ -239,7 +239,7 @@ export const stakingMessages = defineMessages({
   },
   governanceCentreTitle: {
     id: 'components.governance.governanceCentreTitle',
-    defaultMessage: '!!!Governance Centre Title',
+    defaultMessage: '!!!Governance Dashboard',
   },
   confirmTxTitle: {
     id: 'components.stakingcenter.confirmDelegation.title',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Renames the Governance Centre title to "Governance Dashboard" and updates the DRep entry modal to close via requestCloseModal after delegating to Yoroi.
> 
> - **Governance UI/i18n**:
>   - Update `components.governance.governanceCentreTitle` to "Governance Dashboard" in `mobile/src/kernel/i18n/locales/en-US.json` and `mobile/src/kernel/i18n/messages/staking.ts`.
> - **Governance Modal**:
>   - In `mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx`, use `requestCloseModal()` instead of `closeModal()` when delegating to Yoroi DRep.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 054cb5a4f398a169e5d0b6a80b31404a8c7112aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->