### PR TITLE
fix(mobile): airdrop, signing message and utxo list menu navigation

### DIFF
--- a/mobile/packages/resolver/adapters/cns/api.test.ts
+++ b/mobile/packages/resolver/adapters/cns/api.test.ts
@@ -8,6 +8,12 @@ import {cnsCryptoAddress, handleCnsApiError} from './api'
 import {resolveAddress} from './api-helpers'
 
 jest.mock('./api-helpers')
+jest.mock('@yoroi/cardano-wallet', () => {
+  const {init: mockInit} = jest.requireActual('@emurgo/cross-csl-nodejs')
+  return {
+    CardanoMobile: mockInit,
+  }
+})
 
 describe('cnsCryptoAddress', () => {
   beforeEach(jest.clearAllMocks)

--- a/mobile/src/features/Menu/Menu.tsx
+++ b/mobile/src/features/Menu/Menu.tsx
@@ -15,6 +15,7 @@ import {SafeAreaView} from 'react-native-safe-area-context'
 
 import {useRemoteConfig} from '~/common/hooks/useRemoteConfig'
 import {useHasRedeemableThaws} from '~/features/Airdrop/common/useHasRedeemableThaws'
+import {AirdropNavigator} from '~/features/Airdrop/ui/AirdropNavigator'
 import {usePrefetchStakingInfo} from '~/features/Dashboard/ui/shared/StakePoolInfos'
 import {useCanVote} from '~/features/RegisterCatalyst/common/hooks'
 import {NetworkTag} from '~/features/Settings/ui/shared/NetworkTag'
@@ -37,6 +38,9 @@ const MenuStack = createStackNavigator<MenuRoutes>()
 export const MenuNavigator = () => {
   const strings = useStrings()
   const {palette: p} = useTheme()
+  const {config} = useRemoteConfig()
+  const isAirdropEnabled = config?.features?.midnightAirdrop?.enabled ?? false
+
   return (
     <MenuStack.Navigator
       initialRouteName="_menu"
@@ -51,6 +55,16 @@ export const MenuNavigator = () => {
         component={Menu}
         options={{title: strings.menu.menu}}
       />
+
+      {isAirdropEnabled && (
+        <MenuStack.Screen
+          name="airdrop"
+          options={{
+            headerShown: false,
+          }}
+          getComponent={() => AirdropNavigator}
+        />
+      )}
     </MenuStack.Navigator>
   )
 }

--- a/mobile/src/features/Menu/Menu.tsx
+++ b/mobile/src/features/Menu/Menu.tsx
@@ -32,6 +32,10 @@ import {Text} from '~/ui/Text/Text'
 
 import {InsufficientFundsModal} from '../RegisterCatalyst/common/InsufficientFundsModal'
 import {usePoolTransition} from '../Staking/Staking/PoolTransition/usePoolTransition'
+import {MessageSigningResultScreen} from '../Transactions/useCases/MessageSigning/MessageSigningResultScreen'
+import {MessageSigningScreen} from '../Transactions/useCases/MessageSigning/MessageSigningScreen'
+import {UtxoConsolidation} from '../Transactions/useCases/UtxoConsolidation/UtxoConsolidation/UtxoConsolidation'
+import {UtxoList as UtxoListScreen} from '../Transactions/useCases/UtxoList/UtxoList'
 
 const MenuStack = createStackNavigator<MenuRoutes>()
 
@@ -46,14 +50,13 @@ export const MenuNavigator = () => {
       initialRouteName="_menu"
       screenOptions={{
         ...defaultStackNavigationOptions(p),
-        headerLeft: () => null,
         headerTitle: ({children}) => <NetworkTag>{children}</NetworkTag>,
       }}
     >
       <MenuStack.Screen
         name="_menu"
         component={Menu}
-        options={{title: strings.menu.menu}}
+        options={{title: strings.menu.menu, headerLeft: () => null}}
       />
 
       {isAirdropEnabled && (
@@ -65,6 +68,38 @@ export const MenuNavigator = () => {
           getComponent={() => AirdropNavigator}
         />
       )}
+
+      <MenuStack.Screen
+        name="utxo-list"
+        options={{
+          title: strings.transactions.utxo.utxoListTitle,
+        }}
+        getComponent={() => UtxoListScreen}
+      />
+
+      <MenuStack.Screen
+        name="utxo-consolidation"
+        options={{
+          title: strings.transactions.utxo.utxoConsolidationTitle,
+        }}
+        getComponent={() => UtxoConsolidation}
+      />
+
+      <MenuStack.Screen
+        name="message-signing"
+        options={{
+          title: strings.transactions.messageSigning.messageSigningTitle,
+        }}
+        getComponent={() => MessageSigningScreen}
+      />
+
+      <MenuStack.Screen
+        name="message-signing-result"
+        options={{
+          title: strings.transactions.messageSigning.messageSigningResultTitle,
+        }}
+        getComponent={() => MessageSigningResultScreen}
+      />
     </MenuStack.Navigator>
   )
 }

--- a/mobile/src/features/Transactions/TxHistoryNavigator.tsx
+++ b/mobile/src/features/Transactions/TxHistoryNavigator.tsx
@@ -7,8 +7,6 @@ import {
 } from '@react-navigation/stack'
 import * as React from 'react'
 
-import {useRemoteConfig} from '~/common/hooks/useRemoteConfig'
-import {AirdropNavigator} from '~/features/Airdrop/ui/AirdropNavigator'
 import {ClaimScreen} from '~/features/Claim/useCases/ClaimScreen'
 import {ShowSuccessScreen} from '~/features/Claim/useCases/ShowSuccessScreen'
 import {CreateExchangeOrderScreen} from '~/features/Exchange/useCases/CreateExchangeOrderScreen/CreateExchangeOrderScreen'
@@ -52,8 +50,6 @@ export const TxHistoryNavigator = () => {
   const {palette: p, atoms: ta} = useTheme()
   const {meta} = useSelectedWallet()
   const walletNavigation = useWalletNavigation()
-  const {config} = useRemoteConfig()
-  const isAirdropEnabled = config?.features?.midnightAirdrop?.enabled ?? false
 
   // Memoize headerTitle component to prevent recreation on every render
   const headerTitle = React.useCallback(
@@ -308,17 +304,6 @@ export const TxHistoryNavigator = () => {
           }}
           getComponent={() => SelectProviderFromListScreen}
         />
-
-        {/* Menu Screens */}
-        {isAirdropEnabled && (
-          <Stack.Screen
-            name="airdrop"
-            options={{
-              headerShown: false,
-            }}
-            getComponent={() => AirdropNavigator}
-          />
-        )}
       </Stack.Navigator>
     </WithWalletOpened>
   )

--- a/mobile/src/kernel/navigation/hooks/useWalletNavigation.ts
+++ b/mobile/src/kernel/navigation/hooks/useWalletNavigation.ts
@@ -472,14 +472,14 @@ export const useWalletNavigation = () => {
     navigateToUtxoList: () => {
       navigation.navigate('manage-wallets', {
         screen: 'main-wallet-routes',
-        params: {screen: 'history', params: {screen: 'utxo-list'}},
+        params: {screen: 'menu', params: {screen: 'utxo-list'}},
       })
     },
 
     navigateToMessageSigning: () => {
       navigation.navigate('manage-wallets', {
         screen: 'main-wallet-routes',
-        params: {screen: 'history', params: {screen: 'message-signing'}},
+        params: {screen: 'menu', params: {screen: 'message-signing'}},
       })
     },
 
@@ -487,7 +487,7 @@ export const useWalletNavigation = () => {
       navigation.navigate('manage-wallets', {
         screen: 'main-wallet-routes',
         params: {
-          screen: 'history',
+          screen: 'menu',
           params: {
             screen: 'message-signing-result',
             params: {signature, key},
@@ -499,7 +499,7 @@ export const useWalletNavigation = () => {
     navigateToUtxoConsolidation: () => {
       navigation.navigate('manage-wallets', {
         screen: 'main-wallet-routes',
-        params: {screen: 'history', params: {screen: 'utxo-consolidation'}},
+        params: {screen: 'menu', params: {screen: 'utxo-consolidation'}},
       })
     },
 

--- a/mobile/src/kernel/navigation/hooks/useWalletNavigation.ts
+++ b/mobile/src/kernel/navigation/hooks/useWalletNavigation.ts
@@ -161,6 +161,9 @@ export const useWalletNavigation = () => {
         screen: 'main-wallet-routes',
         params: {
           screen: 'menu',
+          params: {
+            screen: '_menu',
+          },
         },
       })
     },

--- a/mobile/src/kernel/navigation/hooks/useWalletNavigation.ts
+++ b/mobile/src/kernel/navigation/hooks/useWalletNavigation.ts
@@ -683,7 +683,7 @@ export const useWalletNavigation = () => {
       navigation.navigate('manage-wallets', {
         screen: 'main-wallet-routes',
         params: {
-          screen: 'history',
+          screen: 'menu',
           params: {
             screen: 'airdrop',
           },

--- a/mobile/src/kernel/navigation/types.tsx
+++ b/mobile/src/kernel/navigation/types.tsx
@@ -313,6 +313,13 @@ export type MenuRoutes = {
   '_menu': undefined
   'voting-registration': undefined
   'airdrop': undefined
+  'utxo-list': undefined
+  'utxo-consolidation': undefined
+  'message-signing': undefined
+  'message-signing-result': {
+    signature: string
+    key: string
+  }
 }
 
 export type AppRoutes = {

--- a/mobile/src/kernel/navigation/types.tsx
+++ b/mobile/src/kernel/navigation/types.tsx
@@ -25,7 +25,7 @@ export type WalletTabRoutes = {
   history: NavigatorScreenParams<TxHistoryRoutes>
   portfolio: NavigatorScreenParams<PortfolioRoutes>
   discover: NavigatorScreenParams<DiscoverRoutes>
-  menu: undefined
+  menu: NavigatorScreenParams<MenuRoutes>
 }
 
 export type WalletStackRoutes = {
@@ -90,7 +90,6 @@ export type TxHistoryRoutes = {
     signature: string
     key: string
   }
-  'airdrop': undefined
   'receive-single': undefined
   'receive-specific-amount': undefined
   'receive-multiple': undefined
@@ -313,6 +312,7 @@ export type NftRouteNavigation = StackNavigationProp<NftRoutes>
 export type MenuRoutes = {
   '_menu': undefined
   'voting-registration': undefined
+  'airdrop': undefined
 }
 
 export type AppRoutes = {


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YW-412

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves airdrop, message signing, and UTXO routes from History to the Menu stack, updates navigation/types accordingly, and adds a wallet mock in CNS API tests.
> 
> - **Navigation/Routes**:
>   - **Menu stack**: Adds `airdrop` (feature-flagged), `utxo-list`, `utxo-consolidation`, `message-signing`, and `message-signing-result` screens in `mobile/src/features/Menu/Menu.tsx`.
>   - **History stack**: Removes airdrop-related routing and config checks from `TxHistoryNavigator`.
>   - **Navigation hooks**: Redirect `navigateToUtxoList`, `navigateToUtxoConsolidation`, `navigateToMessageSigning`, `navigateToMessageSigningResult`, and `navigateToAirdrop` to `menu` routes; ensure `navigateToMenu` targets `'_menu'`.
>   - **Types**: Change `WalletTabRoutes['menu']` to `NavigatorScreenParams<MenuRoutes>`; extend `MenuRoutes` with new screens; remove `airdrop` from `TxHistoryRoutes`.
> - **Tests**:
>   - CNS API tests: mock `@yoroi/cardano-wallet` to provide `CardanoMobile` via `cross-csl` `init` for test setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4081a0ccb3bcd0766de6bc33342fb0058f6166cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->