### PR TITLE
chore: merge from develop to preview

### DIFF
--- a/mobile/scripts/check-thaw-schedule.js
+++ b/mobile/scripts/check-thaw-schedule.js
@@ -1,0 +1,442 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const REDEMPTION_API_BASE_URL = 'https://mainnet.prod.gd.midnighttge.io';
+
+/**
+ * Get API headers to match browser requests
+ */
+const getApiHeaders = () => ({
+  'accept': 'application/json, text/plain, */*',
+  'accept-language': 'en-US,en;q=0.9',
+  'cache-control': 'no-cache',
+  'origin': 'https://redeem.midnight.gd',
+  'referer': 'https://redeem.midnight.gd/',
+  'user-agent':
+    'Mozilla/5.0 (Linux; Android 10; Mobile) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.120 Mobile Safari/537.36',
+});
+
+/**
+ * Get thaw schedule for an address
+ */
+async function getThawSchedule(address) {
+  const url = `${REDEMPTION_API_BASE_URL}/thaws/${encodeURIComponent(address)}/schedule`;
+  
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: getApiHeaders(),
+    });
+
+    if (!response.ok) {
+      if (response.status === 404 || response.status === 400) {
+        return null; // Address not found or no allocations
+      }
+      if (response.status === 403) {
+        throw new Error('API_ACCESS_FORBIDDEN');
+      }
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    if (error.message === 'API_ACCESS_FORBIDDEN') {
+      throw error;
+    }
+    // Network errors or other issues
+    return null;
+  }
+}
+
+/**
+ * Get earliest redeemable thaw date (for sorting/prioritization)
+ */
+function getEarliestRedeemableDate(schedule) {
+  if (!schedule || !schedule.thaws || schedule.thaws.length === 0) {
+    return null;
+  }
+
+  const now = new Date();
+  const redeemableThaws = schedule.thaws
+    .filter((thaw) => {
+      const thawDate = new Date(thaw.thawing_period_start);
+      const hasStarted = thawDate <= now;
+      const isRedeemable = thaw.status === 'redeemable';
+      const isPendingRedeemable = thaw.status === 'upcoming' || thaw.status === 'queued';
+      const isNotRedeemed = 
+        thaw.status !== 'confirmed' &&
+        thaw.status !== 'confirming' &&
+        thaw.status !== 'submitted' &&
+        thaw.status !== 'failed';
+      
+      return (isRedeemable || (hasStarted && isPendingRedeemable && isNotRedeemed));
+    })
+    .sort(
+      (a, b) =>
+        new Date(a.thawing_period_start).getTime() -
+        new Date(b.thawing_period_start).getTime(),
+    );
+
+  return redeemableThaws.length > 0
+    ? redeemableThaws[0].thawing_period_start
+    : null;
+}
+
+/**
+ * Get next thaw date from schedule (next upcoming thaw that hasn't started)
+ */
+function getNextThawDate(schedule) {
+  if (!schedule || !schedule.thaws || schedule.thaws.length === 0) {
+    return null;
+  }
+
+  const now = new Date();
+  const upcomingThaws = schedule.thaws
+    .filter((thaw) => {
+      const thawDate = new Date(thaw.thawing_period_start);
+      return thawDate > now && thaw.status === 'upcoming';
+    })
+    .sort(
+      (a, b) =>
+        new Date(a.thawing_period_start).getTime() -
+        new Date(b.thawing_period_start).getTime(),
+    );
+
+  return upcomingThaws.length > 0
+    ? upcomingThaws[0].thawing_period_start
+    : null;
+}
+
+/**
+ * Calculate total allocation amount
+ */
+function calculateTotalAllocation(schedule) {
+  if (!schedule || !schedule.thaws) return 0;
+  return schedule.thaws.reduce((sum, thaw) => sum + (thaw.amount || 0), 0);
+}
+
+/**
+ * Calculate redeemable amount (thaws that have started)
+ */
+function calculateRedeemableAmount(schedule) {
+  if (!schedule || !schedule.thaws) return 0;
+  const now = new Date();
+  return schedule.thaws.reduce((sum, thaw) => {
+    const thawDate = new Date(thaw.thawing_period_start);
+    const hasStarted = thawDate <= now;
+    const isRedeemable = thaw.status === 'redeemable';
+    const isPendingRedeemable = thaw.status === 'upcoming' || thaw.status === 'queued';
+    const isNotRedeemed = 
+      thaw.status !== 'confirmed' &&
+      thaw.status !== 'confirming' &&
+      thaw.status !== 'submitted' &&
+      thaw.status !== 'failed';
+
+    if (isRedeemable || (hasStarted && isPendingRedeemable && isNotRedeemed)) {
+      return sum + (thaw.amount || 0);
+    }
+    return sum;
+  }, 0);
+}
+
+/**
+ * Format amount for display
+ */
+function formatAmount(amount) {
+  return new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 6,
+  }).format(amount);
+}
+
+/**
+ * Process addresses and check thaw schedules
+ */
+async function checkAddresses(inputFile, outputFile, reportFile) {
+  console.log(`Reading addresses from: ${inputFile}`);
+  
+  const fileContent = fs.readFileSync(inputFile, 'utf-8');
+  const addresses = fileContent
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0);
+
+  console.log(`Found ${addresses.length} addresses to check\n`);
+
+  const results = [];
+  let processed = 0;
+  let errors = 0;
+
+  // Process addresses with a delay to avoid rate limiting
+  for (const address of addresses) {
+    processed++;
+    process.stdout.write(`[${processed}/${addresses.length}] Checking ${address}... `);
+
+    try {
+      const schedule = await getThawSchedule(address);
+      
+      if (schedule === null) {
+        console.log('No allocations');
+        results.push({
+          address,
+          eligible: false,
+          nextThawDate: null,
+          schedule: null,
+        });
+      } else {
+        const earliestRedeemable = getEarliestRedeemableDate(schedule);
+        const nextThawDate = getNextThawDate(schedule);
+        const status = earliestRedeemable 
+          ? `Redeemable now (next: ${nextThawDate || 'N/A'})` 
+          : (nextThawDate ? `Next thaw: ${nextThawDate}` : 'All thaws completed');
+        console.log(status);
+        
+        results.push({
+          address,
+          eligible: true,
+          nextThawDate,
+          earliestRedeemableDate: earliestRedeemable,
+          schedule,
+        });
+      }
+    } catch (error) {
+      errors++;
+      console.log(`Error: ${error.message}`);
+      results.push({
+        address,
+        eligible: false,
+        nextThawDate: null,
+        error: error.message,
+        schedule: null,
+      });
+    }
+
+    // Small delay to avoid rate limiting (100ms between requests)
+    if (processed < addresses.length) {
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+  }
+
+  console.log(`\n\nProcessing complete!`);
+  console.log(`- Processed: ${processed}`);
+  console.log(`- Errors: ${errors}`);
+  console.log(`- Eligible: ${results.filter(r => r.eligible).length}`);
+
+  // Sort by earliest redeemable date first (prioritize addresses with redeemable thaws),
+  // then by next thaw date (nulls go to the end)
+  results.sort((a, b) => {
+    // Prioritize addresses with redeemable thaws
+    const aHasRedeemable = a.earliestRedeemableDate !== null;
+    const bHasRedeemable = b.earliestRedeemableDate !== null;
+    
+    if (aHasRedeemable && !bHasRedeemable) return -1;
+    if (!aHasRedeemable && bHasRedeemable) return 1;
+    
+    // If both have redeemable, sort by earliest redeemable date
+    if (aHasRedeemable && bHasRedeemable) {
+      return new Date(a.earliestRedeemableDate).getTime() - new Date(b.earliestRedeemableDate).getTime();
+    }
+    
+    // Otherwise sort by next thaw date
+    if (a.nextThawDate === null && b.nextThawDate === null) return 0;
+    if (a.nextThawDate === null) return 1;
+    if (b.nextThawDate === null) return -1;
+    return new Date(a.nextThawDate).getTime() - new Date(b.nextThawDate).getTime();
+  });
+
+  // Write summary results to output file
+  console.log(`\nWriting summary to: ${outputFile}`);
+  
+  const outputLines = [];
+  outputLines.push('# Addresses sorted by next thaw schedule');
+  outputLines.push(`# Generated: ${new Date().toISOString()}`);
+  outputLines.push(`# Total addresses: ${addresses.length}`);
+  outputLines.push(`# Eligible addresses: ${results.filter(r => r.eligible).length}`);
+  outputLines.push('');
+  outputLines.push('Address | Eligible | Next Thaw Date | Total Thaws');
+  outputLines.push('--- | --- | --- | ---');
+
+  for (const result of results) {
+    const nextThawStr = result.nextThawDate 
+      ? new Date(result.nextThawDate).toISOString()
+      : 'N/A';
+    const totalThaws = result.schedule?.thaws?.length || 0;
+    const eligibleStr = result.eligible ? 'Yes' : 'No';
+    
+    outputLines.push(`${result.address} | ${eligibleStr} | ${nextThawStr} | ${totalThaws}`);
+  }
+
+  // Also create a simple address-only file sorted by thaw date
+  const addressOnlyLines = results
+    .filter(r => r.eligible && r.nextThawDate !== null)
+    .map(r => r.address);
+
+  const addressOnlyFile = outputFile.replace(/\.(txt|md)$/, '_addresses_only.txt');
+  fs.writeFileSync(addressOnlyFile, addressOnlyLines.join('\n') + '\n');
+  console.log(`Also created address-only file: ${addressOnlyFile}`);
+
+  fs.writeFileSync(outputFile, outputLines.join('\n') + '\n');
+
+  // Write detailed report
+  console.log(`Writing detailed report to: ${reportFile}`);
+  writeDetailedReport(results, reportFile);
+  console.log('Done!');
+}
+
+/**
+ * Write detailed report with all thaw information
+ */
+function writeDetailedReport(results, reportFile) {
+  const now = new Date();
+  const eligibleResults = results.filter(r => r.eligible && r.schedule);
+  
+  const reportLines = [];
+  reportLines.push('# Detailed Thaw Schedule Report');
+  reportLines.push(`# Generated: ${now.toISOString()}`);
+  reportLines.push(`# Total addresses checked: ${results.length}`);
+  reportLines.push(`# Eligible addresses: ${eligibleResults.length}`);
+  reportLines.push(`# Non-eligible addresses: ${results.length - eligibleResults.length}`);
+  reportLines.push('');
+  
+  // Summary statistics
+  const totalAllocation = eligibleResults.reduce((sum, r) => 
+    sum + calculateTotalAllocation(r.schedule), 0);
+  const totalRedeemable = eligibleResults.reduce((sum, r) => 
+    sum + calculateRedeemableAmount(r.schedule), 0);
+  const totalRemaining = totalAllocation - totalRedeemable;
+  
+  reportLines.push('## Summary Statistics');
+  reportLines.push('');
+  reportLines.push(`- **Total Allocation**: ${formatAmount(totalAllocation)} NIGHT`);
+  reportLines.push(`- **Currently Redeemable**: ${formatAmount(totalRedeemable)} NIGHT`);
+  reportLines.push(`- **Remaining to Redeem**: ${formatAmount(totalRemaining)} NIGHT`);
+  reportLines.push('');
+  
+  // Group by earliest redeemable date first, then by next thaw date
+  const byThawDate = {};
+  eligibleResults.forEach(result => {
+    // Prioritize grouping by redeemable date if available
+    const dateKey = result.earliestRedeemableDate
+      ? `redeemable-${new Date(result.earliestRedeemableDate).toISOString().split('T')[0]}`
+      : (result.nextThawDate 
+          ? new Date(result.nextThawDate).toISOString().split('T')[0]
+          : 'completed');
+    if (!byThawDate[dateKey]) {
+      byThawDate[dateKey] = [];
+    }
+    byThawDate[dateKey].push(result);
+  });
+  
+  reportLines.push('## Addresses by Thaw Schedule');
+  reportLines.push('');
+  
+  const sortedDates = Object.keys(byThawDate).sort((a, b) => {
+    // "redeemable-" dates come first
+    if (a.startsWith('redeemable-') && !b.startsWith('redeemable-')) return -1;
+    if (!a.startsWith('redeemable-') && b.startsWith('redeemable-')) return 1;
+    if (a === 'completed') return 1;
+    if (b === 'completed') return -1;
+    // Remove "redeemable-" prefix for comparison
+    const aDate = a.replace('redeemable-', '');
+    const bDate = b.replace('redeemable-', '');
+    return aDate.localeCompare(bDate);
+  });
+  
+  for (const dateKey of sortedDates) {
+    const dateResults = byThawDate[dateKey];
+    let dateLabel;
+    if (dateKey === 'completed') {
+      dateLabel = 'All Thaws Completed';
+    } else if (dateKey.startsWith('redeemable-')) {
+      const actualDate = dateKey.replace('redeemable-', '');
+      dateLabel = `Currently Redeemable (Started: ${new Date(actualDate).toLocaleDateString('en-US', { 
+        year: 'numeric', 
+        month: 'long', 
+        day: 'numeric' 
+      })})`;
+    } else {
+      dateLabel = `Next Thaw: ${new Date(dateKey).toLocaleDateString('en-US', { 
+        year: 'numeric', 
+        month: 'long', 
+        day: 'numeric' 
+      })}`;
+    }
+    
+    reportLines.push(`### ${dateLabel} (${dateResults.length} addresses)`);
+    reportLines.push('');
+    
+    for (const result of dateResults) {
+      const schedule = result.schedule;
+      const totalAlloc = calculateTotalAllocation(schedule);
+      const redeemable = calculateRedeemableAmount(schedule);
+      const remaining = totalAlloc - redeemable;
+      
+      reportLines.push(`#### ${result.address}`);
+      reportLines.push('');
+      reportLines.push(`- **Total Allocation**: ${formatAmount(totalAlloc)} NIGHT`);
+      reportLines.push(`- **Redeemable Now**: ${formatAmount(redeemable)} NIGHT`);
+      reportLines.push(`- **Remaining**: ${formatAmount(remaining)} NIGHT`);
+      reportLines.push(`- **Number of Thaws**: ${schedule.thaws.length}`);
+      if (result.earliestRedeemableDate) {
+        reportLines.push(`- **Earliest Redeemable Date**: ${new Date(result.earliestRedeemableDate).toISOString()} ⚠️ **AVAILABLE NOW**`);
+      }
+      reportLines.push(`- **Next Upcoming Thaw Date**: ${result.nextThawDate ? new Date(result.nextThawDate).toISOString() : 'N/A'}`);
+      reportLines.push('');
+      reportLines.push('**Thaw Schedule:**');
+      reportLines.push('');
+      reportLines.push('| # | Date | Amount | Status |');
+      reportLines.push('|---|------|--------|--------|');
+      
+      schedule.thaws.forEach((thaw, index) => {
+        const thawDate = new Date(thaw.thawing_period_start);
+        const dateStr = thawDate.toISOString();
+        const amount = formatAmount(thaw.amount);
+        const status = thaw.status;
+        reportLines.push(`| ${index + 1} | ${dateStr} | ${amount} NIGHT | ${status} |`);
+      });
+      
+      reportLines.push('');
+      reportLines.push('---');
+      reportLines.push('');
+    }
+  }
+  
+  // Non-eligible addresses
+  const nonEligible = results.filter(r => !r.eligible);
+  if (nonEligible.length > 0) {
+    reportLines.push('## Non-Eligible Addresses');
+    reportLines.push('');
+    reportLines.push(`Total: ${nonEligible.length}`);
+    reportLines.push('');
+    reportLines.push('| Address | Reason |');
+    reportLines.push('|---------|--------|');
+    
+    nonEligible.forEach(result => {
+      const reason = result.error || 'No allocations found';
+      reportLines.push(`| ${result.address} | ${reason} |`);
+    });
+    reportLines.push('');
+  }
+  
+  fs.writeFileSync(reportFile, reportLines.join('\n') + '\n');
+}
+
+// Main execution
+const inputFile = process.argv[2] || '/home/jorbuedo/Downloads/fixed';
+const outputDir = path.dirname(inputFile);
+const outputFile = process.argv[3] || path.join(outputDir, 'thaw_schedule_results.md');
+const reportFile = process.argv[4] || path.join(outputDir, 'thaw_schedule_detailed_report.md');
+
+if (!fs.existsSync(inputFile)) {
+  console.error(`Error: Input file not found: ${inputFile}`);
+  process.exit(1);
+}
+
+checkAddresses(inputFile, outputFile, reportFile).catch((error) => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});
+

--- a/mobile/src/features/Airdrop/common/useAirdropEligibility.ts
+++ b/mobile/src/features/Airdrop/common/useAirdropEligibility.ts
@@ -175,8 +175,20 @@ export const useAirdropEligibility = () => {
                   : 'Manual address'
             }
 
+            // Recalculate numberOfClaimedAllocations from confirmed/confirming thaws
+            // (API sometimes returns incorrect value, so we calculate it ourselves)
+            const numberOfClaimedAllocations =
+              cachedAllocation.schedule.thaws.filter(
+                (thaw) =>
+                  thaw.status === 'confirmed' || thaw.status === 'confirming',
+              ).length
+
             allocations.push({
               ...cachedAllocation,
+              schedule: {
+                ...cachedAllocation.schedule,
+                numberOfClaimedAllocations,
+              },
               isExternal,
               displayName,
               nextThawDate,
@@ -219,9 +231,21 @@ export const useAirdropEligibility = () => {
             continue
           }
 
+          // Recalculate numberOfClaimedAllocations from confirmed/confirming thaws
+          // (API sometimes returns incorrect value, so we calculate it ourselves)
+          const numberOfClaimedAllocations =
+            cachedAllocation.schedule.thaws.filter(
+              (thaw) =>
+                thaw.status === 'confirmed' || thaw.status === 'confirming',
+            ).length
+
           // We have cached data - include it
           allocations.push({
             ...cachedAllocation,
+            schedule: {
+              ...cachedAllocation.schedule,
+              numberOfClaimedAllocations,
+            },
             isExternal: true,
             displayName,
             nextThawDate,
@@ -263,11 +287,10 @@ export const useAirdropEligibility = () => {
             .filter((thaw) => thaw.status === 'redeemable')
             .reduce((sum, thaw) => sum + thaw.amount, 0)
 
-          // Calculate total allocation (sum of all thaws)
-          const totalAllocation = schedule.thaws.reduce(
-            (sum, thaw) => sum + thaw.amount,
-            0,
-          )
+          // Calculate total allocation (sum of all thaws excluding failed ones)
+          const totalAllocation = schedule.thaws
+            .filter((thaw) => thaw.status !== 'failed')
+            .reduce((sum, thaw) => sum + thaw.amount, 0)
 
           // Calculate redeemed so far (sum of confirmed thaws)
           const redeemedSoFar = schedule.thaws
@@ -277,6 +300,7 @@ export const useAirdropEligibility = () => {
             )
             .reduce((sum, thaw) => sum + thaw.amount, 0)
 
+          // Total left to redeem excludes redeemed thaws (failed already excluded from totalAllocation)
           const totalLeftToRedeem = totalAllocation - redeemedSoFar
 
           // Find the next upcoming thaw that hasn't started yet
@@ -297,6 +321,13 @@ export const useAirdropEligibility = () => {
               ? (upcomingThaws[0]?.thawing_period_start ?? null)
               : null
 
+          // Calculate numberOfClaimedAllocations from confirmed/confirming thaws
+          // (API sometimes returns incorrect value, so we calculate it ourselves)
+          const numberOfClaimedAllocations = schedule.thaws.filter(
+            (thaw) =>
+              thaw.status === 'confirmed' || thaw.status === 'confirming',
+          ).length
+
           // Get display name for external address
           const isExternal = externalAddresses.has(address)
           let displayName: string | undefined
@@ -312,7 +343,10 @@ export const useAirdropEligibility = () => {
 
           allocations.push({
             address,
-            schedule,
+            schedule: {
+              ...schedule,
+              numberOfClaimedAllocations,
+            },
             redeemableAmount,
             totalAllocation,
             redeemedSoFar,

--- a/mobile/src/features/Airdrop/common/useHasRedeemableThaws.ts
+++ b/mobile/src/features/Airdrop/common/useHasRedeemableThaws.ts
@@ -24,17 +24,23 @@ export const useHasRedeemableThaws = () => {
 
       // Also check if any thaw has started but isn't confirmed yet
       // (in case backend hasn't updated status yet)
+      // Exclude failed and skipped thaws - they cannot be redeemed
       return allocation.schedule.thaws.some((thaw) => {
+        const thawStatus = thaw.status
+        // Skip failed and skipped thaws - they cannot be redeemed
+        if (thawStatus === 'failed' || thawStatus === 'skipped') {
+          return false
+        }
+
         const thawDate = new Date(thaw.thawing_period_start.replace(/\s/g, ''))
         const hasStarted = thawDate <= now
-        const isRedeemable = thaw.status === 'redeemable'
+        const isRedeemable = thawStatus === 'redeemable'
         const isPendingRedeemable =
-          thaw.status === 'upcoming' || thaw.status === 'queued'
+          thawStatus === 'upcoming' || thawStatus === 'queued'
         const isNotRedeemed =
-          thaw.status !== 'confirmed' &&
-          thaw.status !== 'confirming' &&
-          thaw.status !== 'submitted' &&
-          thaw.status !== 'failed'
+          thawStatus !== 'confirmed' &&
+          thawStatus !== 'confirming' &&
+          thawStatus !== 'submitted'
 
         return (
           isRedeemable || (hasStarted && isPendingRedeemable && isNotRedeemed)

--- a/mobile/src/features/Airdrop/ui/AirdropDetailsScreen.tsx
+++ b/mobile/src/features/Airdrop/ui/AirdropDetailsScreen.tsx
@@ -72,18 +72,22 @@ const getCurrentThawIndex = (thaws: ReadonlyArray<Thaw>): number | null => {
 
   const now = new Date()
 
-  // First, try to find an active/redeemable thaw (started but not confirmed)
+  // First, try to find an active/redeemable thaw (started but not confirmed and not failed)
   for (let i = 0; i < thaws.length; i++) {
     const thaw = thaws[i]
     if (!thaw) continue
     const thawDate = new Date(thaw.thawing_period_start.replace(/\s/g, ''))
-    // Active thaw: started and not confirmed
-    if (thawDate <= now && thaw.status !== 'confirmed') {
+    // Active thaw: started and not confirmed and not failed
+    if (
+      thawDate <= now &&
+      thaw.status !== 'confirmed' &&
+      thaw.status !== 'failed'
+    ) {
       return i
     }
   }
 
-  // If no active thaw, find the first upcoming thaw (next one to start)
+  // If no active thaw, find the first upcoming thaw (next one to start, not failed)
   for (let i = 0; i < thaws.length; i++) {
     const thaw = thaws[i]
     if (!thaw) continue
@@ -293,7 +297,7 @@ export const AirdropDetailsScreen = () => {
         )
         resultNavigation.showResultScreen({
           type: 'error',
-          context: 'default',
+          context: 'airdrop',
           title: strings.airdrop.insufficientFunds,
           message: strings.airdrop.redeemError,
           primaryAction: {

--- a/mobile/src/features/Airdrop/ui/ThawScheduleScreen.tsx
+++ b/mobile/src/features/Airdrop/ui/ThawScheduleScreen.tsx
@@ -11,7 +11,7 @@ import {StackNavigationProp} from '@react-navigation/stack'
 import {BigNumber} from 'bignumber.js'
 import * as React from 'react'
 import {useIntl} from 'react-intl'
-import {ScrollView, Text, View} from 'react-native'
+import {Pressable, ScrollView, Text, View} from 'react-native'
 import {SafeAreaView} from 'react-native-safe-area-context'
 
 import {useNavigateTo} from '~/features/ReviewTx/common/hooks/useNavigateTo'
@@ -38,8 +38,89 @@ const formatAmount = (amount: number): string => {
   return normalized.toFormat(2)
 }
 
+/**
+ * Parse error message to extract and format POSIX timestamps into human-readable dates
+ */
+const formatErrorMessage = (
+  errorMessage: string,
+  intl: {
+    formatDate: (
+      date: Date,
+      options?: {
+        year?: 'numeric' | '2-digit'
+        month?: 'short' | 'long' | 'numeric' | '2-digit'
+        day?: 'numeric' | '2-digit'
+        hour?: '2-digit'
+        minute?: '2-digit'
+      },
+    ) => string
+  },
+): string => {
+  // Check if error contains POSIX timestamps
+  const posixTimeRegex = /getPOSIXTime\s*=\s*(\d+)/g
+  const matches = Array.from(errorMessage.matchAll(posixTimeRegex))
+
+  if (matches.length === 0) {
+    return errorMessage
+  }
+
+  // Extract nextThaw and now timestamps
+  let formattedMessage = errorMessage
+
+  // Try to find nextThaw timestamp
+  const nextThawMatch = errorMessage.match(
+    /nextThaw\s*=\s*POSIXTime\s*\{\s*getPOSIXTime\s*=\s*(\d+)\s*\}/,
+  )
+  const nowMatch = errorMessage.match(
+    /now\s*=\s*POSIXTime\s*\{\s*getPOSIXTime\s*=\s*(\d+)\s*\}/,
+  )
+
+  if (nextThawMatch && nowMatch && nextThawMatch[1] && nowMatch[1]) {
+    const nextThawTimestamp = parseInt(nextThawMatch[1], 10)
+    const nowTimestamp = parseInt(nowMatch[1], 10)
+
+    // Convert POSIX timestamps (milliseconds) to Date objects
+    const nextThawDate = new Date(nextThawTimestamp)
+    const nowDate = new Date(nowTimestamp)
+
+    // Format dates using intl
+    const formattedNextThaw = intl.formatDate(nextThawDate, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+
+    // Create a more user-friendly error message
+    if (errorMessage.includes('NoRedeemableThaws')) {
+      formattedMessage = `There are no redeemable thaws available. The next thaw will be available on ${formattedNextThaw}.`
+    } else {
+      // For other errors, replace timestamps with formatted dates
+      formattedMessage = errorMessage
+        .replace(
+          /nextThaw\s*=\s*POSIXTime\s*\{\s*getPOSIXTime\s*=\s*\d+\s*\}/,
+          `nextThaw = ${formattedNextThaw}`,
+        )
+        .replace(
+          /now\s*=\s*POSIXTime\s*\{\s*getPOSIXTime\s*=\s*\d+\s*\}/,
+          `now = ${intl.formatDate(nowDate, {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+          })}`,
+        )
+    }
+  }
+
+  return formattedMessage
+}
+
 export const ThawScheduleScreen = () => {
   const strings = useStrings()
+  const intl = useIntl()
   const {atoms: ta} = useTheme()
   const route = useRoute<RouteProp<AirdropRoutes, 'airdrop-thaw-schedule'>>()
   const navigation = useNavigation<StackNavigationProp<AirdropRoutes>>()
@@ -121,7 +202,8 @@ export const ThawScheduleScreen = () => {
   }, [thaws, refetchEligibility])
 
   const handleRedeem = async () => {
-    if (!canRedeem || isRedeeming) {
+    // Allow retry even if canRedeem is false (for failed/completed thaws)
+    if (isRedeeming) {
       return
     }
 
@@ -179,6 +261,12 @@ export const ThawScheduleScreen = () => {
         },
       })
     } catch (error) {
+      logger.error('handleRedeem: Failed to redeem', {
+        destAddress: allocation.address,
+        error: error instanceof Error ? error.message : String(error),
+        errorStack: error instanceof Error ? error.stack : undefined,
+      })
+
       // Check if error is due to insufficient funds
       if (isInsufficientBalanceError(error)) {
         logger.info(
@@ -187,7 +275,7 @@ export const ThawScheduleScreen = () => {
         )
         resultNavigation.showResultScreen({
           type: 'error',
-          context: 'default',
+          context: 'airdrop',
           title: strings.airdrop.insufficientFunds,
           message: strings.airdrop.redeemError,
           primaryAction: {
@@ -213,7 +301,42 @@ export const ThawScheduleScreen = () => {
         return
       }
 
-      setIsRedeeming(false)
+      // Show error message for other build failures (e.g., already redeemed, no redeemable thaws)
+      const rawErrorMessage =
+        error instanceof Error
+          ? error.message
+          : 'Failed to build redemption transaction'
+      const formattedErrorMessage = formatErrorMessage(rawErrorMessage, intl)
+
+      // Use more specific title for "NoRedeemableThaws" errors
+      const errorTitle = rawErrorMessage.includes('NoRedeemableThaws')
+        ? strings.airdrop.noRedeemableThaws
+        : strings.airdrop.redeemError
+
+      resultNavigation.showResultScreen({
+        type: 'error',
+        context: 'airdrop',
+        title: errorTitle,
+        message: formattedErrorMessage,
+        primaryAction: {
+          title: strings.txReview.failedTxButton,
+          onPress: () => {
+            setIsRedeeming(false)
+            // Navigate back to thaw schedule screen
+            navigation.dispatch(
+              CommonActions.reset({
+                index: 0,
+                routes: [
+                  {
+                    name: 'airdrop-thaw-schedule',
+                    params: {allocation},
+                  },
+                ],
+              }),
+            )
+          },
+        },
+      })
     }
   }
 
@@ -230,6 +353,10 @@ export const ThawScheduleScreen = () => {
             index={index}
             totalThaws={totalThaws}
             isLast={index === thaws.length - 1}
+            onRetryFailed={handleRedeem}
+            isReadOnly={isReadOnly}
+            isWalletInitialized={isWalletInitialized}
+            isRedeeming={isRedeeming}
           />
         ))}
       </ScrollView>
@@ -253,9 +380,22 @@ type ThawItemProps = {
   index: number
   totalThaws: number
   isLast: boolean
+  onRetryFailed: () => Promise<void>
+  isReadOnly: boolean
+  isWalletInitialized: boolean
+  isRedeeming: boolean
 }
 
-const ThawItem = ({thaw, index, totalThaws, isLast}: ThawItemProps) => {
+const ThawItem = ({
+  thaw,
+  index,
+  totalThaws,
+  isLast,
+  onRetryFailed,
+  isReadOnly,
+  isWalletInitialized,
+  isRedeeming,
+}: ThawItemProps) => {
   const strings = useStrings()
   const intl = useIntl()
   const {atoms: ta, palette: p} = useTheme()
@@ -289,11 +429,19 @@ const ThawItem = ({thaw, index, totalThaws, isLast}: ThawItemProps) => {
     minute: '2-digit',
   })
 
+  const isFailed = thaw.status === 'failed'
+
   const getStatusBadge = () => {
     if (isCompleted) {
       return {
         label: strings.airdrop.redeemed,
         color: p.secondary_600,
+      }
+    }
+    if (isFailed) {
+      return {
+        label: strings.airdrop.status.failed,
+        color: p.sys_magenta_500,
       }
     }
     if (isRedeemable) {
@@ -329,6 +477,21 @@ const ThawItem = ({thaw, index, totalThaws, isLast}: ThawItemProps) => {
             ]}
           >
             <Icon.Check size={16} color={p.white_static} />
+          </View>
+        ) : isFailed ? (
+          <View
+            style={[
+              a.align_center,
+              a.justify_center,
+              a.rounded_full,
+              {
+                width: 28,
+                height: 28,
+                backgroundColor: p.sys_magenta_500,
+              },
+            ]}
+          >
+            <Icon.Close size={16} color={p.white_static} />
           </View>
         ) : isRedeemable ? (
           <View
@@ -406,8 +569,33 @@ const ThawItem = ({thaw, index, totalThaws, isLast}: ThawItemProps) => {
 
         <Space.Height.sm />
 
-        {/* Status badge */}
-        <Badge label={badge.label} color={badge.color} />
+        {/* Status badge and Try again button for failed thaws */}
+        <View style={[a.flex_row, a.align_center, a.gap_sm]}>
+          <Badge label={badge.label} color={badge.color} />
+          {isFailed && !isReadOnly && isWalletInitialized && (
+            <Pressable
+              onPress={onRetryFailed}
+              disabled={isRedeeming}
+              style={({pressed}) => [
+                {
+                  borderRadius: 999,
+                  paddingHorizontal: 8,
+                  paddingVertical: 4,
+                  backgroundColor: pressed
+                    ? p.primary_600
+                    : isRedeeming
+                      ? p.gray_400
+                      : p.primary_500,
+                  opacity: isRedeeming ? 0.6 : 1,
+                },
+              ]}
+            >
+              <Text style={[a.body_3_sm_regular, {color: p.white_static}]}>
+                {strings.airdrop.tryAgain}
+              </Text>
+            </Pressable>
+          )}
+        </View>
       </View>
     </View>
   )

--- a/mobile/src/features/Links/common/parsers.ts
+++ b/mobile/src/features/Links/common/parsers.ts
@@ -116,6 +116,8 @@ export const parseCardanoLink = (codeContent: string): Links.CardanoAction => {
   // Handle drep authority (DRep delegation)
   if (authority === 'drep') {
     const {drep} = parsedCardanoLink.params
+    // DRep ID from deeplink can be bech32 format (drep1...), not just hex
+    // asDRepId will warn if not hex but still cast it - parsing happens later
     return freeze({
       action: 'delegate-drep',
       drep: Branded.asDRepId(drep as string),

--- a/mobile/src/features/Links/components/ActionHandler.tsx
+++ b/mobile/src/features/Links/components/ActionHandler.tsx
@@ -54,6 +54,20 @@ const showsModal = (pendingAction: PendingAction): boolean => {
 }
 
 /**
+ * Check if an action navigates to a screen that uses route params.
+ * These actions should be cleared after navigation completes to prevent
+ * re-triggering when navigating back.
+ */
+const needsDelayedClearing = (pendingAction: PendingAction): boolean => {
+  if (pendingAction.source === 'cardano') {
+    // delegate-drep navigates with route params that persist in navigation state
+    // We need to delay clearing to ensure navigation completes first
+    return pendingAction.action.action === 'delegate-drep'
+  }
+  return false
+}
+
+/**
  * Create a safe action ID without circular references
  */
 const createActionId = (pendingAction: PendingAction | null): string | null => {
@@ -333,12 +347,22 @@ export const ActionHandler = () => {
             try {
               executeActionRef.current(action)
               if (!showsModal(action)) {
-                // For non-modal actions, mark as processed immediately
-                markActionProcessedRef.current()
-                // Clear processing flag after a short delay to prevent rapid re-processing
-                setTimeout(() => {
-                  isProcessingRef.current = false
-                }, 100)
+                if (needsDelayedClearing(action)) {
+                  // For navigation actions that use route params, delay clearing
+                  // to ensure navigation completes before clearing the action
+                  // This prevents re-triggering when navigating back
+                  setTimeout(() => {
+                    markActionProcessedRef.current()
+                    isProcessingRef.current = false
+                  }, 500)
+                } else {
+                  // For non-modal actions, mark as processed immediately
+                  markActionProcessedRef.current()
+                  // Clear processing flag after a short delay to prevent rapid re-processing
+                  setTimeout(() => {
+                    isProcessingRef.current = false
+                  }, 100)
+                }
               } else {
                 // For modal actions, clear processing flag after modal is shown
                 // The modal will call markActionProcessed when it closes

--- a/mobile/src/features/Portfolio/common/hooks/useNavigateTo.tsx
+++ b/mobile/src/features/Portfolio/common/hooks/useNavigateTo.tsx
@@ -1,14 +1,22 @@
 import {isEmptyString} from '@yoroi/cardano-wallet'
-import {Portfolio} from '@yoroi/types'
+import {Chain, Portfolio} from '@yoroi/types'
+import {useSelectedNetwork} from '@yoroi/wallet-manager'
 
 import {NavigationProp, useNavigation} from '@react-navigation/native'
 import * as React from 'react'
 
+import {useRemoteConfig} from '~/common/hooks/useRemoteConfig'
+import {setPendingSwapToken} from '~/features/Notifications/common/tools'
+import {useSwap} from '~/features/Swap/common/useSwap'
 import {useParams} from '~/kernel/navigation/hooks/useParams'
 import {PortfolioRoutes} from '~/kernel/navigation/types'
 
 export const useNavigateTo = () => {
   const navigation = useNavigation<NavigationProp<PortfolioRoutes>>()
+  const swapForm = useSwap()
+  const {network} = useSelectedNetwork()
+  const {config} = useRemoteConfig()
+  const tokenOutId = config?.swap?.initialPair?.tokenOut
 
   return React.useRef({
     tokensList: () => navigation.navigate('portfolio-tokens-list'),
@@ -27,6 +35,31 @@ export const useNavigateTo = () => {
       navigation.navigate('history', {screen: 'send-start-tx'})
     },
     resetTabAndSwap: () => {
+      navigation.reset({index: 0, routes: [{name: 'dashboard-portfolio'}]})
+      navigation.navigate('history', {
+        screen: 'swap',
+        params: {
+          screen: 'main',
+        },
+      })
+    },
+    resetTabAndSwapWithRemoteConfig: async () => {
+      if (network === Chain.Network.Preprod) {
+        navigation.navigate('history', {
+          screen: 'swap',
+          params: {
+            screen: 'preprod-notice',
+          },
+        })
+        return
+      }
+
+      swapForm.action({type: 'ResetForm'})
+
+      if (tokenOutId) {
+        await setPendingSwapToken(tokenOutId)
+      }
+
       navigation.reset({index: 0, routes: [{name: 'dashboard-portfolio'}]})
       navigation.navigate('history', {
         screen: 'swap',

--- a/mobile/src/features/Portfolio/common/hooks/useNavigateTo.tsx
+++ b/mobile/src/features/Portfolio/common/hooks/useNavigateTo.tsx
@@ -18,73 +18,76 @@ export const useNavigateTo = () => {
   const {config} = useRemoteConfig()
   const tokenOutId = config?.swap?.initialPair?.tokenOut
 
-  return React.useRef({
-    tokensList: () => navigation.navigate('portfolio-tokens-list'),
-    tokenDetail: (params: PortfolioTokenDetailParams) =>
-      navigation.navigate('portfolio-token-details', {id: params.id}),
-    nftsList: () =>
-      navigation.navigate('portfolio-nfts', {screen: 'nft-gallery'}),
-    nftDetails: (id: Portfolio.Token.Id) =>
-      navigation.navigate('portfolio-nfts', {
-        screen: 'nft-details',
-        params: {id},
-        initial: true,
-      }),
-    resetTabAndSend: () => {
-      navigation.reset({index: 0, routes: [{name: 'dashboard-portfolio'}]})
-      navigation.navigate('history', {screen: 'send-start-tx'})
-    },
-    resetTabAndSwap: () => {
-      navigation.reset({index: 0, routes: [{name: 'dashboard-portfolio'}]})
-      navigation.navigate('history', {
-        screen: 'swap',
-        params: {
-          screen: 'main',
-        },
-      })
-    },
-    resetTabAndSwapWithRemoteConfig: async () => {
-      if (network === Chain.Network.Preprod) {
+  return React.useMemo(
+    () => ({
+      tokensList: () => navigation.navigate('portfolio-tokens-list'),
+      tokenDetail: (params: PortfolioTokenDetailParams) =>
+        navigation.navigate('portfolio-token-details', {id: params.id}),
+      nftsList: () =>
+        navigation.navigate('portfolio-nfts', {screen: 'nft-gallery'}),
+      nftDetails: (id: Portfolio.Token.Id) =>
+        navigation.navigate('portfolio-nfts', {
+          screen: 'nft-details',
+          params: {id},
+          initial: true,
+        }),
+      resetTabAndSend: () => {
+        navigation.reset({index: 0, routes: [{name: 'dashboard-portfolio'}]})
+        navigation.navigate('history', {screen: 'send-start-tx'})
+      },
+      resetTabAndSwap: () => {
+        navigation.reset({index: 0, routes: [{name: 'dashboard-portfolio'}]})
+        navigation.navigate('history', {
+          screen: 'swap',
+          params: {
+            screen: 'main',
+          },
+        })
+      },
+      resetTabAndSwapWithRemoteConfig: async () => {
+        if (network === Chain.Network.Preprod) {
+          navigation.navigate('history', {
+            screen: 'swap',
+            params: {
+              screen: 'preprod-notice',
+            },
+          })
+          return
+        }
+
+        swapForm.action({type: 'ResetForm'})
+
+        if (tokenOutId) {
+          await setPendingSwapToken(tokenOutId)
+        }
+
+        navigation.reset({index: 0, routes: [{name: 'dashboard-portfolio'}]})
+        navigation.navigate('history', {
+          screen: 'swap',
+          params: {
+            screen: 'main',
+          },
+        })
+      },
+      swap: () =>
+        navigation.navigate('history', {
+          screen: 'swap',
+          params: {
+            screen: 'main',
+          },
+        }),
+      swapPreprodNotice: () =>
         navigation.navigate('history', {
           screen: 'swap',
           params: {
             screen: 'preprod-notice',
           },
-        })
-        return
-      }
-
-      swapForm.action({type: 'ResetForm'})
-
-      if (tokenOutId) {
-        await setPendingSwapToken(tokenOutId)
-      }
-
-      navigation.reset({index: 0, routes: [{name: 'dashboard-portfolio'}]})
-      navigation.navigate('history', {
-        screen: 'swap',
-        params: {
-          screen: 'main',
-        },
-      })
-    },
-    swap: () =>
-      navigation.navigate('history', {
-        screen: 'swap',
-        params: {
-          screen: 'main',
-        },
-      }),
-    swapPreprodNotice: () =>
-      navigation.navigate('history', {
-        screen: 'swap',
-        params: {
-          screen: 'preprod-notice',
-        },
-      }),
-    buyAda: () =>
-      navigation.navigate('history', {screen: 'exchange-create-order'}),
-  } as const).current
+        }),
+      buyAda: () =>
+        navigation.navigate('history', {screen: 'exchange-create-order'}),
+    }),
+    [navigation, network, tokenOutId, swapForm],
+  )
 }
 
 type PortfolioTokenDetailParams = PortfolioRoutes['portfolio-token-details']

--- a/mobile/src/features/Portfolio/screens/PortfolioDashboard/DashboardTokensList/TradeTokensBanner.tsx
+++ b/mobile/src/features/Portfolio/screens/PortfolioDashboard/DashboardTokensList/TradeTokensBanner.tsx
@@ -13,10 +13,10 @@ import {TradeTokensAsset} from './TradeTokensAsset'
 export const TradeTokensBanner = () => {
   const {palette: p} = useTheme()
   const strings = useStrings()
-  const navigationTo = useNavigateTo()
+  const navigateTo = useNavigateTo()
 
   const handleSwap = () => {
-    navigationTo.swap()
+    navigateTo.resetTabAndSwapWithRemoteConfig()
   }
 
   return (

--- a/mobile/src/features/Portfolio/screens/PortfolioTokensList/PortfolioWalletTokenList/TradeTokensBannerBig.tsx
+++ b/mobile/src/features/Portfolio/screens/PortfolioTokensList/PortfolioWalletTokenList/TradeTokensBannerBig.tsx
@@ -1,12 +1,11 @@
 import {atoms as a, useTheme} from '@yoroi/theme'
 
-import {useNavigation} from '@react-navigation/native'
 import {LinearGradient} from 'expo-linear-gradient'
 import * as React from 'react'
 import {Text, View} from 'react-native'
 
+import {useNavigateTo} from '~/features/Portfolio/common/hooks/useNavigateTo'
 import {useStrings} from '~/kernel/i18n/useStrings'
-import {TxHistoryRouteNavigation} from '~/kernel/navigation/types'
 import {Button} from '~/ui/Button/Button'
 import {Space} from '~/ui/Space/Space'
 
@@ -15,12 +14,10 @@ import {TradeTokensAsset} from '../../PortfolioDashboard/DashboardTokensList/Tra
 export const TradeTokensBannerBig = () => {
   const {palette: p, atoms: ta} = useTheme()
   const strings = useStrings()
+  const navigateTo = useNavigateTo()
 
-  const navigation = useNavigation<TxHistoryRouteNavigation>()
   const handleSwap = () => {
-    navigation.navigate('swap', {
-      screen: 'main',
-    })
+    navigateTo.resetTabAndSwapWithRemoteConfig()
   }
 
   return (

--- a/mobile/src/features/Staking/Governance/common/navigation.tsx
+++ b/mobile/src/features/Staking/Governance/common/navigation.tsx
@@ -66,16 +66,18 @@ export const useNavigateTo = () => {
     }
 
     return {
-      home: (params?: {drepId?: string}) =>
+      home: (params?: {drepId?: string}) => {
         navigation.navigate('governance', {
           screen: 'staking-gov-home',
           params,
-        }),
-      changeVote: (params?: {drepId?: string}) =>
+        })
+      },
+      changeVote: (params?: {drepId?: string}) => {
         navigation.navigate('governance', {
           screen: 'staking-gov-change-vote',
           params,
-        }),
+        })
+      },
       votingOptions: () =>
         navigation.navigate('governance', {
           screen: 'staking-gov-voting-options',

--- a/mobile/src/features/Staking/Governance/useCases/ChangeVote/ChangeVoteScreen.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/ChangeVote/ChangeVoteScreen.tsx
@@ -1,13 +1,16 @@
 import {isNonNullable} from '@yoroi/common'
 import {
+  GovernanceProvider,
   getYoroiDrepIdHex,
   useDelegationCertificate,
+  useGovernance,
   useStakingKeyState,
   useVotingCertificate,
 } from '@yoroi/staking'
 import {atoms as a, useTheme} from '@yoroi/theme'
 import {useSelectedWallet} from '@yoroi/wallet-manager'
 
+import {useFocusEffect, useRoute} from '@react-navigation/native'
 import * as React from 'react'
 import {Text, View} from 'react-native'
 import {ScrollView} from 'react-native-gesture-handler'
@@ -17,14 +20,18 @@ import {LearnMoreLink} from '~/features/Staking/Governance/common/LearnMoreLink/
 import {YoroiRecordLink} from '~/features/Staking/Governance/common/YoroiRecordLink/YoroiRecordLink'
 import {useStakingKey} from '~/features/Staking/hooks/useStakingKey'
 import {useStrings} from '~/kernel/i18n/useStrings'
+import {useModal} from '~/ui/Modal/context/ModalContext'
 import {Space} from '~/ui/Space/Space'
 
 import {Action} from '../../common/Action/Action'
 import {mapStakingKeyStateToGovernanceAction} from '../../common/helpers'
 import {useGovernanceVoteFlow} from '../../common/useGovernanceVoteFlow'
-import {useOpenDrepIdModal} from '../EnterDrepIdModal/useOpenDrepIdModal'
+import {EnterDrepIdModal} from '../EnterDrepIdModal/EnterDrepIdModal'
 
 export const ChangeVoteScreen = () => {
+  const route = useRoute()
+  const routeParams = route.params as {drepId?: string} | undefined
+
   const {config} = useRemoteConfig()
   const isYoroiDrepBannerEnabled = Boolean(config?.banners?.yoroiDrep?.display)
   const strings = useStrings()
@@ -35,7 +42,8 @@ export const ChangeVoteScreen = () => {
   const action = stakingStatus
     ? mapStakingKeyStateToGovernanceAction(stakingStatus)
     : null
-  const {openDrepIdModal} = useOpenDrepIdModal()
+  const {openModal} = useModal()
+  const {manager} = useGovernance()
 
   const createDelegationCertificate = useDelegationCertificate()
   const createVotingCertificate = useVotingCertificate()
@@ -54,21 +62,108 @@ export const ChangeVoteScreen = () => {
   if (!isNonNullable(action)) throw new Error('User has never voted')
 
   const isPending = isCreatingTx || pendingVote !== null
+  // Track if we've already opened the modal for this drepId to prevent reopening
+  const hasOpenedModalRef = React.useRef<string | undefined>(undefined)
+  // Store timer in ref to prevent cancellation during re-renders
+  const modalTimerRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  )
 
-  const handleDelegate = () => {
-    if (isPending) return
-    openDrepIdModal(async (options) => {
-      const stakingKey = wallet.getStakingKey()
-
-      const certificate = await createDelegationCertificate({
-        hash: options.hash,
-        type: options.type,
-        stakingKey,
+  // Wrapper to open modal with prefilled DRep ID
+  const openDrepIdModal = React.useCallback(
+    (
+      onSubmit: (options: {
+        hash: string
+        type: 'key' | 'script'
+        CIP105: boolean
+      }) => void,
+      prefilledDrepId?: string,
+    ) => {
+      openModal({
+        title: strings.staking.enterDRepID,
+        content: (
+          <GovernanceProvider manager={manager}>
+            <EnterDrepIdModal
+              onSubmit={onSubmit}
+              initialDrepId={prefilledDrepId}
+            />
+          </GovernanceProvider>
+        ),
+        height: prefilledDrepId ? 340 : 650,
+        canDiscard: true,
       })
+      // Set ref only after modal is actually opened
+      if (prefilledDrepId) {
+        hasOpenedModalRef.current = prefilledDrepId
+      }
+    },
+    [openModal, strings.staking.enterDRepID, manager],
+  )
 
-      submitDelegate([certificate], options)
-    })
-  }
+  const handleDelegate = React.useCallback(
+    (prefilledDrepId?: string) => {
+      if (isPending) {
+        return
+      }
+      openDrepIdModal(async (options) => {
+        const stakingKey = wallet.getStakingKey()
+
+        const certificate = await createDelegationCertificate({
+          hash: options.hash,
+          type: options.type,
+          stakingKey,
+        })
+
+        submitDelegate([certificate], options)
+      }, prefilledDrepId)
+    },
+    [
+      isPending,
+      openDrepIdModal,
+      wallet,
+      createDelegationCertificate,
+      submitDelegate,
+    ],
+  )
+
+  // Check if we have a drepId from route params and open modal automatically
+  // Use useFocusEffect to ensure this only runs when screen is focused
+  useFocusEffect(
+    React.useCallback(() => {
+      const drepId = routeParams?.drepId
+
+      // Clear any existing timer when effect runs
+      if (modalTimerRef.current) {
+        clearTimeout(modalTimerRef.current)
+        modalTimerRef.current = undefined
+      }
+
+      if (drepId && !isPending && hasOpenedModalRef.current !== drepId) {
+        // Store timer in ref so it persists across re-renders
+        modalTimerRef.current = setTimeout(() => {
+          modalTimerRef.current = undefined
+          handleDelegate(drepId)
+        }, 300)
+      }
+
+      // Cleanup: only clear timer if screen loses focus
+      return () => {
+        if (modalTimerRef.current) {
+          clearTimeout(modalTimerRef.current)
+          modalTimerRef.current = undefined
+        }
+      }
+    }, [routeParams?.drepId, isPending, handleDelegate]),
+  )
+
+  // Cleanup timer on unmount
+  React.useEffect(() => {
+    return () => {
+      if (modalTimerRef.current) {
+        clearTimeout(modalTimerRef.current)
+      }
+    }
+  }, [])
 
   const yoroiDrepIdHex = React.useMemo(
     () => getYoroiDrepIdHex(wallet.networkManager.network),
@@ -152,7 +247,7 @@ export const ChangeVoteScreen = () => {
           <Action
             title={strings.staking.actionDelegateToADRepTitle}
             description={strings.staking.actionDelegateToADRepDescription}
-            onPress={handleDelegate}
+            onPress={() => handleDelegate()}
             pending={isCreatingTx && pendingVote === 'delegate-other'}
           />
         )}
@@ -161,7 +256,7 @@ export const ChangeVoteScreen = () => {
           <Action
             title={strings.staking.changeDRep}
             description={strings.staking.actionDelegateToADRepDescription}
-            onPress={handleDelegate}
+            onPress={() => handleDelegate()}
             pending={isCreatingTx && pendingVote === 'delegate-other'}
           />
         )}

--- a/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
@@ -55,13 +55,8 @@ export const EnterDrepIdModal = ({onSubmit, initialDrepId}: Props) => {
   const timeoutRef = React.useRef<ReturnType<typeof setTimeout>>(undefined)
   const showCardRef = React.useRef(showCard)
   const isInputFocusedRef = React.useRef(false)
-
-  // Update drepId when initialDrepId changes
-  React.useEffect(() => {
-    if (initialDrepId !== undefined && initialDrepId !== null) {
-      setDrepId(initialDrepId)
-    }
-  }, [initialDrepId])
+  // Track if we've already set initialDrepId to prevent overriding user input
+  const hasSetInitialDrepIdRef = React.useRef(false)
 
   React.useEffect(() => {
     return () => {
@@ -143,10 +138,64 @@ export const EnterDrepIdModal = ({onSubmit, initialDrepId}: Props) => {
     return trimmedDrepId
   }, [isHandle, drepInfo, trimmedDrepId])
 
-  const {error, isFetched, isFetching} = useIsValidDRepID(resolvedDrepId, {
+  const {
+    error,
+    isFetching,
+    isSuccess,
+    isPending,
+    data: isValidDRep,
+    refetch,
+  } = useIsValidDRepID(resolvedDrepId, {
     retry: false,
     enabled: resolvedDrepId.length > 0 && !isResolvingHandle,
+    refetchOnMount: 'always',
   })
+
+  // Update drepId when initialDrepId changes (only once, not on every drepId change)
+  // Use handleDrepIdChange to ensure all side effects (card hiding, validation) are triggered
+  React.useEffect(() => {
+    if (
+      initialDrepId !== undefined &&
+      initialDrepId !== null &&
+      !hasSetInitialDrepIdRef.current
+    ) {
+      hasSetInitialDrepIdRef.current = true
+      // Use handleDrepIdChange instead of setDrepId directly to trigger all side effects
+      handleDrepIdChange(initialDrepId)
+    }
+  }, [initialDrepId, handleDrepIdChange])
+
+  // Ensure validation runs when resolvedDrepId changes (including when initialDrepId is set)
+  // React Query should automatically run when enabled becomes true, but we ensure it runs
+  React.useEffect(() => {
+    const queryEnabled = resolvedDrepId.length > 0 && !isResolvingHandle
+
+    // If query is enabled but hasn't succeeded yet and isn't currently running, trigger it
+    // Check isPending to see if query is waiting to start
+    if (queryEnabled && !isSuccess && !isFetching && !isPending) {
+      // Use a small delay to ensure React Query has processed the enabled state change
+      const timer = setTimeout(() => {
+        // Only refetch if still needed (query might have started automatically)
+        if (!isSuccess && !isFetching && !isPending) {
+          refetch().catch(() => {
+            // Silently handle refetch errors
+          })
+        }
+      }, 200)
+
+      return () => {
+        clearTimeout(timer)
+      }
+    }
+    return undefined
+  }, [
+    resolvedDrepId,
+    isResolvingHandle,
+    isSuccess,
+    isFetching,
+    isPending,
+    refetch,
+  ])
 
   const noDrepForHandle =
     isHandle &&
@@ -157,11 +206,20 @@ export const EnterDrepIdModal = ({onSubmit, initialDrepId}: Props) => {
     ? 'This ADA handle does not have a DRep associated with it'
     : handleResolutionError?.message || error?.message
   const isLoading = isResolvingHandle || isFetching
+
+  // Button is enabled when:
+  // - DRep ID is entered
+  // - Not currently loading/resolving
+  // - Validation has succeeded (isSuccess && data === true)
+  // - No errors
+  // - If it's a handle, we have drepInfo
+  // Use isSuccess instead of isFetched because isSuccess is true when validation succeeds,
+  // while isFetched can be true even if validation failed
   const isSubmitDisabled =
-    isNonNullable(error) ||
     drepId.length === 0 ||
-    !isFetched ||
     isLoading ||
+    isNonNullable(error) ||
+    !(isSuccess && isValidDRep === true) ||
     (isHandle && drepInfo === null)
 
   const handleSubmit = () => {

--- a/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
@@ -172,11 +172,19 @@ export const EnterDrepIdModal = ({onSubmit, initialDrepId}: Props) => {
 
     // If query is enabled but hasn't succeeded yet and isn't currently running, trigger it
     // Check isPending to see if query is waiting to start
-    if (queryEnabled && !isSuccess && !isFetching && !isPending) {
+    // Don't refetch if there's an error - user needs to fix input first
+    if (
+      queryEnabled &&
+      !isSuccess &&
+      !isFetching &&
+      !isPending &&
+      !isNonNullable(error)
+    ) {
       // Use a small delay to ensure React Query has processed the enabled state change
       const timer = setTimeout(() => {
         // Only refetch if still needed (query might have started automatically)
-        if (!isSuccess && !isFetching && !isPending) {
+        // Also check error again in case it was set during the delay
+        if (!isSuccess && !isFetching && !isPending && !isNonNullable(error)) {
           refetch().catch(() => {
             // Silently handle refetch errors
           })
@@ -194,6 +202,7 @@ export const EnterDrepIdModal = ({onSubmit, initialDrepId}: Props) => {
     isSuccess,
     isFetching,
     isPending,
+    error,
     refetch,
   ])
 

--- a/mobile/src/features/Staking/Governance/useCases/Home/HomeScreen.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/Home/HomeScreen.tsx
@@ -38,16 +38,16 @@ export const HomeScreen = () => {
   const routeParams = route.params as {drepId?: string} | undefined
   const navigateTo = useNavigateTo()
   const {isLoading, pendingAction, confirmedAction} = useHomeScreen()
-
   // Track if we've already navigated to prevent infinite loops
   const hasNavigatedRef = React.useRef<string | undefined>(undefined)
 
-  // If user is already participating and we have a drepId from route params,
+  // If user is already participating (either pending or confirmed) and we have a drepId from route params,
   // navigate to changeVote screen to handle the DRep change
   React.useEffect(() => {
     const drepId = routeParams?.drepId
+
     if (
-      confirmedAction !== null &&
+      (pendingAction !== null || confirmedAction !== null) &&
       drepId &&
       hasNavigatedRef.current !== drepId
     ) {
@@ -61,7 +61,7 @@ export const HomeScreen = () => {
       }
     }
     return undefined
-  }, [confirmedAction, routeParams?.drepId, navigateTo])
+  }, [pendingAction, confirmedAction, routeParams?.drepId, navigateTo])
 
   if (isLoading) return null
 

--- a/mobile/src/features/Staking/Staking/StakingUpdateModal/useStakingUpdateModal.tsx
+++ b/mobile/src/features/Staking/Staking/StakingUpdateModal/useStakingUpdateModal.tsx
@@ -31,27 +31,63 @@ export const useStakingUpdateModal = () => {
   const storage = useAsyncStorage()
   const queryClient = useQueryClient()
 
+  // Check cache first to avoid unnecessary storage reads
+  const cachedValue = queryClient.getQueryData<boolean>(QUERY_KEY)
+
   // Check if modal has been shown before (app-wide, not wallet-specific)
   // Use useQuery for proper caching and to prevent race conditions
   const hasBeenShownQuery = useQuery({
     queryKey: QUERY_KEY,
+    // If we already have the value in cache (especially if it's true), use it as initial data
+    // This prevents refetching when cache exists
+    initialData: cachedValue,
     queryFn: async () => {
       try {
-        // parseBoolean handles both cases: if it's already a boolean, return it; if it's a string, parse it
-        const storedValue = await storage.getItem(
+        // Read raw string from AsyncStorage to handle all possible formats
+        // Storage might contain: JSON string "true", plain string "true", or boolean true
+        const rawValue = await storage.getItem<string | null>(
           STAKING_UPDATE_MODAL_SHOWN_KEY,
+          (value) => value, // Get raw string from AsyncStorage
         )
 
-        return parseBoolean(storedValue) ?? false
+        // parseBoolean handles all formats:
+        // - If already boolean: returns it directly
+        // - If JSON string "true"/"false": parseSafe does JSON.parse, returns boolean
+        // - If plain string "true": parseSafe tries JSON.parse, fails, returns undefined
+        //   Then we check if rawValue === "true" as fallback
+        if (rawValue === null) {
+          return false
+        }
+
+        const parsed = parseBoolean(rawValue)
+        if (parsed !== undefined) {
+          return parsed
+        }
+
+        // Fallback: handle plain string "true"/"false" if JSON.parse failed
+        if (rawValue === 'true') {
+          return true
+        }
+        if (rawValue === 'false') {
+          return false
+        }
+
+        // Default to true (don't show) if value exists but can't be parsed
+        // Safer to assume modal was already shown rather than show it again
+        return true
       } catch (error) {
-        return false
+        // On error reading storage, default to true (don't show modal)
+        // Safer to assume modal was already shown rather than potentially show it multiple times
+        // This should only happen if storage is corrupted or inaccessible
+        return true
       }
     },
-    placeholderData: false,
+    placeholderData: true, // Default to true (don't show) while loading
     staleTime: Infinity, // Never refetch - once shown, always shown
     gcTime: Infinity, // Keep in cache forever
     refetchOnMount: false,
     refetchOnWindowFocus: false,
+    retry: false, // Don't retry on failure - if storage read fails, assume not shown
   })
 
   const setModalShown = useMutationWithInvalidations({
@@ -113,7 +149,12 @@ export const useStakingUpdateModal = () => {
       // Mark as triggered to prevent infinite loop
       hasTriggeredRef.current = true
 
-      // Mark as shown and update cache
+      // Update cache FIRST (synchronously) to prevent re-triggering on remount
+      // This ensures the modal won't show again even if storage write fails or component remounts
+      queryClient.setQueryData(QUERY_KEY, true)
+
+      // Write to storage asynchronously (fire and forget)
+      // If this fails, the cache update above still prevents re-showing
       setModalShown.mutate()
 
       openModal({
@@ -135,6 +176,7 @@ export const useStakingUpdateModal = () => {
     strings,
     modalHeight,
     setModalShown,
+    queryClient,
   ])
 
   return {isLoading: isLoadingStakingInfo || isLoadingConfig}

--- a/mobile/src/features/Transactions/useCases/UtxoConsolidation/UtxoConsolidation/useUtxoConsolidationBanner.tsx
+++ b/mobile/src/features/Transactions/useCases/UtxoConsolidation/UtxoConsolidation/useUtxoConsolidationBanner.tsx
@@ -9,7 +9,6 @@ import {useQuery, useQueryClient} from '@tanstack/react-query'
 
 import {BannerIds, showBanner} from '~/features/Notifications/common/banners'
 import {useUtxoList} from '~/features/Transactions/useCases/UtxoList/useUtxoList'
-import {features} from '~/kernel/features'
 import {useStrings} from '~/kernel/i18n/useStrings'
 
 export const useUtxoConsolidationBanner = () => {
@@ -27,7 +26,7 @@ export const useUtxoConsolidationBanner = () => {
   useQuery({
     queryKey: ['utxoConsolidationBanner', wallet?.id, network],
     staleTime: time.fiveMinutes,
-    enabled: !isLoading && features.utxoConsolidation,
+    enabled: !isLoading,
     queryFn: async () => {
       if (isConsolidationNeeded) {
         if (network === Chain.Network.Mainnet) {

--- a/mobile/src/features/Transactions/useCases/UtxoList/UtxoList.tsx
+++ b/mobile/src/features/Transactions/useCases/UtxoList/UtxoList.tsx
@@ -5,7 +5,6 @@ import {FlashList} from '@shopify/flash-list'
 import * as React from 'react'
 import {Text, View} from 'react-native'
 
-import {features} from '~/kernel/features'
 import {useStrings} from '~/kernel/i18n/useStrings'
 import {Space} from '~/ui/Space/Space'
 
@@ -33,10 +32,7 @@ export const UtxoList = () => {
 
   const ListHeaderComponent = React.useMemo(
     () =>
-      features.utxoConsolidation &&
-      utxoList &&
-      utxoList.length > 1 &&
-      isSingle ? (
+      utxoList && utxoList.length > 1 && isSingle ? (
         <>
           <WarningSingleAddress />
 

--- a/mobile/src/kernel/features.ts
+++ b/mobile/src/kernel/features.ts
@@ -1,5 +1,3 @@
-import {isDev} from './constants'
-
 export const features = {
   useTestnet: false,
   prefillWalletInfo: false,
@@ -10,7 +8,6 @@ export const features = {
   portfolioExport: false,
   walletListAggregatedBalance: false,
   swapTokenLinks: true,
-  utxoConsolidation: isDev,
   pushNotifications: true,
 }
 

--- a/mobile/src/kernel/i18n/locales/en-US.json
+++ b/mobile/src/kernel/i18n/locales/en-US.json
@@ -1199,6 +1199,7 @@
   "airdrop.status.failed": "Failed",
   "airdrop.status.queued": "Queued",
   "airdrop.status.skipped": "Skipped",
+  "airdrop.tryAgain": "Try Again",
   "airdrop.enterPassword": "Enter your password to sign the redemption transaction",
   "airdrop.redeemSuccess": "Redemption transaction submitted successfully",
   "airdrop.redeemError": "Failed to redeem tokens",

--- a/mobile/src/kernel/i18n/messages/airdrop.ts
+++ b/mobile/src/kernel/i18n/messages/airdrop.ts
@@ -144,7 +144,11 @@ export const airdropMessages = defineMessages({
   statusSkipped: {
     id: 'airdrop.status.skipped',
     defaultMessage: '!!!Skipped',
-  }, // Add these to the existing airdropMessages in airdrop.ts
+  },
+  tryAgain: {
+    id: 'airdrop.tryAgain',
+    defaultMessage: '!!!Try Again',
+  },
   destinationAddressTitle: {
     id: 'airdrop.destinationAddressTitle',
     defaultMessage: '!!!Destination address',

--- a/mobile/src/kernel/i18n/useStrings.ts
+++ b/mobile/src/kernel/i18n/useStrings.ts
@@ -354,6 +354,7 @@ export const useStrings = () => {
           queued: f(airdropMessages.statusQueued),
           skipped: f(airdropMessages.statusSkipped),
         },
+        tryAgain: f(airdropMessages.tryAgain),
       },
 
       // Portfolio strings

--- a/mobile/src/ui/ResultScreen/ResultScreen.tsx
+++ b/mobile/src/ui/ResultScreen/ResultScreen.tsx
@@ -1,8 +1,10 @@
 import {atoms as a, useTheme} from '@yoroi/theme'
 
+import {useNavigation} from '@react-navigation/native'
 import * as React from 'react'
 import {Text, View} from 'react-native'
 
+import {useStrings} from '~/kernel/i18n/useStrings'
 import {useUnsafeParams} from '~/kernel/navigation/hooks/useUnsafeParams'
 import {Button, ButtonType} from '~/ui/Button/Button'
 import {FailedTxIcon} from '~/ui/FailedTxIcon/FailedTxIcon'
@@ -15,6 +17,8 @@ import {ResultScreenParams} from './types'
 
 export const ResultScreen = (props?: ResultScreenParams) => {
   const {palette: p, atoms: ta} = useTheme()
+  const strings = useStrings()
+  const navigation = useNavigation()
   const navParamsRaw = useUnsafeParams<
     ResultScreenParams | {route?: {params?: ResultScreenParams}}
   >()
@@ -48,6 +52,18 @@ export const ResultScreen = (props?: ResultScreenParams) => {
   const defaultsForType = useResultScreenDefaults(context, type)
   const title = params.title ?? defaultsForType.defaultTitle
   const message = params.message ?? defaultsForType.defaultMessage
+
+  // Set navigation header title - use concise title for navigation, detailed message stays in content
+  // For error screens, use a short generic title; for success, use context-appropriate title
+  React.useEffect(() => {
+    const navigationTitle =
+      type === 'error'
+        ? strings.txReview.failedTxTitle // Concise title for navigation header
+        : title // Use full title for success screens
+    navigation.setOptions({
+      title: navigationTitle,
+    })
+  }, [navigation, type, title, strings.txReview.failedTxTitle])
   const icon = params.icon ?? defaultsForType.defaultIcon
   const primaryAction =
     params.primaryAction ?? defaultsForType.defaultPrimaryAction

--- a/mobile/src/ui/ResultScreen/ResultScreenContext.tsx
+++ b/mobile/src/ui/ResultScreen/ResultScreenContext.tsx
@@ -55,6 +55,15 @@ const getDefaultConfig = (
       case 'delegate':
       case 'withdraw':
       case 'utxo-consolidation':
+      case 'airdrop':
+        return {
+          defaultTitle: strings.airdrop.redeemError,
+          defaultMessage: strings.txReview.failedTxText,
+          defaultPrimaryAction: {
+            title: strings.txReview.failedTxButton,
+            onPress: navigation.resetToTxHistory,
+          },
+        }
       default:
         return {
           defaultTitle: strings.txReview.failedTxTitle,

--- a/mobile/src/ui/ResultScreen/ResultScreenContext.tsx
+++ b/mobile/src/ui/ResultScreen/ResultScreenContext.tsx
@@ -55,6 +55,14 @@ const getDefaultConfig = (
       case 'delegate':
       case 'withdraw':
       case 'utxo-consolidation':
+        return {
+          defaultTitle: strings.txReview.failedTxTitle,
+          defaultMessage: strings.txReview.failedTxText,
+          defaultPrimaryAction: {
+            title: strings.txReview.failedTxButton,
+            onPress: navigation.resetToTxHistory,
+          },
+        }
       case 'airdrop':
         return {
           defaultTitle: strings.airdrop.redeemError,

--- a/mobile/src/ui/ResultScreen/types.ts
+++ b/mobile/src/ui/ResultScreen/types.ts
@@ -11,6 +11,7 @@ export type OperationContext =
   | 'exchange'
   | 'withdraw'
   | 'utxo-consolidation'
+  | 'airdrop'
   | 'default'
 
 export type ResultScreenType = 'success' | 'error'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves NIGHT airdrop redemption UX and error handling, adds DRep deeplink flow/validation, enhances swap navigation via remote config, enables UTXO consolidation banner, adds a thaw-schedule checker script, and updates result screen/i18n.
> 
> - **Airdrop (NIGHT)**:
>   - Recompute `schedule.numberOfClaimedAllocations` from confirmed/confirming thaws; exclude `failed` from totals and redeemability checks.
>   - Thaw schedule UI: add retry for failed thaws, failed badge/icon, formatted error messages (POSIX timestamps → human-readable), allow redeem retry, use `context: 'airdrop'` for result screens.
>   - Details screen: active thaw selection ignores failed; insufficient funds uses airdrop context.
>   - Hook updates: `useHasRedeemableThaws` excludes `failed`/`skipped`; eligibility calculations refined.
>   - i18n: add `airdrop.tryAgain` and related labels.
> - **Governance / Links**:
>   - Support bech32 `drep` IDs in deeplinks; delay action clearing for `delegate-drep` navigation to prevent re-trigger.
>   - Auto-open Change Vote with prefilled `drepId`; Enter DRep modal improves initial value handling and validation/refetch flow.
> - **Portfolio / Swap**:
>   - New `resetTabAndSwapWithRemoteConfig`: resets form, optionally preselects token from remote config, handles preprod notice; banners updated to use it.
> - **Transactions / UTxO**:
>   - Enable UTXO consolidation banner (feature flag removed); show single-address warning header when applicable.
> - **UI / Result Screen**:
>   - Set concise navigation title from result type; add default config for `context: 'airdrop'`.
> - **Scripts**:
>   - Add `mobile/scripts/check-thaw-schedule.js` to fetch thaw schedules for addresses, sort/aggregate, and output summary and detailed reports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eedbcfc5867aacb5c0a97c1c513f6791316ac27a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->