### PR TITLE
fix prod submit ci

### DIFF
--- a/.github/workflows/production-eas-build.yml
+++ b/.github/workflows/production-eas-build.yml
@@ -7,6 +7,8 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  EAS_BUILD_PROFILE: production
+  EXPO_PUBLIC_BUILD_VARIANT: PROD
 
 jobs:
   production-build:
@@ -38,12 +40,21 @@ jobs:
 
       - name: 🚀 Create production build
         working-directory: mobile
+        env:
+          EAS_BUILD_PROFILE: production
+          EXPO_PUBLIC_BUILD_VARIANT: PROD
         run: eas build --profile production --platform all --non-interactive
 
       - name: 🚀 Submit build to Apple TestFlight
         working-directory: mobile
+        env:
+          EAS_BUILD_PROFILE: production
+          EXPO_PUBLIC_BUILD_VARIANT: PROD
         run: eas submit --platform ios --profile production --non-interactive --latest
 
       - name: 🚀 Submit build to Android Google Play
         working-directory: mobile
+        env:
+          EAS_BUILD_PROFILE: production
+          EXPO_PUBLIC_BUILD_VARIANT: PROD
         run: eas submit --platform android --profile production --non-interactive --latest

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -106,7 +106,8 @@
       "ios": {
         "appleId": "amurmurmur@gmail.com",
         "ascAppId": "1447326389",
-        "appleTeamId": "F8NVT2G2L4"
+        "appleTeamId": "F8NVT2G2L4",
+        "bundleIdentifier": "com.emurgo.yoroi"
       }
     }
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Set production EAS env in the workflow and add the iOS bundleIdentifier to eas.json for production submission.
> 
> - **CI/CD (GitHub Actions)**:
>   - Set production env vars globally and for submit/build steps: `EAS_BUILD_PROFILE=production`, `EXPO_PUBLIC_BUILD_VARIANT=PROD` in `.github/workflows/production-eas-build.yml`.
> - **EAS Config**:
>   - Add iOS `bundleIdentifier` (`com.emurgo.yoroi`) to `submit.production.ios` in `mobile/eas.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe4287620cdfe35f75ac229f13e8f4323e29adb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->