### PR TITLE
fix(mobile): modal closure

### DIFF
--- a/mobile/src/ui/Modal/context/ModalContext.tsx
+++ b/mobile/src/ui/Modal/context/ModalContext.tsx
@@ -92,11 +92,13 @@ export const ModalProvider = ({children, initialState}: Props) => {
   const prevLoggedOutRef = React.useRef(isLoggedOut)
   const shouldCloseAfterKeyboardDismissRef = React.useRef(false)
   const isKeyboardOpen = useIsKeyboardOpen()
+  const isKeyboardOpenRef = React.useRef(isKeyboardOpen)
 
   React.useEffect(() => {
     isOpenRef.current = state.isOpen
     queueRef.current = state.queue
-  }, [state.isOpen, state.queue])
+    isKeyboardOpenRef.current = isKeyboardOpen
+  }, [state.isOpen, state.queue, isKeyboardOpen])
 
   React.useEffect(() => {
     if (!isKeyboardOpen && shouldCloseAfterKeyboardDismissRef.current) {
@@ -108,7 +110,7 @@ export const ModalProvider = ({children, initialState}: Props) => {
   }, [isKeyboardOpen])
 
   const closeModal = React.useCallback(() => {
-    if (isKeyboardOpen) {
+    if (isKeyboardOpenRef.current) {
       shouldCloseAfterKeyboardDismissRef.current = true
       Keyboard.dismiss()
       return
@@ -116,7 +118,7 @@ export const ModalProvider = ({children, initialState}: Props) => {
     dispatch({
       type: 'closeAndProcessQueue',
     })
-  }, [isKeyboardOpen])
+  }, [])
 
   const openModal = React.useCallback(
     ({


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YW-413

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces direct keyboard-open state checks with a ref in `ModalContext` to reliably defer closing until after keyboard dismissal and simplify callback deps.
> 
> - **Mobile ModalContext (`mobile/src/ui/Modal/context/ModalContext.tsx`)**:
>   - Track keyboard state with `isKeyboardOpenRef`, synced via effect; include `isKeyboardOpen` in effect deps.
>   - Update `closeModal` to read `isKeyboardOpenRef` and remove dependencies, deferring close via `Keyboard.dismiss()` when keyboard is open.
>   - Keep queue processing by dispatching `closeAndProcessQueue` after keyboard dismissal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c42f865448b7489cb15e250f4b164b122f678ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->