### PR TITLE
fix(mobile): exhange loading screen closure

### DIFF
--- a/mobile/src/features/Exchange/useCases/CreateExchangeOrderScreen/CreateExchangeOrderScreen.tsx
+++ b/mobile/src/features/Exchange/useCases/CreateExchangeOrderScreen/CreateExchangeOrderScreen.tsx
@@ -8,8 +8,7 @@ import {
 import {linksYoroiModuleMaker} from '@yoroi/links'
 import {atoms as a} from '@yoroi/theme'
 import {Chain, Exchange} from '@yoroi/types'
-import {useSelectedWallet} from '@yoroi/wallet-manager'
-import {useWalletManager} from '@yoroi/wallet-manager'
+import {useSelectedWallet, useWalletManager} from '@yoroi/wallet-manager'
 
 import * as React from 'react'
 import {Linking, View} from 'react-native'
@@ -121,8 +120,10 @@ export const CreateExchangeOrderScreen = () => {
           ),
         })
       },
-      onSuccess: (referralLink) => {
+      onSuccess: async (referralLink) => {
         closeModal()
+
+        await delay(100)
 
         if (referralLink.toString() !== '') {
           Linking.openURL(referralLink.toString())


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YW-135

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a 100ms delay in the referral link success handler so the loading modal closes before opening the URL and navigating.
> 
> - **Mobile – Exchange**:
>   - **Loading modal closure**: Make `onSuccess` async and add a `100ms` `delay` before `Linking.openURL` and navigation to ensure the modal fully closes first.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1a4746b70d258c1e760b4a4bcff8e85d2d9eca4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->