### PR TITLE
refactor(createSendTx): enhance ADA requirement calculation for toke

### DIFF
--- a/mobile/packages/cardano-wallet/transaction-recipes/createSendTx.ts
+++ b/mobile/packages/cardano-wallet/transaction-recipes/createSendTx.ts
@@ -229,7 +229,9 @@ export async function createSendTx({
         const minAdaToUse =
           actualMinAda > minUtxoValue ? actualMinAda : minUtxoValue
 
-        adaNeeded = minAdaToUse
+        if (adaNeeded < minAdaToUse) {
+          adaNeeded = minAdaToUse
+        }
       }
 
       // Update requiredAmounts for ADA

--- a/mobile/packages/cardano-wallet/transaction-recipes/createSendTx.ts
+++ b/mobile/packages/cardano-wallet/transaction-recipes/createSendTx.ts
@@ -103,8 +103,12 @@ export async function createSendTx({
         entry.amounts[primaryTokenId] ?? Branded.ZERO_QUANTITY,
       )
 
-      // If output has tokens but insufficient ADA, calculate actual minimum UTXO value
-      if (hasTokens && adaAmount < minUtxoValue) {
+      // Determine the ADA amount needed for this entry
+      let adaNeeded = adaAmount
+
+      // If output has tokens, we must verify the minimum ADA requirement
+      // The default minUtxoValue (e.g. 1 ADA) might not be enough for a token bundle
+      if (hasTokens) {
         // Calculate actual minimum ADA required for this output using CSL
         const actualMinAda = await CardanoMobileWrapped.cslScope(
           async (csl) => {
@@ -221,18 +225,23 @@ export async function createSendTx({
         // Store the calculated minAda for this entry
         entryMinAda.set(i, actualMinAda)
 
-        const currentAda = BigInt(
-          requiredAmounts[primaryTokenId] ?? Branded.ZERO_QUANTITY,
-        )
         // Use the calculated minimum or the hardcoded fallback, whichever is higher
         const minAdaToUse =
           actualMinAda > minUtxoValue ? actualMinAda : minUtxoValue
-        requiredAmounts[primaryTokenId] = (
-          currentAda + minAdaToUse
-        ).toString() as Balance.Quantity
+
+        adaNeeded = minAdaToUse
       }
 
+      // Update requiredAmounts for ADA
+      const currentAda = BigInt(
+        requiredAmounts[primaryTokenId] ?? Branded.ZERO_QUANTITY,
+      )
+      requiredAmounts[primaryTokenId] = (
+        currentAda + adaNeeded
+      ).toString() as Balance.Quantity
+
       for (const [tokenId, quantity] of Object.entries(entry.amounts)) {
+        if (tokenId === primaryTokenId) continue
         const tokenIdBranded = Branded.asTokenId(tokenId)
         const current = BigInt(
           requiredAmounts[tokenIdBranded] ?? Branded.ZERO_QUANTITY,
@@ -372,18 +381,21 @@ export async function createSendTx({
           entry.amounts[primaryTokenId] ?? Branded.ZERO_QUANTITY,
         )
 
-        // If output has tokens but insufficient ADA, use calculated minAda or fallback
+        // If output has tokens, ensure we meet the calculated minimum requirement
         const adjustedAmounts = {...entry.amounts}
-        if (hasTokens && adaAmount < minUtxoValue) {
+        if (hasTokens) {
           // Use the calculated minAda if available, otherwise use the fallback
           const calculatedMinAda = entryMinAda.get(i)
-          const minAdaToUse =
+          const minRequired =
             calculatedMinAda && calculatedMinAda > minUtxoValue
               ? calculatedMinAda
               : minUtxoValue
 
-          adjustedAmounts[primaryTokenId] =
-            minAdaToUse.toString() as Balance.Quantity
+          // If the current amount is less than required, bump it up
+          if (adaAmount < minRequired) {
+            adjustedAmounts[primaryTokenId] =
+              minRequired.toString() as Balance.Quantity
+          }
         }
 
         builderState = addOutput(

--- a/mobile/src/features/Send/useCases/ListAmountsToSend/ListAmountsToSendScreen.tsx
+++ b/mobile/src/features/Send/useCases/ListAmountsToSend/ListAmountsToSendScreen.tsx
@@ -22,7 +22,6 @@ import {isInsufficientBalanceError} from '~/features/Staking/Governance/common/t
 import {useStrings} from '~/kernel/i18n/useStrings'
 import {logger} from '~/kernel/logger/logger'
 import {BackButton} from '~/kernel/navigation/common/helpers'
-import {useResultNavigation} from '~/kernel/navigation/hooks/useResultNavigation'
 import {useWalletNavigation} from '~/kernel/navigation/hooks/useWalletNavigation'
 import {AddTokenButton} from '~/ui/AddTokenButton/AddTokenButton'
 import {Boundary} from '~/ui/Boundary/Boundary'
@@ -33,7 +32,6 @@ import {TokenAmountItem} from '~/ui/TokenAmountItem/TokenAmountItem'
 
 export const ListAmountsToSendScreen = () => {
   const navigateTo = useNavigateTo()
-  const resultNavigation = useResultNavigation()
   const {navigateToTxReview, resetToStartTransfer} = useWalletNavigation()
   const strings = useStrings()
   const {clearSearch} = useSearch()
@@ -208,31 +206,56 @@ export const ListAmountsToSendScreen = () => {
 
   const handleCreateUnsignedTxError = React.useCallback(
     (error: Error) => {
-      // Check for insufficient balance errors and show error screen
+      logger.error('ListAmountsToSendScreen: Transaction creation failed', {
+        errorMessage: error.message,
+        errorStack: error.stack,
+      })
+
       if (
         error instanceof NotEnoughMoneyToSendError ||
         isInsufficientBalanceError(error)
       ) {
-        logger.info('ListAmountsToSendScreen: Insufficient balance error', {
-          errorMessage: error.message,
-        })
         // Use unified result screen with insufficient balance message
-        resultNavigation.showResultScreen({
-          type: 'error',
-          context: 'send',
-          title: strings.send.noBalance,
-          message: strings.send.failedTxText,
-          primaryAction: {
-            title: strings.send.failedTxButton,
-            onPress: resetToStartTransfer,
+        // @ts-ignore - Navigating to a screen in a sibling navigator
+        navigation.navigate('manage-wallets', {
+          screen: 'review-tx-routes',
+          params: {
+            screen: 'result-screen',
+            params: {
+              type: 'error',
+              context: 'send',
+              title: strings.send.noBalance,
+              message: strings.send.failedTxText,
+              primaryAction: {
+                title: strings.send.failedTxButton,
+                onPress: resetToStartTransfer,
+              },
+            },
           },
         })
         return
       }
-      // Re-throw other errors to be handled by default error handling
-      throw error
+
+      // Show generic error screen for other unexpected errors
+      // @ts-ignore - Navigating to a screen in a sibling navigator
+      navigation.navigate('manage-wallets', {
+        screen: 'review-tx-routes',
+        params: {
+          screen: 'result-screen',
+          params: {
+            type: 'error',
+            context: 'send',
+            title: strings.send.failedTxTitle,
+            message: error.message,
+            primaryAction: {
+              title: strings.send.failedTxButton,
+              onPress: resetToStartTransfer,
+            },
+          },
+        },
+      })
     },
-    [resultNavigation, strings, resetToStartTransfer],
+    [navigation, strings, resetToStartTransfer],
   )
 
   const {resolve: createUnsignedTx, isPending} = usePromise({


### PR DESCRIPTION

- Improved logic to determine the minimum ADA needed when sending tokens.
- Updated handling of insufficient ADA scenarios to ensure compliance with calculated minimum requirements.
- Refactored error handling in ListAmountsToSendScreen to streamline navigation on transaction errors.

https://emurgo.atlassian.net/browse/YW-437

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves transaction building for token transfers and simplifies error handling in the send flow.
> 
> - In `createSendTx.ts`, computes per-output minimum ADA with CSL, records it per entry, and aggregates ADA requirements via `adaNeeded`; ensures outputs with tokens are bumped to the higher of calculated min or fallback and avoids double-counting ADA when summing tokens.
> - In `ListAmountsToSendScreen.tsx`, replaces `useResultNavigation` with direct navigation to a unified result screen; adds structured logging and shows a generic error screen for unexpected failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62399c100b8de3fab0e2f141657419da3cf1e045. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->