### PR TITLE
fix swap cancel

### DIFF
--- a/mobile/packages/cardano-wallet/common/signatureUtils.ts
+++ b/mobile/packages/cardano-wallet/common/signatureUtils.ts
@@ -104,6 +104,23 @@ const getRequiredSigners = async (
     })
 
   const getAddressAddressing = (bech32Address: string) => {
+    // Check if wallet actually controls this address (payment key)
+    const addressBranded = Branded.asAddress(bech32Address)
+    const internalIndex = wallet.internalAddresses().indexOf(addressBranded)
+    const externalIndex = wallet.externalAddresses().indexOf(addressBranded)
+    const walletControlsAddress = internalIndex !== -1 || externalIndex !== -1
+
+    // If wallet doesn't control the address and we're in strict mode, return null
+    if (!walletControlsAddress && !partial) {
+      return null
+    }
+
+    // If wallet doesn't control the address, don't return addressing even in partial mode
+    // This prevents signing for addresses we don't control (e.g., Minswap payment key + our staking key)
+    if (!walletControlsAddress) {
+      return null
+    }
+
     const path = getDerivationPathForAddress(
       bech32Address,
       wallet,

--- a/mobile/packages/tx/ledger/plutus.ts
+++ b/mobile/packages/tx/ledger/plutus.ts
@@ -71,24 +71,31 @@ export const createLedgerPlutusPayload = async (
 
     const originalRequiredSigners = getRequiredSigners(body)
 
-    const requiredSigners = originalRequiredSigners.map((s) => {
-      const paymentStakeCredential = csl.Credential.fromKeyhash(s)
-      const stakeCredential = csl.Credential.fromKeyhash(stakeVKHash)
-      const baseAddress = csl.BaseAddress.new(
-        networkId,
-        paymentStakeCredential,
-        stakeCredential,
-      )
-      const addressing = getAddressAddressing(
-        baseAddress.toAddress().toBech32(undefined),
-      )
-      if (!addressing)
-        throw new Error(
-          `Could not find addressing for required signer: ${s.toHex()}`,
+    // Only include required signers that the wallet actually controls
+    // Skip signers we don't control (e.g., Minswap's payment key + our staking key)
+    const requiredSigners = originalRequiredSigners
+      .map((s) => {
+        const paymentStakeCredential = csl.Credential.fromKeyhash(s)
+        const stakeCredential = csl.Credential.fromKeyhash(stakeVKHash)
+        const baseAddress = csl.BaseAddress.new(
+          networkId,
+          paymentStakeCredential,
+          stakeCredential,
         )
-      const path = addressing.path
-      return {type: TxRequiredSignerType.PATH as const, path}
-    })
+        const addressing = getAddressAddressing(
+          baseAddress.toAddress().toBech32(undefined),
+        )
+        if (!addressing) {
+          // Skip if wallet doesn't control this address
+          return null
+        }
+        const path = addressing.path
+        return {type: TxRequiredSignerType.PATH as const, path}
+      })
+      .filter(
+        (s): s is {type: TxRequiredSignerType.PATH; path: number[]} =>
+          s !== null,
+      )
 
     const inputs = body.inputs()
     const inputsArray: TxInput[] = []

--- a/mobile/packages/tx/ledger/signers.ts
+++ b/mobile/packages/tx/ledger/signers.ts
@@ -158,7 +158,13 @@ const getRequiredSignersAddressing = async ({
   const addressingArray: Addressing[] = []
 
   for (const signer of signersArray) {
-    if (stakingKeyPath) {
+    // Check if this required signer matches the wallet's staking key hash
+    const signerKeyHashHex = signer.toHex()
+    const walletStakingKeyHashHex = stakeVKHash.toHex()
+    const isStakingKeySigner = signerKeyHashHex === walletStakingKeyHashHex
+
+    if (stakingKeyPath && isStakingKeySigner) {
+      // Only add staking key signer if the required signer actually matches our staking key
       addressingArray.push({
         path: stakingKeyPath,
         startLevel: 1,
@@ -166,6 +172,7 @@ const getRequiredSignersAddressing = async ({
       continue
     }
 
+    // For payment key signers, construct the address and check if wallet controls it
     const paymentStakeCredential = wasm.Credential.fromKeyhash(signer)
     const stakeCredential = wasm.Credential.fromKeyhash(stakeVKHash)
     const baseAddress = wasm.BaseAddress.new(
@@ -175,14 +182,18 @@ const getRequiredSignersAddressing = async ({
     )
     const bech32Address = baseAddress.toAddress().toBech32(undefined)
     const addressing = getAddressAddressing(bech32Address)
+
+    // Only include if we can get addressing AND the address is actually controlled by the wallet
     if (!addressing) {
       if (!partial) {
         throw new Error(
           `Could not find addressing for required signer: ${signer.toHex()}`,
         )
       }
+      // Skip if we don't control this address (partial mode)
       continue
     }
+
     addressingArray.push(addressing)
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Restricts required signers to wallet-controlled addresses and adds strict staking-key matching when building Ledger/Plutus payloads and signer lists.
> 
> - **Signing logic**:
>   - `signatureUtils.getAddressAddressing(...)`: Validate the wallet controls the address (internal/external); return `null` otherwise, regardless of partial mode.
> - **Ledger Plutus payload (`tx/ledger/plutus.ts`)**:
>   - Filter `requiredSigners` to only those the wallet controls; map to `PATH` and skip non-controlled signers.
> - **Signer resolution (`tx/ledger/signers.ts`)**:
>   - Add staking-key signer only if the required signer equals the wallet staking key.
>   - For payment-key signers, derive base address and include only if `getAddressAddressing` confirms control; skip (or throw in strict mode) otherwise.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31d3ba4e732a8f420cf7565f57a8131bb7da6949. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->