### PR TITLE
chore: merge from develop to preview

### DIFF
--- a/mobile/packages/cardano-wallet/transaction-recipes/createVotingRegTx.ts
+++ b/mobile/packages/cardano-wallet/transaction-recipes/createVotingRegTx.ts
@@ -89,16 +89,17 @@ export async function createVotingRegTx({
   if (!baseAddrObj) {
     throw new Error('Failed to convert base address to Address')
   }
-  const paymentAddressCIP36 = baseAddrObj.toBech32(undefined)
-  if (!paymentAddressCIP36) {
-    throw new Error('Failed to convert payment address to bech32')
+  // Convert addresses to hex format (bech32 strings are too long for metadata)
+  const paymentAddressHex = baseAddrObj.toHex()
+  if (!paymentAddressHex) {
+    throw new Error('Failed to convert payment address to hex')
   }
 
   // Derive reward address from base address
   const rewardAddr = baseAddrObj
-  const rewardAddress = rewardAddr.toBech32(undefined)
-  if (!rewardAddress) {
-    throw new Error('Failed to convert reward address to bech32')
+  const rewardAddressHex = rewardAddr.toHex()
+  if (!rewardAddressHex) {
+    throw new Error('Failed to convert reward address to hex')
   }
 
   // Estimate fee for voting registration transaction
@@ -125,34 +126,26 @@ export async function createVotingRegTx({
   builderState = addInputs(builderState, selectedUtxos)
 
   // Create and add voting metadata
-  const votingPublicKeyBech32 = votingPublicKey.toBech32()
-  if (!votingPublicKeyBech32) {
-    throw new Error('Failed to convert voting public key to bech32')
-  }
-  const stakingPublicKeyBech32 = stakingPublicKey.toBech32()
-  if (!stakingPublicKeyBech32) {
-    throw new Error('Failed to convert staking public key to bech32')
-  }
-  const rewardAddressBranded =
-    typeof rewardAddress === 'string'
-      ? (rewardAddress as Address)
-      : rewardAddress
-  const paymentAddressBranded =
-    typeof paymentAddressCIP36 === 'string'
-      ? (paymentAddressCIP36 as Address)
-      : paymentAddressCIP36
+  // Convert public keys to hex format (bech32 strings are too long for metadata)
+  const votingPublicKeyHex = Buffer.from(votingPublicKey.asBytes()).toString(
+    'hex',
+  )
+  const stakingPublicKeyHex = Buffer.from(stakingPublicKey.asBytes()).toString(
+    'hex',
+  )
+
   const votingMetadata = supportsCIP36
     ? createCIP36VotingMetadata(
-        votingPublicKeyBech32 as PublicKeyHex,
-        stakingPublicKeyBech32 as PublicKeyHex,
-        rewardAddressBranded,
+        votingPublicKeyHex,
+        stakingPublicKeyHex,
+        rewardAddressHex,
         nonce,
-        paymentAddressBranded,
+        paymentAddressHex,
       )
     : createCIP15VotingMetadata(
-        votingPublicKeyBech32 as PublicKeyHex,
-        stakingPublicKeyBech32 as PublicKeyHex,
-        rewardAddressBranded,
+        votingPublicKeyHex,
+        stakingPublicKeyHex,
+        rewardAddressHex,
         nonce,
       )
 

--- a/mobile/packages/cardano-wallet/transaction-recipes/createVotingRegTx.ts
+++ b/mobile/packages/cardano-wallet/transaction-recipes/createVotingRegTx.ts
@@ -103,8 +103,9 @@ export async function createVotingRegTx({
   }
 
   // Estimate fee for voting registration transaction
-  // Voting registration transactions are typically small (~400-600 bytes)
-  const estimatedTxSize = 600 // bytes - conservative estimate
+  // CIP-36 metadata with hex addresses can be larger (~600-800 bytes)
+  // Use a more conservative estimate to account for metadata size
+  const estimatedTxSize = supportsCIP36 ? 800 : 600 // bytes - CIP-36 has larger metadata
   const estimatedFee =
     BigInt(protocolParams.linearFee.constant) +
     BigInt(protocolParams.linearFee.coefficient) * BigInt(estimatedTxSize)
@@ -113,7 +114,8 @@ export async function createVotingRegTx({
   // 1. Fee for the transaction
   // 2. Minimum UTXO value for the change output (at least 1 ADA)
   const minUtxoValue = BigInt(protocolParamsConfig.minimumUtxoVal || '1000000') // Base min UTXO (1 ADA)
-  const feeBuffer = BigInt('100000') // 0.1 ADA buffer for fee estimation variance
+  // Increase fee buffer for CIP-36 to account for larger metadata and fee calculation variance
+  const feeBuffer = supportsCIP36 ? BigInt('200000') : BigInt('100000') // 0.2 ADA for CIP-36, 0.1 ADA for CIP-15
   const requiredAda = (estimatedFee + minUtxoValue + feeBuffer).toString()
 
   // Select only necessary UTXOs to cover fees

--- a/mobile/packages/tx/transaction-builder/builder.ts
+++ b/mobile/packages/tx/transaction-builder/builder.ts
@@ -1193,6 +1193,87 @@ export async function buildTransaction(
       })
 
       try {
+        // If transaction has metadata, estimate witness set size and set manual fee
+        // BEFORE calling addChangeIfNeeded, since CSL calculates fee based on body size only
+        // The witness set size (signatures) increases total transaction size, which increases fee
+        // This is especially important for voting registration transactions with CIP-36 metadata
+        if (
+          state.metadata.length > 0 &&
+          !state.options.manualFee &&
+          (!state.options.mints || state.options.mints.length === 0)
+        ) {
+          // Estimate witness set size: each input needs a signature (~64 bytes)
+          // Plus CBOR overhead for witness set structure (~20 bytes)
+          const signatureSize = 64
+          const witnessSetOverhead = 20
+          const estimatedWitnessSetSize =
+            state.inputs.length * signatureSize + witnessSetOverhead
+
+          // Estimate transaction body size
+          const baseBodySizeEstimate = 200
+          const inputsSize = state.inputs.length * 80
+          const outputsSize = state.outputs.length * 150
+          const certificatesSize = state.certificates.length * 120
+          const withdrawalsSize = state.withdrawals.length * 60
+
+          // Metadata size - estimate conservatively based on actual metadata
+          let metadataSize = 100 // Base overhead
+          for (const meta of state.metadata) {
+            if (meta) {
+              const metaStr = JSON.stringify(meta.data)
+              // CIP-36 metadata with hex addresses can be large
+              metadataSize += Math.max(metaStr.length, 300)
+            }
+          }
+
+          // Estimate change output size (will be added by addChangeIfNeeded)
+          const changeOutputSize = 150
+
+          const estimatedBodySize =
+            baseBodySizeEstimate +
+            inputsSize +
+            outputsSize +
+            certificatesSize +
+            withdrawalsSize +
+            metadataSize +
+            changeOutputSize
+
+          // Apply safety multiplier for CBOR encoding overhead
+          const adjustedBodySize = Math.ceil(estimatedBodySize * 2.0)
+
+          // Total transaction size including witness set
+          const totalTxSizeEstimate = adjustedBodySize + estimatedWitnessSetSize
+
+          // Calculate fee with buffer: constant + coefficient * total_size
+          // Add 10% buffer to account for fee calculation variance
+          const baseFee =
+            BigInt(protocolParams.linearFee.constant) +
+            BigInt(protocolParams.linearFee.coefficient) *
+              BigInt(totalTxSizeEstimate)
+          const feeBuffer = baseFee / BigInt(10) // 10% buffer
+          const totalFee = baseFee + feeBuffer
+
+          // Set manual fee BEFORE calling addChangeIfNeeded
+          const feeBigNum = csl.BigNum.fromStr(totalFee.toString())
+          if (feeBigNum) {
+            cslTxBuilder.setFee(feeBigNum)
+            getLogger().info(
+              'buildTransaction: Set manual fee accounting for metadata and witness set',
+              {
+                estimatedBodySize,
+                adjustedBodySize,
+                estimatedWitnessSetSize,
+                totalTxSizeEstimate,
+                baseFee: baseFee.toString(),
+                feeBuffer: feeBuffer.toString(),
+                totalFee: totalFee.toString(),
+                metadataCount: state.metadata.length,
+                inputsCount: state.inputs.length,
+              },
+            )
+          }
+        }
+
         // If minting with native scripts, calculate witness set size and estimate fee
         // BEFORE calling addChangeIfNeeded, since CSL calculates fee based on body size only
         // The witness set size increases total transaction size, which increases fee

--- a/mobile/packages/tx/transaction-builder/helpers.test.ts
+++ b/mobile/packages/tx/transaction-builder/helpers.test.ts
@@ -61,9 +61,9 @@ describe('transaction builder helpers', () => {
 
       expect(result.label).toBe(61284)
       expect(result.data).toEqual({
-        1: 'voting_key',
-        2: 'staking_key',
-        3: 'reward_addr',
+        1: '0xvoting_key',
+        2: '0xstaking_key',
+        3: '0xreward_addr',
         4: 123,
       })
     })
@@ -80,10 +80,11 @@ describe('transaction builder helpers', () => {
 
       expect(result.label).toBe(61284)
       expect(result.data).toEqual({
-        1: 'voting_key',
-        2: 'staking_key',
-        3: 'reward_addr',
+        1: [['0xvoting_key', 1]],
+        2: '0xstaking_key',
+        3: '0xreward_addr',
         4: 123,
+        5: 0,
       })
     })
 
@@ -96,7 +97,14 @@ describe('transaction builder helpers', () => {
         'payment_addr',
       )
 
-      expect(result.data).toHaveProperty('5', 'payment_addr')
+      expect(result.label).toBe(61284)
+      expect(result.data).toEqual({
+        1: [['0xvoting_key', 1]],
+        2: '0xstaking_key',
+        3: '0xpayment_addr',
+        4: 123,
+        5: 0,
+      })
     })
   })
 

--- a/mobile/packages/tx/transaction-builder/helpers.ts
+++ b/mobile/packages/tx/transaction-builder/helpers.ts
@@ -446,12 +446,23 @@ export function createCIP15VotingMetadata(
     typeof stakingPublicKey === 'string' ? stakingPublicKey : stakingPublicKey
   const rewardAddrStr =
     typeof rewardAddress === 'string' ? rewardAddress : rewardAddress
+  // Add 0x prefix for hex strings to match Cardano metadata format
+  // Remove 0x if already present to avoid double prefix
+  const votingKeyHex = votingKeyStr.startsWith('0x')
+    ? votingKeyStr
+    : `0x${votingKeyStr}`
+  const stakingKeyHex = stakingKeyStr.startsWith('0x')
+    ? stakingKeyStr
+    : `0x${stakingKeyStr}`
+  const rewardAddrHex = rewardAddrStr.startsWith('0x')
+    ? rewardAddrStr
+    : `0x${rewardAddrStr}`
   return {
     label: 61284, // CIP-15 DATA label
     data: {
-      1: votingKeyStr,
-      2: stakingKeyStr,
-      3: rewardAddrStr,
+      1: votingKeyHex,
+      2: stakingKeyHex,
+      3: rewardAddrHex,
       4: nonce,
     },
   }
@@ -459,6 +470,12 @@ export function createCIP15VotingMetadata(
 
 /**
  * Create CIP-36 voting metadata (new Catalyst voting format)
+ * CIP-36 format:
+ * - Field 1: delegations (array of [votingKey, weight])
+ * - Field 2: stake_credential (staking key)
+ * - Field 3: payment_address (payment address for receiving voting rewards)
+ * - Field 4: nonce
+ * - Field 5: voting_purpose (optional, default 0)
  */
 export function createCIP36VotingMetadata(
   votingPublicKey: PublicKeyHex | string,
@@ -471,19 +488,31 @@ export function createCIP36VotingMetadata(
     typeof votingPublicKey === 'string' ? votingPublicKey : votingPublicKey
   const stakingKeyStr =
     typeof stakingPublicKey === 'string' ? stakingPublicKey : stakingPublicKey
-  const rewardAddrStr =
-    typeof rewardAddress === 'string' ? rewardAddress : rewardAddress
-  const metadata: Record<string, unknown> = {
-    1: votingKeyStr,
-    2: stakingKeyStr,
-    3: rewardAddrStr,
-    4: nonce,
-  }
+  // Add 0x prefix for hex strings to match Cardano metadata format
+  // Remove 0x if already present to avoid double prefix
+  const votingKeyHex = votingKeyStr.startsWith('0x')
+    ? votingKeyStr
+    : `0x${votingKeyStr}`
+  const stakingKeyHex = stakingKeyStr.startsWith('0x')
+    ? stakingKeyStr
+    : `0x${stakingKeyStr}`
 
-  if (paymentAddress) {
-    const paymentAddrStr =
-      typeof paymentAddress === 'string' ? paymentAddress : paymentAddress
-    metadata[5] = paymentAddrStr
+  // CIP-36 uses payment_address in field 3, not reward_address
+  // If paymentAddress is provided, use it; otherwise fall back to rewardAddress
+  const addressToUse = paymentAddress || rewardAddress
+  const addressStr =
+    typeof addressToUse === 'string' ? addressToUse : addressToUse
+  const addressHex = addressStr.startsWith('0x')
+    ? addressStr
+    : `0x${addressStr}`
+
+  // CIP-36 format: field 1 is an array of [votingKey, weight]
+  const metadata: Record<string, unknown> = {
+    1: [[votingKeyHex, 1]],
+    2: stakingKeyHex,
+    3: addressHex, // payment_address (field 3 in CIP-36)
+    4: nonce,
+    5: 0, // voting_purpose (default 0 for voting registration)
   }
 
   return {

--- a/mobile/packages/wallet-manager/wallet-manager.ts
+++ b/mobile/packages/wallet-manager/wallet-manager.ts
@@ -1172,7 +1172,7 @@ export const makeWalletManager = (
               internal: [],
               external: [firstAddress],
               rewardAddressHex,
-              enableDiscovery: true, // Enable discovery to find more addresses
+              enableDiscovery: false, // Disable comprehensive discovery for full read-only wallets (they have accountPubKeyHex to derive addresses)
               accountVisual,
             })
 

--- a/mobile/src/features/Airdrop/common/scheduleThawNotifications.ts
+++ b/mobile/src/features/Airdrop/common/scheduleThawNotifications.ts
@@ -8,39 +8,38 @@ import {
 import {isAndroid} from '~/kernel/constants'
 import {logger} from '~/kernel/logger/logger'
 
-import type {AddressAllocation, Thaw} from '../types'
+import type {AddressAllocation} from '../types'
 
 const AIRDROP_NOTIFICATION_PREFIX = 'airdrop_thaw_'
 
 /**
- * Creates a unique identifier for a thaw notification based on address and thaw time
+ * Creates a unique identifier for a thaw notification based on thaw date only
  */
-const getThawNotificationId = (address: string, thawDate: Date): string => {
-  // Use address hash and timestamp to create unique ID
-  const addressHash = address.slice(-8) // Last 8 chars of address
+const getThawNotificationId = (thawDate: Date): string => {
+  // Use timestamp to create unique ID per date
   const timestamp = thawDate.getTime()
-  return `${AIRDROP_NOTIFICATION_PREFIX}${addressHash}_${timestamp}`
+  return `${AIRDROP_NOTIFICATION_PREFIX}${timestamp}`
 }
 
 /**
- * Checks if a notification is already scheduled for a specific thaw time
+ * Gets all existing scheduled notification IDs for airdrop thaws
  */
-const isThawNotificationScheduled = async (
-  address: string,
-  thawDate: Date,
-): Promise<boolean> => {
+const getExistingThawNotificationIds = async (): Promise<Set<string>> => {
   try {
     const scheduledNotifications =
       await Notifications.getAllScheduledNotificationsAsync()
-    const expectedId = getThawNotificationId(address, thawDate)
+    const existingIds = new Set<string>()
 
-    return scheduledNotifications.some((notification) => {
-      const notificationId = notification.identifier
-      return notificationId === expectedId
-    })
+    for (const notification of scheduledNotifications) {
+      if (notification.identifier.startsWith(AIRDROP_NOTIFICATION_PREFIX)) {
+        existingIds.add(notification.identifier)
+      }
+    }
+
+    return existingIds
   } catch (error) {
-    logger.error('Failed to check scheduled notifications', {error})
-    return false
+    logger.error('Failed to get existing scheduled notifications', {error})
+    return new Set<string>()
   }
 }
 
@@ -69,17 +68,13 @@ const setupNotificationSystem = async (): Promise<void> => {
 }
 
 /**
- * Gets all upcoming thaws from all allocations
+ * Gets unique upcoming thaw dates from all allocations
  */
-const getUpcomingThaws = (
+const getUniqueUpcomingThawDates = (
   allocations: ReadonlyArray<AddressAllocation>,
-): Array<{allocation: AddressAllocation; thaw: Thaw; thawDate: Date}> => {
+): Array<Date> => {
   const now = new Date()
-  const upcomingThaws: Array<{
-    allocation: AddressAllocation
-    thaw: Thaw
-    thawDate: Date
-  }> = []
+  const thawDates = new Set<number>()
 
   for (const allocation of allocations) {
     for (const thaw of allocation.schedule.thaws) {
@@ -90,7 +85,8 @@ const getUpcomingThaws = (
             thaw.thawing_period_start.replace(/\s/g, ''),
           )
           if (thawDate > now) {
-            upcomingThaws.push({allocation, thaw, thawDate})
+            // Use timestamp as key to ensure uniqueness per date
+            thawDates.add(thawDate.getTime())
           }
         } catch (error) {
           logger.error('Failed to parse thaw date', {
@@ -103,10 +99,10 @@ const getUpcomingThaws = (
     }
   }
 
-  // Sort by date (earliest first)
-  return upcomingThaws.sort(
-    (a, b) => a.thawDate.getTime() - b.thawDate.getTime(),
-  )
+  // Convert back to Date objects and sort by date (earliest first)
+  return Array.from(thawDates)
+    .map((timestamp) => new Date(timestamp))
+    .sort((a, b) => a.getTime() - b.getTime())
 }
 
 /**
@@ -137,10 +133,10 @@ export const scheduleThawNotifications = async (
     // Set up notification system
     await setupNotificationSystem()
 
-    // Get all upcoming thaws
-    const upcomingThaws = getUpcomingThaws(allocations)
+    // Get unique upcoming thaw dates
+    const uniqueThawDates = getUniqueUpcomingThawDates(allocations)
 
-    if (upcomingThaws.length === 0) {
+    if (uniqueThawDates.length === 0) {
       Alert.alert(
         'No Upcoming Thaws',
         'There are no upcoming thaws to schedule notifications for.',
@@ -148,38 +144,29 @@ export const scheduleThawNotifications = async (
       return {scheduled: 0, skipped: 0, errors: 0}
     }
 
-    // Schedule notifications for each thaw
-    for (const {allocation, thaw, thawDate} of upcomingThaws) {
-      try {
-        // Check if already scheduled
-        const alreadyScheduled = await isThawNotificationScheduled(
-          allocation.address,
-          thawDate,
-        )
+    // Get all existing scheduled notification IDs once
+    const existingNotificationIds = await getExistingThawNotificationIds()
 
-        if (alreadyScheduled) {
+    // Schedule one notification per unique date
+    for (const thawDate of uniqueThawDates) {
+      try {
+        // Check if already scheduled using the pre-fetched Set
+        const notificationId = getThawNotificationId(thawDate)
+        if (existingNotificationIds.has(notificationId)) {
           skipped++
           continue
         }
 
         // Schedule the notification
-        const notificationId = getThawNotificationId(
-          allocation.address,
-          thawDate,
-        )
-        const amount = (thaw.amount / Math.pow(10, 6)).toFixed(2) // NIGHT has 6 decimals
-
         await Notifications.scheduleNotificationAsync({
           identifier: notificationId,
           content: {
             title: 'Airdrop Thaw Available',
-            body: `${amount} NIGHT tokens are now available to redeem`,
+            body: 'Thaw available',
             sound: 'default',
             data: {
               type: 'airdrop_thaw',
-              address: allocation.address,
               thawDate: thawDate.toISOString(),
-              amount: thaw.amount,
             },
           },
           trigger: {
@@ -191,7 +178,6 @@ export const scheduleThawNotifications = async (
         scheduled++
       } catch (error) {
         logger.error('Failed to schedule thaw notification', {
-          address: allocation.address,
           thawDate: thawDate.toISOString(),
           error,
         })

--- a/mobile/src/features/Airdrop/common/useAirdropEligibility.ts
+++ b/mobile/src/features/Airdrop/common/useAirdropEligibility.ts
@@ -41,6 +41,7 @@ export const useAirdropEligibility = () => {
       !!wallet &&
       !isByronWallet,
     staleTime: time.fiveMinutes,
+    retry: false,
     queryFn: async (): Promise<AddressAllocation[]> => {
       if (!wallet || !wallet.isMainnet) {
         return []
@@ -273,11 +274,25 @@ export const useAirdropEligibility = () => {
         cachedAllocationsCount: allocations.length,
       })
 
-      for (const address of addressesToCheck) {
+      // Helper function for rate limiting
+      const delay = (ms: number) =>
+        new Promise((resolve) => setTimeout(resolve, ms))
+
+      for (let i = 0; i < addressesToCheck.length; i++) {
+        const address = addressesToCheck[i]
+        if (!address) {
+          continue
+        }
+
         try {
           // Skip Byron addresses - they don't support airdrop
           if (isByronAddress(address)) {
             continue
+          }
+
+          // Add delay between API calls to avoid rate limiting (skip first call)
+          if (i > 0) {
+            await delay(200)
           }
 
           const schedule = await redemptionApi.getThawSchedule(address)
@@ -392,6 +407,32 @@ export const useAirdropEligibility = () => {
           }
         }
       }
+
+      // Sort allocations to maintain original order:
+      // 1. Wallet addresses first (in their original order)
+      // 2. External addresses next (in the order they were added)
+      allocations.sort((a, b) => {
+        // Both are external addresses - sort by their index in externalAddressesList
+        if (a.isExternal && b.isExternal) {
+          const indexA = externalAddressesList.indexOf(a.address)
+          const indexB = externalAddressesList.indexOf(b.address)
+          // If both found, sort by index; if not found, keep current order
+          if (indexA >= 0 && indexB >= 0) {
+            return indexA - indexB
+          }
+          return 0
+        }
+        // External addresses come after wallet addresses
+        if (a.isExternal && !b.isExternal) {
+          return 1
+        }
+        if (!a.isExternal && b.isExternal) {
+          return -1
+        }
+        // Both are wallet addresses - maintain original order
+        // (they were added in the order they appear in wallet.receiveAddresses())
+        return 0
+      })
 
       // Return allocations for all addresses we checked
       // Note: addresses cached as not-eligible were skipped entirely

--- a/mobile/src/features/Airdrop/ui/AirdropSelectionScreen.tsx
+++ b/mobile/src/features/Airdrop/ui/AirdropSelectionScreen.tsx
@@ -92,13 +92,33 @@ export const AirdropSelectionScreen = () => {
         // Also remove from eligible cache if it exists there
         await addressCache.removeEligibleAddress(address)
 
-        // Invalidate and refetch queries to update the list
-        await queryClient.invalidateQueries({
-          queryKey: [persistPrefixKeyword, 'airdropEligibility'],
+        // Update React Query cache directly to avoid network calls
+        // Invalidate with partial key to match all wallets, then update cache directly
+        const partialQueryKey = [
+          persistPrefixKeyword,
+          'airdropEligibility',
+        ] as const
+
+        // Get all matching queries and update them
+        const queryCache = queryClient.getQueryCache()
+        const matchingQueries = queryCache.findAll({
+          queryKey: partialQueryKey,
         })
-        await queryClient.refetchQueries({
-          queryKey: [persistPrefixKeyword, 'airdropEligibility'],
-        })
+
+        for (const query of matchingQueries) {
+          const currentData = query.state.data as
+            | AddressAllocation[]
+            | undefined
+
+          if (currentData && Array.isArray(currentData)) {
+            // Remove the address from allocations array
+            const updatedData = currentData.filter(
+              (allocation) => allocation.address !== address,
+            )
+            // Update cache directly without network call
+            queryClient.setQueryData(query.queryKey, updatedData)
+          }
+        }
       } catch (error) {
         logger.error('Failed to remove external address', {address, error})
       }

--- a/mobile/src/features/Airdrop/ui/ManualAddressModal.tsx
+++ b/mobile/src/features/Airdrop/ui/ManualAddressModal.tsx
@@ -5,7 +5,6 @@ import {useQueryClient} from '@tanstack/react-query'
 import * as React from 'react'
 import {ScrollView, Text} from 'react-native'
 
-import {AddressInput} from '~/common/AddressInput/AddressInput'
 import {persistPrefixKeyword} from '~/kernel/connection/ConnectionProvider'
 import {useStrings} from '~/kernel/i18n/useStrings'
 import {logger} from '~/kernel/logger/logger'
@@ -13,6 +12,7 @@ import {Button} from '~/ui/Button/Button'
 import {useModal} from '~/ui/Modal/context/ModalContext'
 import {Modal} from '~/ui/Modal/ui/screens/Modal/Modal'
 import {Space} from '~/ui/Space/Space'
+import {TextInput} from '~/ui/TextInput/TextInput'
 
 import {redemptionApi} from '../api/redemptionApi'
 import {useAirdropAddressCache} from '../common/airdropAddressCache'
@@ -24,9 +24,13 @@ const ManualAddressModalContent = () => {
   const strings = useStrings()
   const {atoms: ta} = useTheme()
 
-  const [address, setAddress] = React.useState('')
-  const [isValid, setIsValid] = React.useState(false)
+  const [addressesText, setAddressesText] = React.useState('')
   const [error, setError] = React.useState<string | null>(null)
+  const [results, setResults] = React.useState<{
+    processed: number
+    skipped: number
+    errors: number
+  }>({processed: 0, skipped: 0, errors: 0})
 
   // Use ref to store the latest handler to avoid recreating footer unnecessarily
   const handleCheckEligibilityRef = React.useRef<
@@ -34,119 +38,181 @@ const ManualAddressModalContent = () => {
   >(undefined)
 
   const handleCheckEligibility = React.useCallback(async () => {
-    if (!isValid || !address.trim()) {
+    if (!addressesText.trim()) {
       return
     }
 
-    const trimmedAddress = address.trim()
+    const delay = (ms: number) =>
+      new Promise((resolve) => setTimeout(resolve, ms))
 
-    // Skip Byron addresses - they don't support airdrop
-    if (isByronAddress(trimmedAddress)) {
-      setError('Byron addresses are not supported for airdrop')
-      setLoading(false)
-      return
+    const processAddress = async (address: string): Promise<boolean> => {
+      const trimmedAddress = address.trim()
+
+      // Skip empty addresses
+      if (!trimmedAddress) {
+        return false
+      }
+
+      // Skip Byron addresses - they don't support airdrop
+      if (isByronAddress(trimmedAddress)) {
+        logger.info('Skipping Byron address', {address: trimmedAddress})
+        return false
+      }
+
+      // Check cache first
+      const [eligibleAddresses, notEligibleAddresses, externalAddresses] =
+        await Promise.all([
+          addressCache.getEligibleAddresses(),
+          addressCache.getNotEligibleAddresses(),
+          addressCache.getExternalAddresses(),
+        ])
+
+      // Skip if already in external addresses (already processed)
+      if (externalAddresses.has(trimmedAddress)) {
+        logger.info('Address already added', {address: trimmedAddress})
+        return false
+      }
+
+      // Skip if already marked as not eligible
+      if (notEligibleAddresses.has(trimmedAddress)) {
+        logger.info('Address already marked as not eligible', {
+          address: trimmedAddress,
+        })
+        return false
+      }
+
+      // If already eligible, just add to external addresses if not already there
+      if (eligibleAddresses[trimmedAddress]) {
+        await addressCache.addExternalAddress(trimmedAddress)
+        logger.info('Address already eligible, added to external', {
+          address: trimmedAddress,
+        })
+        return true
+      }
+
+      // Need to check API - add delay to avoid rate limiting
+      await delay(200)
+
+      try {
+        const schedule = await redemptionApi.getThawSchedule(trimmedAddress)
+
+        // Calculate next thaw date
+        const now = new Date()
+        const upcomingThaws = schedule.thaws
+          .filter((thaw) => {
+            const thawDate = new Date(thaw.thawing_period_start)
+            return thawDate > now && thaw.status === 'upcoming'
+          })
+          .sort(
+            (a, b) =>
+              new Date(a.thawing_period_start).getTime() -
+              new Date(b.thawing_period_start).getTime(),
+          )
+
+        const nextThawDate =
+          upcomingThaws.length > 0
+            ? (upcomingThaws[0]?.thawing_period_start ?? null)
+            : null
+
+        // Save as external address and eligible
+        await addressCache.addExternalAddress(trimmedAddress)
+        await addressCache.updateEligibleAddress(trimmedAddress, nextThawDate)
+        return true
+      } catch (err: unknown) {
+        if (
+          err &&
+          typeof err === 'object' &&
+          'message' in err &&
+          typeof err.message === 'string'
+        ) {
+          if (err.message.includes('ADDRESS_NOT_FOUND')) {
+            // Expected error - address has no allocations
+            await addressCache.addNotEligibleAddress(trimmedAddress)
+            logger.info('External address has no allocations', {
+              address: trimmedAddress,
+            })
+            return false
+          } else if (err.message.includes('API_ACCESS_FORBIDDEN')) {
+            // Expected error - API access forbidden
+            logger.warn('API access forbidden for external address', {
+              address: trimmedAddress,
+            })
+            throw err
+          } else {
+            // Unexpected error - log as error
+            logger.error('Failed to check eligibility for external address', {
+              address: trimmedAddress,
+              error: err,
+            })
+            throw err
+          }
+        } else {
+          logger.error('Failed to check eligibility for external address', {
+            address: trimmedAddress,
+            error: err,
+          })
+          throw err
+        }
+      }
     }
 
     setError(null)
     setLoading(true)
+    setResults({processed: 0, skipped: 0, errors: 0})
+
+    const addresses = addressesText.split('\n').map((addr) => addr.trim())
+    let processed = 0
+    let skipped = 0
+    let errors = 0
 
     try {
-      // Check if address already exists in wallet addresses
-      // This would be handled by useAirdropEligibility, but we check here to avoid duplicates
-      const schedule = await redemptionApi.getThawSchedule(trimmedAddress)
-
-      // Calculate next thaw date
-      const now = new Date()
-      const upcomingThaws = schedule.thaws
-        .filter((thaw) => {
-          const thawDate = new Date(thaw.thawing_period_start)
-          return thawDate > now && thaw.status === 'upcoming'
-        })
-        .sort(
-          (a, b) =>
-            new Date(a.thawing_period_start).getTime() -
-            new Date(b.thawing_period_start).getTime(),
-        )
-
-      const nextThawDate =
-        upcomingThaws.length > 0
-          ? (upcomingThaws[0]?.thawing_period_start ?? null)
-          : null
-
-      // Save as external address and eligible
-      await addressCache.addExternalAddress(trimmedAddress)
-      await addressCache.updateEligibleAddress(trimmedAddress, nextThawDate)
+      for (const address of addresses) {
+        try {
+          const wasProcessed = await processAddress(address)
+          if (wasProcessed) {
+            processed++
+          } else {
+            skipped++
+          }
+          setResults({processed, skipped, errors})
+        } catch (err) {
+          errors++
+          setResults({processed, skipped, errors})
+          // Continue processing other addresses even if one fails
+        }
+      }
 
       // Invalidate queries to refresh allocations
+      const queryKey = [persistPrefixKeyword, 'airdropEligibility'] as const
       await queryClient.invalidateQueries({
-        queryKey: [persistPrefixKeyword, 'airdropEligibility'],
+        queryKey,
       })
 
-      // Explicitly refetch and wait for completion to ensure the new address appears
+      // Explicitly refetch and wait for completion to ensure new addresses appear
       await queryClient.refetchQueries({
-        queryKey: [persistPrefixKeyword, 'airdropEligibility'],
+        queryKey,
         type: 'active', // Only refetch active queries
       })
 
       // Close modal after queries are updated
       closeModal()
     } catch (err: unknown) {
-      if (
-        err &&
-        typeof err === 'object' &&
-        'message' in err &&
-        typeof err.message === 'string'
-      ) {
-        if (err.message.includes('ADDRESS_NOT_FOUND')) {
-          // Expected error - address has no allocations
-          logger.info('External address has no allocations', {address})
-          setError(strings.airdrop.noAllocations)
-        } else if (err.message.includes('API_ACCESS_FORBIDDEN')) {
-          // Expected error - API access forbidden
-          logger.info('API access forbidden for external address', {address})
-          setError('Access forbidden. Please try again later.')
-        } else {
-          // Unexpected error - log as error
-          logger.error('Failed to check eligibility for external address', {
-            address,
-            error: err,
-          })
-          setError(err.message)
-        }
-      } else {
-        // Unexpected error - log as error
-        logger.error('Failed to check eligibility for external address', {
-          address,
-          error: err,
-        })
-        setError('Failed to check eligibility. Please try again.')
-      }
+      logger.error('Failed to process addresses', {error: err})
+      setError('Failed to process some addresses. Please try again.')
     } finally {
       setLoading(false)
     }
-  }, [
-    address,
-    isValid,
-    addressCache,
-    closeModal,
-    setLoading,
-    strings,
-    queryClient,
-  ])
+  }, [addressesText, addressCache, closeModal, setLoading, queryClient])
 
   // Store latest handler in ref
   React.useEffect(() => {
     handleCheckEligibilityRef.current = handleCheckEligibility
   }, [handleCheckEligibility])
 
-  // Memoize the validation change handler to prevent infinite loops
-  const handleValidationChange = React.useCallback(
-    (isValid: boolean) => {
-      setIsValid(isValid)
-      setCanContinue(isValid)
-    },
-    [setCanContinue],
-  )
+  // Enable continue button if there's text
+  React.useEffect(() => {
+    setCanContinue(addressesText.trim().length > 0)
+  }, [addressesText, setCanContinue])
 
   // Create stable footer handler that uses ref
   const footerHandlerRef = React.useRef(() => {
@@ -163,19 +229,13 @@ const ManualAddressModalContent = () => {
     [],
   )
 
-  // Track previous validity to avoid unnecessary footer updates
-  const prevIsValidRef = React.useRef(isValid)
-
-  // Update footer when validity changes (only depend on isValid to avoid loops)
+  // Update footer when text changes
   React.useEffect(() => {
-    // Only update footer if validity actually changed
-    if (prevIsValidRef.current !== isValid) {
-      prevIsValidRef.current = isValid
-      setFooter(isValid ? footerWithHandler : footerWithoutHandler)
-    }
+    const hasText = addressesText.trim().length > 0
+    setFooter(hasText ? footerWithHandler : footerWithoutHandler)
     // footerWithHandler and footerWithoutHandler are stable (memoized with empty deps)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isValid, setFooter])
+  }, [addressesText, setFooter])
 
   return (
     <Modal.Content>
@@ -186,18 +246,34 @@ const ManualAddressModalContent = () => {
 
         <Space.Height.xl />
 
-        <AddressInput
-          value={address}
-          onChangeText={setAddress}
-          onValidationChange={handleValidationChange}
-          placeholder={strings.send.addressInputLabel}
+        <TextInput
+          value={addressesText}
+          onChangeText={setAddressesText}
+          placeholder="Enter addresses, one per line"
           label={strings.airdrop.address}
+          multiline
+          autoComplete="off"
+          autoCapitalize="none"
+          autoCorrect={false}
+          renderComponentStyle={{minHeight: 200}}
         />
 
         {error && (
           <>
             <Space.Height.md />
             <Text style={[a.body_2_md_regular, ta.text_error]}>{error}</Text>
+          </>
+        )}
+
+        {(results.processed > 0 ||
+          results.skipped > 0 ||
+          results.errors > 0) && (
+          <>
+            <Space.Height.md />
+            <Text style={[a.body_2_md_regular, ta.text_gray_max]}>
+              Processed: {results.processed} | Skipped: {results.skipped} |
+              Errors: {results.errors}
+            </Text>
           </>
         )}
       </ScrollView>
@@ -229,7 +305,6 @@ const ManualAddressModalFooter = ({
 export const useManualAddressModal = () => {
   const {openModal} = useModal()
   const strings = useStrings()
-  const queryClient = useQueryClient()
 
   const openManualAddressModal = React.useCallback(() => {
     openModal({
@@ -239,14 +314,8 @@ export const useManualAddressModal = () => {
       height: 500,
       canDiscard: true,
       canContinue: false,
-      onClose: () => {
-        // Invalidate queries to refresh allocations after adding external address
-        queryClient.invalidateQueries({
-          queryKey: [persistPrefixKeyword, 'airdropEligibility'],
-        })
-      },
     })
-  }, [openModal, strings, queryClient])
+  }, [openModal, strings])
 
   return {openManualAddressModal}
 }

--- a/mobile/src/features/Links/common/parsers.ts
+++ b/mobile/src/features/Links/common/parsers.ts
@@ -229,6 +229,74 @@ export const parseCardanoLink = (codeContent: string): Links.CardanoAction => {
   ) as Links.CardanoAction
 }
 
+/**
+ * Parse legacy yoroi-frontend public key QR code format.
+ * Legacy format is a JSON object: { publicKeyHex: string, path: Array<number> }
+ * This format was used in yoroi-frontend before the web+cardano:// link format.
+ */
+export const parseLegacyPublicKeyQR = (
+  codeContent: string,
+): Links.CardanoAction | null => {
+  try {
+    // Try to parse as JSON
+    const parsed = JSON.parse(codeContent)
+
+    // Check if it matches the legacy format
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      typeof parsed.publicKeyHex === 'string' &&
+      parsed.publicKeyHex.length > 0
+    ) {
+      // Validate that publicKeyHex looks like a valid hex string
+      // Account public keys are typically 128 hex characters (64 bytes)
+      if (!/^[0-9a-fA-F]+$/.test(parsed.publicKeyHex)) {
+        return null
+      }
+
+      // Extract accountVisual from path if present
+      // The path is a BIP44 derivation path array: [purpose', coinType', account']
+      // The last element is the hardened account index
+      // To get accountVisual, subtract the hardened offset (0x80000000 = 2147483648)
+      let accountVisual: number | undefined
+      if (
+        Array.isArray(parsed.path) &&
+        parsed.path.length > 0 &&
+        typeof parsed.path[parsed.path.length - 1] === 'number'
+      ) {
+        const hardenedAccountIndex = parsed.path[parsed.path.length - 1]
+        const HARDENED_OFFSET = 0x80000000 // 2147483648
+        // Extract unhardened account index
+        accountVisual = hardenedAccountIndex - HARDENED_OFFSET
+        // Validate it's a reasonable account index (non-negative)
+        if (accountVisual < 0) {
+          accountVisual = undefined
+        }
+      }
+
+      // Convert legacy format to CardanoAction restore-wallet format
+      return freeze({
+        action: 'restore-wallet',
+        type: 'readonly',
+        accountPubKey: parsed.publicKeyHex,
+        encryption: 'plain',
+        accountVisual:
+          accountVisual !== undefined ? String(accountVisual) : undefined,
+        implementation: undefined,
+        addressMode: undefined,
+        name: undefined,
+        mnemonic: undefined,
+        rootKey: undefined,
+      } as const)
+    }
+  } catch {
+    // Not valid JSON, return null to indicate it's not the legacy format
+    return null
+  }
+
+  return null
+}
+
 const nonProtocolRegex = /^[a-zA-Z0-9_\-.$]+$/
 const isOpenableLink = (content: string) => {
   return content.startsWith('yoroi') || content.startsWith('https')

--- a/mobile/src/features/Scan/useCases/ScanCodeScreen.tsx
+++ b/mobile/src/features/Scan/useCases/ScanCodeScreen.tsx
@@ -7,7 +7,10 @@ import * as Haptics from 'expo-haptics'
 import * as React from 'react'
 import {Alert, Text, TouchableOpacity, View} from 'react-native'
 
-import {parseCardanoLink} from '~/features/Links/common/parsers'
+import {
+  parseCardanoLink,
+  parseLegacyPublicKeyQR,
+} from '~/features/Links/common/parsers'
 import {useStrings} from '~/kernel/i18n/useStrings'
 import {
   CameraCodeScanner,
@@ -44,6 +47,17 @@ export const ScanCodeScreen = () => {
           setPendingAction({
             source: 'yoroi',
             action: {info: parsedYoroiAction, isTrusted: false},
+          })
+          return
+        }
+
+        // Try legacy yoroi-frontend public key QR format (JSON with publicKeyHex)
+        const legacyAction = parseLegacyPublicKeyQR(event.data)
+        if (legacyAction != null) {
+          Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success)
+          setPendingAction({
+            source: 'cardano',
+            action: legacyAction,
           })
           return
         }

--- a/mobile/src/ui/Icon/Direction.tsx
+++ b/mobile/src/ui/Icon/Direction.tsx
@@ -12,7 +12,6 @@ import {Received} from '~/ui/Icon/Received'
 import {RewardWithdrawn} from '~/ui/Icon/RewardWithdrawn'
 import {Send} from '~/ui/Icon/Send'
 import {Staking} from '~/ui/Icon/Staking'
-import {StakingKeyDeregistered} from '~/ui/Icon/StakingKeyDeregistered'
 import {StakingKeyRegistered} from '~/ui/Icon/StakingKeyRegistered'
 import {Swap} from '~/ui/Icon/Swap'
 import {Transaction} from '~/ui/Icon/Transaction'
@@ -158,7 +157,7 @@ const iconMap: Record<
   SWAP: Swap,
   SMART_CONTRACT: DigitalAsset,
   STAKE_REGISTRATION: StakingKeyRegistered,
-  STAKE_DEREGISTRATION: StakingKeyDeregistered,
+  STAKE_DEREGISTRATION: Staking,
   STAKE_DELEGATION: Staking,
   STAKE_UNDELEGATION: Staking,
   VOTE_DELEGATION: Governance,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch voting registration to hex metadata with better fee estimation, add legacy public key QR parsing, batch/simplify airdrop thaw notifications, and refine airdrop/address UX and icons.
> 
> - **Transaction/Voting (CIP-15/36)**:
>   - Use hex for `voting/staking keys` and `addresses` in metadata; update creators `createCIP15VotingMetadata` and `createCIP36VotingMetadata` (+ tests).
>   - Adjust fee/size estimates and buffers; in builder, precompute size (incl. metadata/witness set) to set manual fee before `addChangeIfNeeded`.
>   - Voting recipe updated to hex conversions, larger CIP-36 size/buffer, and nonce/TTL handling unchanged.
> - **Airdrop**:
>   - Schedule one notification per unique thaw date; prefetch existing IDs; simpler content; Android channel setup; robust errors.
>   - Eligibility fetch: disable retries, add small rate-limit delays, include external addresses, and stable ordering; expose hard refresh.
>   - Manual Address modal: multiline input to process multiple addresses with caching, rate-limit delays, results summary, and query invalidation; removal updates React Query cache directly.
> - **Wallet Manager**:
>   - For read-only xpub wallets, store initial address with `enableDiscovery: false`.
> - **Links/Scan**:
>   - Add `parseLegacyPublicKeyQR` to support legacy JSON `{publicKeyHex,path}`; integrate into scanner before Cardano link parsing.
> - **UI/Icon**:
>   - Map `STAKE_DEREGISTRATION` to `Staking` icon instead of `StakingKeyDeregistered`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afef66708ec45f226f2d1bbc116a7bb02a1d5191. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->