### PR TITLE
fix(mobile): loading screen keeps open in exchange screen

### DIFF
--- a/mobile/src/features/Exchange/useCases/CreateExchangeOrderScreen/CreateExchangeOrderScreen.tsx
+++ b/mobile/src/features/Exchange/useCases/CreateExchangeOrderScreen/CreateExchangeOrderScreen.tsx
@@ -46,7 +46,7 @@ export const CreateExchangeOrderScreen = () => {
     selected: {network},
   } = useWalletManager()
 
-  const {openModal, closeModal} = useModal()
+  const {openModal, closeModal, forceCloseModal} = useModal()
 
   const navigateTo = useNavigateTo()
   const {
@@ -122,7 +122,7 @@ export const CreateExchangeOrderScreen = () => {
         })
       },
       onSuccess: (referralLink) => {
-        closeModal()
+        forceCloseModal()
 
         if (referralLink.toString() !== '') {
           Linking.openURL(referralLink.toString())

--- a/mobile/src/ui/Modal/context/ModalContext.tsx
+++ b/mobile/src/ui/Modal/context/ModalContext.tsx
@@ -51,6 +51,7 @@ type ModalActions = {
     canExpand?: boolean
   }) => void
   closeModal: () => void
+  forceCloseModal: () => void
   setLoading: (isLoading: boolean) => void
   setFooter: (footer: React.ReactNode | undefined) => void
   setTitle: (title: string) => void
@@ -105,6 +106,13 @@ export const ModalProvider = ({children, initialState}: Props) => {
       type: 'closeAndProcessQueue',
     })
   }, [isKeyboardOpen])
+
+  const forceCloseModal = React.useCallback(() => {
+    Keyboard.dismiss()
+    dispatch({
+      type: 'closeAndProcessQueue',
+    })
+  }, [])
 
   const openModal = React.useCallback(
     ({
@@ -176,6 +184,7 @@ export const ModalProvider = ({children, initialState}: Props) => {
   const actions = React.useMemo<ModalActions>(
     () => ({
       closeModal,
+      forceCloseModal,
       openModal,
       setLoading: (isLoading: boolean) => {
         dispatch({
@@ -237,7 +246,7 @@ export const ModalProvider = ({children, initialState}: Props) => {
         })
       },
     }),
-    [closeModal, openModal],
+    [closeModal, forceCloseModal, openModal],
   )
 
   const context = React.useMemo(


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YW-135

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `forceCloseModal` action to reliably close modals (even with keyboard open) and uses it in the exchange order screen after referral link success.
> 
> - **Modal**:
>   - Add `forceCloseModal` to `ModalContext` API and implementation to always dismiss keyboard and close modal.
>   - Expose via context actions and update dependencies.
> - **Exchange**:
>   - Use `forceCloseModal` in `CreateExchangeOrderScreen` on referral link success to ensure the loading modal closes before navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 240073a37f6324c8cb1c7fc273480b171c5d4b63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->