### PR TITLE
add collateral utxo even if it gets ignored, and set up change address properly

### DIFF
--- a/mobile/src/features/Airdrop/api/redemptionApi.ts
+++ b/mobile/src/features/Airdrop/api/redemptionApi.ts
@@ -184,8 +184,11 @@ export const redemptionApi = {
       request: {
         changeAddress: request.change_address,
         fundingUtxosCount: request.funding_utxos.length,
-        collateralUtxosCount: request.collateral_utxos.length,
         fundingUtxosPreview: request.funding_utxos
+          .slice(0, 2)
+          .map((utxo) => `${utxo.substring(0, 32)}...`),
+        collateralUtxosCount: request.collateral_utxos.length,
+        collateralUtxosPreview: request.collateral_utxos
           .slice(0, 2)
           .map((utxo) => `${utxo.substring(0, 32)}...`),
       },

--- a/mobile/src/features/Airdrop/common/useRedeemThaw.ts
+++ b/mobile/src/features/Airdrop/common/useRedeemThaw.ts
@@ -1,5 +1,9 @@
 import {RawUtxo} from '@yoroi/api'
-import {CardanoMobileWrapped} from '@yoroi/cardano-wallet'
+import {
+  CardanoMobileWrapped,
+  collateralConfig,
+  utxosMaker,
+} from '@yoroi/cardano-wallet'
 import type {SelectionStrategy} from '@yoroi/tx'
 import {rawUtxoToModernUtxo, selectUtxos} from '@yoroi/tx'
 import {Balance} from '@yoroi/types'
@@ -57,8 +61,8 @@ export const useRedeemThaw = () => {
         [primaryTokenId]: '5000000' as Balance.Quantity, // 5 ADA in lovelace
       }
 
-      const fundingUtxosHex = await CardanoMobileWrapped.cslScope(
-        async (csl) => {
+      const {fundingUtxosHex, collateralUtxosHex} =
+        await CardanoMobileWrapped.cslScope(async (csl) => {
           // Convert RawUtxo[] to ModernUtxo[] using current pattern
           const rawUtxos = wallet.utxos()
 
@@ -91,6 +95,20 @@ export const useRedeemThaw = () => {
             throw new Error('No UTXOs available with sufficient funds')
           }
 
+          // Track which UTXOs were selected for funding (by utxo_id from RawUtxo)
+          // Match ModernUtxo to RawUtxo by txHash and txIndex
+          const selectedFundingUtxoIds = new Set<string>()
+          selection.selected.forEach((modernUtxo) => {
+            const matchingRawUtxo = rawUtxos.find(
+              (rawUtxo) =>
+                rawUtxo.tx_hash === modernUtxo.txHash &&
+                rawUtxo.tx_index === modernUtxo.txIndex,
+            )
+            if (matchingRawUtxo) {
+              selectedFundingUtxoIds.add(matchingRawUtxo.utxo_id)
+            }
+          })
+
           // Convert ModernUtxo to hex strings using toTransactionUnspentOutput
           const utxoHexStrings = await Promise.all(
             selection.selected.map(async (utxo) => {
@@ -99,18 +117,49 @@ export const useRedeemThaw = () => {
             }),
           )
 
-          return utxoHexStrings
-        },
-      )
+          // Find collateral candidates (pure ADA, <= 5 ADA)
+          const utxosList = utxosMaker(rawUtxos, collateralConfig)
+          const collateralCandidates = utxosList.findCollateralCandidates()
 
-      // Get change address
-      const changeAddress = wallet.getChangeAddress('multiple')
+          // Filter out UTXOs already selected for funding
+          const availableCollateral = collateralCandidates.filter(
+            (utxo: RawUtxo) => !selectedFundingUtxoIds.has(utxo.utxo_id),
+          )
+
+          // Convert the first available collateral UTXO to hex format
+          let collateralUtxosHex: string[] = []
+          if (availableCollateral.length > 0) {
+            const collateralUtxo = availableCollateral[0]!
+            // Find the corresponding ModernUtxo to convert it
+            const collateralModernUtxo = modernUtxos.find(
+              (utxo) =>
+                utxo.txHash === collateralUtxo.tx_hash &&
+                utxo.txIndex === collateralUtxo.tx_index,
+            )
+
+            if (collateralModernUtxo) {
+              const cslUtxo =
+                collateralModernUtxo.toTransactionUnspentOutput(csl)
+              collateralUtxosHex = [
+                Buffer.from(cslUtxo.toBytes()).toString('hex'),
+              ]
+            }
+          }
+
+          return {
+            fundingUtxosHex: utxoHexStrings,
+            collateralUtxosHex,
+          }
+        })
+
+      // Get change address (respects wallet's address mode - single uses first address, multiple uses unused address)
+      const changeAddress = wallet.getChangeAddress(meta.addressMode)
 
       // Build transaction request
       const buildRequest: BuildTransactionRequest = {
         change_address: changeAddress,
         funding_utxos: fundingUtxosHex,
-        collateral_utxos: [],
+        collateral_utxos: collateralUtxosHex,
       }
 
       logger.info(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Selects a collateral ADA UTXO (excluding funding UTXOs) and passes it to the build request, and sets the change address based on wallet address mode; adds collateral UTXO preview logging.
> 
> - **Airdrop Redemption (useRedeemThaw)**:
>   - **Collateral UTXO**: Determine collateral candidates via `utxosMaker`/`collateralConfig`, exclude funding UTXOs, convert first candidate to hex, and include in `buildRequest.collateral_utxos`.
>   - **Change Address**: Use `wallet.getChangeAddress(meta.addressMode)` instead of hardcoded `'multiple'`.
>   - **Logging**: Log `collateralUtxosCount`.
> - **API (redemptionApi.buildTransaction)**:
>   - **Logging**: Add `collateralUtxosPreview` (and count) to request logs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aad19da70c6f7c5ea8179eb51044fd78c1940ef2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->