### PR TITLE
Fix dexhunter swaps

### DIFF
--- a/mobile/src/features/ReviewTx/common/hooks/useOnConfirm.tsx
+++ b/mobile/src/features/ReviewTx/common/hooks/useOnConfirm.tsx
@@ -448,6 +448,7 @@ const signTx = async (
 ): Promise<{
   signedTx: (csl: WasmModuleProxy) => Transaction
   txId: string
+  signedTxBytes: Uint8Array
 } | null> => {
   const result = await CardanoMobileWrapped.cslScope(async (csl) => {
     const signers = await getTransactionSigners(cbor, wallet, meta)
@@ -491,7 +492,11 @@ const signTx = async (
     return tx
   }
 
-  return {signedTx, txId: result.txId}
+  return {
+    signedTx,
+    txId: result.txId,
+    signedTxBytes: result.signedTxBytes, // Include bytes directly to avoid re-serialization
+  }
 }
 
 const submitTx = async (
@@ -512,11 +517,9 @@ const submitTx = async (
     return null
   }
 
-  // Get signed transaction bytes for submission
-  const signedTxBytes = await CardanoMobileWrapped.cslScope(async (csl) => {
-    const tx = signResult.signedTx(csl)
-    return tx.toBytes()
-  })
+  // Use the bytes directly from signRawTransaction to avoid re-serialization
+  // Re-serializing through Transaction.toBytes() might change the CBOR structure
+  const signedTxBytes = signResult.signedTxBytes
 
   // Submit the transaction (convert to base64 for API)
   const signedTxBase64 = Branded.asTransactionCborBase64(

--- a/mobile/src/features/ReviewTx/useCases/ReviewTxScreen/ReviewTxScreen.tsx
+++ b/mobile/src/features/ReviewTx/useCases/ReviewTxScreen/ReviewTxScreen.tsx
@@ -6,7 +6,6 @@ import * as React from 'react'
 
 import {useAnalyticsTracking} from '~/features/Analytics/hooks/useAnalyticsTracking'
 import {AnalyticsEventEnum} from '~/features/Analytics/types/analytics-event-enum'
-import {useAuth} from '~/features/Auth/context/AuthProvider'
 import {ReviewTxMemoProvider} from '~/features/ReviewTx/common/context/ReviewTxMemoContext'
 import {useFormattedMetadata} from '~/features/ReviewTx/common/hooks/useFormattedMetadata'
 import {useFormattedTx} from '~/features/ReviewTx/common/hooks/useFormattedTx'
@@ -18,8 +17,7 @@ import {
   TransactionBody,
 } from '~/features/ReviewTx/common/types'
 import {useUnsafeParams} from '~/kernel/navigation/hooks/useUnsafeParams'
-import {ReviewTxRoutes} from '~/kernel/navigation/types'
-import {ReviewContext} from '~/kernel/navigation/types'
+import {ReviewContext, ReviewTxRoutes} from '~/kernel/navigation/types'
 import {OperationContext} from '~/ui/ResultScreen/types'
 
 import {ReviewTx} from './ReviewTx/ReviewTx'
@@ -90,7 +88,6 @@ const ReviewTxContent = ({
   trackEvent: ReturnType<typeof useAnalyticsTracking>['trackEvent']
 }) => {
   const {meta} = useSelectedWallet()
-  const {isAuthDev} = useAuth()
   const {onConfirm} = useOnConfirm({
     cbor: params?.cbor,
     partial: params?.partial,
@@ -130,7 +127,7 @@ const ReviewTxContent = ({
       receiverCustomTitle={params?.receiverCustomTitle}
       createdBy={params?.createdBy}
       validationResult={validationResult}
-      cbor={params?.cbor != null && isAuthDev ? params.cbor : null}
+      cbor={params?.cbor ?? null}
       onConfirm={meta.isReadOnly ? undefined : handleOnConfirm}
       readOnly={meta.isReadOnly}
       isReviewFlow={true}

--- a/mobile/src/features/Transactions/common/getOperationTypeKey.ts
+++ b/mobile/src/features/Transactions/common/getOperationTypeKey.ts
@@ -182,6 +182,7 @@ export const getOperationTypeKey = (
     if (direction === 'RECEIVED') return 'swapResolved'
   }
 
+  /*
   // 4.5. Check for NIGHT redemption transactions
   // Pattern: Smart contract interaction where NIGHT tokens are being spent/redeemed
   // NIGHT token: policyId '0691b2fecca1ac4f53cb6dfb00b7013e561d1f34403b957cbb5af1fa', name '4e49474854'
@@ -229,7 +230,7 @@ export const getOperationTypeKey = (
       return 'nightRedemption'
     }
   }
-
+*/
   // 5. Check for smart contracts
   if (
     !swapInfo.isSwap &&

--- a/mobile/src/features/Transactions/common/operationDisplay.ts
+++ b/mobile/src/features/Transactions/common/operationDisplay.ts
@@ -319,7 +319,7 @@ export const getOperationDisplayText = (
       return strings.transactions.operation.swapResolved
     }
   }
-
+  /*
   // 4.5. Check for NIGHT redemption transactions
   // Pattern: Smart contract interaction where NIGHT tokens are being spent/redeemed
   // Redemption pattern: NIGHT tokens in inputs (being spent) + smart contract address present
@@ -353,7 +353,7 @@ export const getOperationDisplayText = (
       return strings.transactions.operation.nightRedemption
     }
   }
-
+*/
   // 5. Check for smart contracts (only if no certificate matched, no mint/burn, and not a swap)
   if (
     !swapInfo.isSwap &&


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Use raw signed bytes for submission to avoid CBOR changes, remove NIGHT redemption detection, and simplify ReviewTx screen CBOR handling.
> 
> - **Transactions**:
>   - Use raw `signedTxBytes` from `signRawTx` for submission; avoid re-serializing via `Transaction.toBytes()`.
>   - `signTx` now returns `signedTxBytes` and a function to recreate `Transaction` from bytes; `submitTx` reuses these bytes and returns the same result.
> - **UI/Review Flow**:
>   - Simplify `ReviewTxScreen`: remove auth gating and always pass `cbor` (if present); minor import consolidation.
> - **Operation Classification**:
>   - Disable NIGHT redemption detection logic in `getOperationTypeKey` and `operationDisplay` (commented out).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79f4f6592d59211611074ffc6bbc0cf61f0d3d27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->