### PR TITLE
chore: merge from develop to preview

### DIFF
--- a/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
@@ -150,7 +150,7 @@ export const EnterDrepIdModal = ({onSubmit}: Props) => {
       type: 'key',
       CIP105: false,
     })
-    closeModal()
+    requestCloseModal()
   }
 
   return (

--- a/mobile/src/kernel/i18n/locales/en-US.json
+++ b/mobile/src/kernel/i18n/locales/en-US.json
@@ -165,7 +165,7 @@
   "components.governance.goToGovernance": "Go to Governance",
   "components.governance.goToStaking": "Go to staking",
   "components.governance.goToWallet": "Go to wallet",
-  "components.governance.governanceCentreTitle": "Dashboard",
+  "components.governance.governanceCentreTitle": "Governance Dashboard",
   "components.governance.hardwareWalletSupportComingSoon": "Hardware wallet support coming soon",
   "components.governance.learnMoreAboutGovernance": "Learn more About Governance",
   "components.governance.operations": "Operations",

--- a/mobile/src/kernel/i18n/messages/staking.ts
+++ b/mobile/src/kernel/i18n/messages/staking.ts
@@ -239,7 +239,7 @@ export const stakingMessages = defineMessages({
   },
   governanceCentreTitle: {
     id: 'components.governance.governanceCentreTitle',
-    defaultMessage: '!!!Governance Centre Title',
+    defaultMessage: '!!!Governance Dashboard',
   },
   confirmTxTitle: {
     id: 'components.stakingcenter.confirmDelegation.title',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Use safe modal close flow in Enter DRep modal and rename governance title to “Governance Dashboard.”
> 
> - **Governance UI**:
>   - `EnterDrepIdModal.tsx`: replace `closeModal()` with `requestCloseModal()` when delegating to Yoroi, ensuring proper keyboard-dismiss handling before closing.
> - **i18n**:
>   - `en-US.json`: update `components.governance.governanceCentreTitle` to "Governance Dashboard".
>   - `messages/staking.ts`: set `governanceCentreTitle.defaultMessage` to "!!!Governance Dashboard".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2301b3357b68f588d31423e1963f11e705ada43b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->