### PR TITLE
fix: resolve multiple UI bugs and improve transaction notifications

### DIFF
--- a/mobile/packages/wallet-manager/hooks/useLaunchWalletAfterSyncing.tsx
+++ b/mobile/packages/wallet-manager/hooks/useLaunchWalletAfterSyncing.tsx
@@ -97,7 +97,27 @@ export function useLaunchWalletAfterSyncing({
         // Do quick sync first to make wallet usable immediately
         await wallet.quickSync({isForced: true})
 
-        // Navigate immediately after quick sync
+        // Wait a bit for balance to be calculated after quickSync
+        // Balance calculation happens asynchronously after UTXO sync
+        await new Promise((resolve) => setTimeout(resolve, 500))
+
+        // Check if balance is available (hydrated)
+        // For new/empty wallets, balance might legitimately be zero, but we want to ensure
+        // balance manager has been updated with the synced data
+        let balanceCheckAttempts = 0
+        const maxBalanceCheckAttempts = 5
+        while (balanceCheckAttempts < maxBalanceCheckAttempts) {
+          const balance = wallet.primaryBalance()
+          // If balance manager is hydrated and has processed the sync, proceed
+          // We check if balance info is available (not just quantity)
+          if (balance && balance.info) {
+            break
+          }
+          balanceCheckAttempts++
+          await new Promise((resolve) => setTimeout(resolve, 300))
+        }
+
+        // Navigate after balance is available
         if (shouldNavigateAfterSync) {
           try {
             walletNavigation.resetToTxHistory()

--- a/mobile/src/features/Airdrop/ui/AirdropNavigator.tsx
+++ b/mobile/src/features/Airdrop/ui/AirdropNavigator.tsx
@@ -63,7 +63,7 @@ export const AirdropNavigator = () => {
             Record<string, unknown>
           >
         }
-        options={{headerShown: false}}
+        options={{headerShown: true}}
       />
     </Stack.Navigator>
   )

--- a/mobile/src/features/Notifications/common/TransactionReceivedNotification.tsx
+++ b/mobile/src/features/Notifications/common/TransactionReceivedNotification.tsx
@@ -1,12 +1,11 @@
 import {YoroiWallet} from '@yoroi/cardano-wallet'
-import {Amounts, Quantities} from '@yoroi/cardano-wallet'
-import {useTheme} from '@yoroi/theme'
-import {Notifications, Portfolio} from '@yoroi/types'
+import {Notifications} from '@yoroi/types'
 import {useSelectedWallet} from '@yoroi/wallet-manager'
 
 import * as React from 'react'
-import {View} from 'react-native'
 
+import {getOperationTypeKey} from '~/features/Transactions/common/getOperationTypeKey'
+import {getOperationDisplayText} from '~/features/Transactions/common/operationDisplay'
 import {walletTransactionToSummary} from '~/features/Transactions/common/transactionSummary'
 import {useStrings} from '~/kernel/i18n/useStrings'
 import {Icon} from '~/ui/Icon'
@@ -34,43 +33,23 @@ export const getTransactionReceivedNotificationTitle = (
     wallet.portfolioPrimaryTokenInfo,
   )
 
-  const isIntraWallet = summary.direction === 'SELF'
-  const isReceived = summary.direction === 'RECEIVED'
-  const isSent = summary.direction === 'SENT'
+  // Use the same display text logic as transaction list item
+  const operationText = getOperationDisplayText(
+    rawTx,
+    strings,
+    summary.direction,
+    summary.amount,
+    rawTx.metadata,
+    rawTx.inputs,
+    rawTx.outputs,
+    summary.delta,
+  )
 
-  if (isIntraWallet) {
-    return strings.notifications.intraWalletTransactionSent
-  }
-
-  if (isReceived) {
-    const details = getTransactionSummaryDetails(summary, wallet)
-
-    return details.hasReceivedMultipleAssets
-      ? strings.notifications.multipleAssetsReceived
-      : `${formatAssets(
-          Quantities.format(
-            details.firstAssetAmountReceived,
-            details.firstReceivedAsset.denomination,
-          ),
-          details.firstReceivedAsset.name,
-        )} ${strings.notifications.received}`
-  }
-
-  if (isSent) {
-    const details = getTransactionSummaryDetails(summary, wallet)
-
-    return details.hasSentMultipleAssets
-      ? strings.notifications.multipleAssetsSent
-      : `${formatAssets(
-          Quantities.format(
-            details.firstAssetAmountSent,
-            details.firstSentAsset.denomination,
-          ),
-          details.firstSentAsset.name,
-        )} ${strings.notifications.sent}`
-  }
-
-  return ''
+  // Use operation text if available, otherwise fall back to direction
+  return (
+    operationText ??
+    strings.transactions.direction({direction: summary.direction})
+  )
 }
 
 export const getTransactionReceivedNotificationIcon = (
@@ -92,28 +71,24 @@ export const getTransactionReceivedNotificationIcon = (
     wallet.portfolioPrimaryTokenInfo,
   )
 
-  const isIntraWallet = summary.direction === 'SELF'
-  const isReceived = summary.direction === 'RECEIVED'
-  const isSent = summary.direction === 'SENT'
-  const isMultiSig = summary.direction === 'MULTI'
+  // Use the same operation type detection as transaction list item
+  const operationTypeKey = getOperationTypeKey(
+    rawTx,
+    summary.direction,
+    summary.amount,
+    rawTx.metadata,
+    rawTx.inputs,
+    rawTx.outputs,
+    summary.delta,
+  )
 
-  if (isIntraWallet) {
-    return <Icon.Direction transactionDirection="SELF" />
-  }
-
-  if (isReceived) {
-    return <Icon.Direction transactionDirection="RECEIVED" />
-  }
-
-  if (isSent) {
-    return <Icon.Direction transactionDirection="SENT" />
-  }
-
-  if (isMultiSig) {
-    return <Icon.Direction transactionDirection="MULTI" />
-  }
-
-  return null
+  // Use Icon.Direction with operation prop to get the correct icon (same as transaction list)
+  return (
+    <Icon.Direction
+      transactionDirection={summary.direction}
+      operation={operationTypeKey}
+    />
+  )
 }
 
 export const TransactionReceivedNotification = ({
@@ -135,122 +110,8 @@ export const TransactionReceivedNotification = ({
   )
 }
 const IconWrapper = ({event}: {event: Notifications.Event}) => {
-  const {palette: p} = useTheme()
   const {wallet} = useSelectedWallet()
 
-  return (
-    <View
-      style={[
-        {
-          width: 40,
-          height: 40,
-          borderRadius: 20,
-          alignItems: 'center',
-          justifyContent: 'center',
-        },
-        {backgroundColor: p.secondary_100},
-      ]}
-    >
-      {getTransactionReceivedNotificationIcon(event, wallet)}
-    </View>
-  )
-}
-
-const getTransactionSummaryDetails = (
-  summary: ReturnType<typeof walletTransactionToSummary>,
-  wallet: YoroiWallet,
-) => {
-  const primaryTokenInfo = wallet.portfolioPrimaryTokenInfo
-  const defaultId = primaryTokenInfo.id
-
-  // Convert delta to array of amounts and filter out zero amounts
-  const deltaAmounts = Amounts.toArray(summary.delta).filter(
-    ({quantity}) => !Quantities.isZero(quantity),
-  )
-
-  // Separate positive (received) and negative (sent) amounts
-  const positiveAmounts = deltaAmounts.filter(({quantity}) =>
-    Quantities.isGreaterThan(quantity, Quantities.zero),
-  )
-  const negativeAmounts = deltaAmounts.filter(({quantity}) =>
-    Quantities.isGreaterThan(Quantities.zero, quantity),
-  )
-
-  // Get non-default token IDs (excluding primary token)
-  const positiveIds = positiveAmounts
-    .filter(({tokenId}) => tokenId !== defaultId)
-    .map(({tokenId}) => tokenId)
-  const negativeIds = negativeAmounts
-    .filter(({tokenId}) => tokenId !== defaultId)
-    .map(({tokenId}) => tokenId)
-
-  // Get primary token delta
-  const ptDelta = Amounts.getAmount(summary.delta, defaultId).quantity
-
-  const hasReceivedMultipleAssets = positiveAmounts.length > 1
-  const hasSentMultipleAssets = negativeAmounts.length > 1
-
-  // Received side: prefer an actually received non-primary token; fallback to primary if none
-  const firstAssetIdReceived = positiveIds[0] ?? defaultId
-  const firstAssetAmountReceived =
-    positiveIds.length > 0
-      ? Amounts.getAmount(summary.delta, firstAssetIdReceived).quantity
-      : ptDelta
-  const firstReceivedAsset =
-    positiveIds.length > 0
-      ? resolveTokenInfo(firstAssetIdReceived, wallet, primaryTokenInfo)
-      : {name: primaryTokenInfo.name, denomination: primaryTokenInfo.decimals}
-
-  // Sent side: prefer an actually sent non-primary token; fallback to primary if none
-  const firstAssetIdSent = negativeIds[0] ?? defaultId
-  const firstAssetAmountSent =
-    negativeIds.length > 0
-      ? Quantities.negated(
-          Amounts.getAmount(summary.delta, firstAssetIdSent).quantity,
-        )
-      : Quantities.negated(ptDelta)
-
-  const firstSentAsset =
-    negativeIds.length > 0
-      ? resolveTokenInfo(firstAssetIdSent, wallet, primaryTokenInfo)
-      : {name: primaryTokenInfo.name, denomination: primaryTokenInfo.decimals}
-
-  return {
-    hasReceivedMultipleAssets,
-    hasSentMultipleAssets,
-    firstReceivedAsset,
-    firstSentAsset,
-    firstAssetAmountReceived,
-    firstAssetAmountSent,
-  }
-}
-
-const resolveTokenInfo = (
-  identifier: string,
-  wallet: YoroiWallet,
-  primaryTokenInfo: Portfolio.Token.Info,
-) => {
-  if (identifier === primaryTokenInfo.id) {
-    return {
-      name: primaryTokenInfo.name,
-      denomination: primaryTokenInfo.decimals,
-    }
-  }
-  const walletRecord = wallet
-    .balances()
-    .records.get(identifier as Portfolio.Token.Id)?.info
-  if (walletRecord != null) {
-    const pick = (...vals: Array<string | undefined>) =>
-      vals.find((v) => typeof v === 'string' && v.trim().length > 0) ??
-      identifier
-    const name = pick(walletRecord.ticker, walletRecord.name)
-    return {name, denomination: walletRecord.decimals}
-  }
-  // fallback: use identifier as name
-  return {name: identifier, denomination: 0}
-}
-
-const formatAssets = (quantity: string, name: string) => {
-  const truncatedName = name.length > 15 ? `${name.slice(0, 15)}...` : name
-  return `${quantity} ${truncatedName}`
+  // Icon.Direction already handles its own container styling with proper background colors
+  return getTransactionReceivedNotificationIcon(event, wallet)
 }

--- a/mobile/src/features/ReviewTx/ReviewTxNavigator.tsx
+++ b/mobile/src/features/ReviewTx/ReviewTxNavigator.tsx
@@ -39,7 +39,7 @@ export const ReviewTxNavigator = () => {
             Record<string, unknown>
           >
         }
-        options={{headerShown: false}}
+        options={{headerShown: true}}
       />
     </Stack.Navigator>
   )

--- a/mobile/src/kernel/i18n/messages/portfolio.ts
+++ b/mobile/src/kernel/i18n/messages/portfolio.ts
@@ -290,7 +290,7 @@ export const portfolioMessages = defineMessages({
     defaultMessage: '!!!Total dApps value tooltip',
   },
   portfolioSwapTokensTitle: {
-    id: 'components.txhistory.txnavigationbuttons.sendButton',
+    id: 'portfolio.portfolioDashboardScreen.portfolioSwapTokensTitle',
     defaultMessage: '!!!Portfolio Swap Tokens Title',
   },
   portfolioSwapTokensDescription: {

--- a/mobile/src/ui/Icon/Direction.tsx
+++ b/mobile/src/ui/Icon/Direction.tsx
@@ -160,7 +160,7 @@ const iconMap: Record<
   STAKE_REGISTRATION: StakingKeyRegistered,
   STAKE_DEREGISTRATION: StakingKeyDeregistered,
   STAKE_DELEGATION: Staking,
-  STAKE_UNDELEGATION: StakingKeyDeregistered,
+  STAKE_UNDELEGATION: Staking,
   VOTE_DELEGATION: Governance,
   COLLATERAL_CREATION: Lock,
   MINT: DigitalAsset,

--- a/mobile/src/ui/ResultScreen/ResultScreen.tsx
+++ b/mobile/src/ui/ResultScreen/ResultScreen.tsx
@@ -3,7 +3,6 @@ import {atoms as a, useTheme} from '@yoroi/theme'
 import * as React from 'react'
 import {Text, View} from 'react-native'
 
-import {useBlockGoBack} from '~/kernel/navigation/hooks/useBlockGoBack'
 import {useUnsafeParams} from '~/kernel/navigation/hooks/useUnsafeParams'
 import {Button, ButtonType} from '~/ui/Button/Button'
 import {FailedTxIcon} from '~/ui/FailedTxIcon/FailedTxIcon'
@@ -15,7 +14,6 @@ import {useResultScreenDefaults} from './ResultScreenContext'
 import {ResultScreenParams} from './types'
 
 export const ResultScreen = (props?: ResultScreenParams) => {
-  useBlockGoBack()
   const {palette: p, atoms: ta} = useTheme()
   const navParamsRaw = useUnsafeParams<
     ResultScreenParams | {route?: {params?: ResultScreenParams}}
@@ -70,8 +68,6 @@ export const ResultScreen = (props?: ResultScreenParams) => {
         a.justify_center,
       ]}
     >
-      <View style={{height: 144}} />
-
       {defaultIcon}
 
       <Space.Height.lg />


### PR DESCRIPTION
- Fix Stake Undelegation icon to use Staking icon (same as Stake Delegation)
- Fix portfolio swap banner title message ID (was using wrong 'sendButton' ID)
- Fix result screen missing back button by removing useBlockGoBack and enabling header
- Fix result screen UI displacement by removing spacer View
- Fix wallet balance showing 0 after restoration by waiting for balance sync
- Update transaction notifications to use same icons/labels as transaction list items
- Use getOperationTypeKey and getOperationDisplayText for consistent display
- Use Icon.Direction with operation prop for correct icons


https://emurgo.atlassian.net/browse/YW-133
https://emurgo.atlassian.net/browse/YW-409
https://emurgo.atlassian.net/browse/YW-404
https://emurgo.atlassian.net/browse/YW-411
https://emurgo.atlassian.net/browse/YW-406
https://emurgo.atlassian.net/browse/YW-198

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies transaction notification text/icons with the tx list, enables headers on result screens, waits for wallet balance hydration after quick sync, and fixes a portfolio i18n message ID.
> 
> - **Wallet launch flow**:
>   - In `wallet-manager/hooks/useLaunchWalletAfterSyncing.tsx`, wait for balance hydration after `quickSync` (with retries) before navigating; start background full sync.
> - **Notifications**:
>   - In `TransactionReceivedNotification.tsx`, use `getOperationDisplayText` and `getOperationTypeKey` with `Icon.Direction` for consistent titles/icons; remove bespoke asset logic and wrapper styling.
> - **Result screens & navigation**:
>   - In `AirdropNavigator.tsx` and `ReviewTxNavigator.tsx`, set `options: {headerShown: true}` for `result-screen`.
>   - In `ResultScreen.tsx`, remove back-blocking and spacer, simplify param handling and layout.
> - **Icons**:
>   - In `ui/Icon/Direction.tsx`, map `STAKE_UNDELEGATION` to `Staking` icon and keep direction-based coloring.
> - **i18n**:
>   - Fix `portfolioSwapTokensTitle` message ID to `portfolio.portfolioDashboardScreen.portfolioSwapTokensTitle` in `messages/portfolio.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0058b69b4dd9b28faec33136883972a405ad227. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->