### PR TITLE
fix: metro path aliases

### DIFF
--- a/mobile/metro.config.js
+++ b/mobile/metro.config.js
@@ -33,6 +33,7 @@ config.resolver.alias = {
     projectRoot,
     './packages/dapp-connector',
   ),
+  '@yoroi/logger': path.resolve(projectRoot, './packages/logger'),
   '@yoroi/exchange': path.resolve(projectRoot, './packages/exchange'),
   '@yoroi/explorers': path.resolve(projectRoot, './packages/explorers'),
   '@yoroi/identicon': path.resolve(projectRoot, './packages/identicon'),
@@ -46,8 +47,14 @@ config.resolver.alias = {
   '@yoroi/theme': path.resolve(projectRoot, './packages/theme'),
   '@yoroi/transfer': path.resolve(projectRoot, './packages/transfer'),
   '@yoroi/types': path.resolve(projectRoot, './packages/types'),
-  '@yoroi/cardano-wallet': path.resolve(projectRoot, './packages/cardano-wallet'),
-  '@yoroi/wallet-manager': path.resolve(projectRoot, './packages/wallet-manager'),
+  '@yoroi/cardano-wallet': path.resolve(
+    projectRoot,
+    './packages/cardano-wallet',
+  ),
+  '@yoroi/wallet-manager': path.resolve(
+    projectRoot,
+    './packages/wallet-manager',
+  ),
   '@yoroi/tx': path.resolve(projectRoot, './packages/tx'),
   '@yoroi/p2p-communication': path.resolve(
     projectRoot,
@@ -57,6 +64,7 @@ config.resolver.alias = {
   // ~ aliases
   '~/ui': path.resolve(projectRoot, './src/ui'),
   '~/features': path.resolve(projectRoot, './src/features'),
+  '~/common': path.resolve(projectRoot, './src/common'),
   '~/hooks': path.resolve(projectRoot, './src/hooks'),
   '~/kernel': path.resolve(projectRoot, './src/kernel'),
   '~/wallets': path.resolve(projectRoot, './src/wallets'),

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -23,8 +23,6 @@
       "~/hooks/*": ["./src/hooks/*"],
       "~/kernel/*": ["./src/kernel/*"],
       "~/wallets/*": ["./src/wallets/*"],
-      "~/queries": ["./src/queries"],
-      "~/utils/*": ["./src/utils/*"],
       "~/components/*": ["./src/ui/*"],
       "~/assets/*": ["./assets/*"],
       "@yoroi/api": ["./packages/api"],


### PR DESCRIPTION
Not sure if it's actually affecting anything, but Ai was complaining on the other PR, so just in case the prod build works differently than preview one. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Metro aliases for `@yoroi/logger` and `~/common`, and removes stale TS path aliases `~/queries` and `~/utils/*`.
> 
> - **Config**:
>   - **Metro (`mobile/metro.config.js`)**:
>     - Add alias `@yoroi/logger` and `~/common`.
>   - **TypeScript (`mobile/tsconfig.json`)**:
>     - Remove path aliases `~/queries` and `~/utils/*`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fae79339077015df29c1bf511f477326e0aaa07b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->