### PR TITLE
fix(mobile): only persist successful queries to avoid Promise serialization crash

### DIFF
--- a/mobile/src/kernel/connection/ConnectionProvider.tsx
+++ b/mobile/src/kernel/connection/ConnectionProvider.tsx
@@ -51,7 +51,6 @@ const queryClient = new QueryClient({
 const safeAsyncStorage = {
   getItem: (key: string): Promise<string | null> => {
     const result = AsyncStorage.getItem(key)
-    // Ensure we always return a promise
     if (result && typeof result.then === 'function') {
       return result.catch(() => null)
     }
@@ -59,7 +58,6 @@ const safeAsyncStorage = {
   },
   setItem: (key: string, value: string): Promise<void> => {
     const result = AsyncStorage.setItem(key, value)
-    // Ensure we always return a promise
     if (result && typeof result.then === 'function') {
       return result.catch(() => undefined)
     }
@@ -67,7 +65,6 @@ const safeAsyncStorage = {
   },
   removeItem: (key: string): Promise<void> => {
     const result = AsyncStorage.removeItem(key)
-    // Ensure we always return a promise
     if (result && typeof result.then === 'function') {
       return result.catch(() => undefined)
     }
@@ -101,7 +98,13 @@ const cacheKeyIndicator: QueryKey = freeze([persistPrefixKeyword])
 const dehydrateOptions: PersistQueryClientProviderProps['persistOptions']['dehydrateOptions'] =
   {
     shouldDehydrateMutation: () => false,
-    shouldDehydrateQuery: ({queryKey}) =>
+    // Only dehydrate successful queries that have the 'persist' prefix.
+    // IMPORTANT: We must check status === 'success' to avoid serializing queries
+    // with pending promises. Since React Query 5.40+, pending queries can include
+    // a promise property for SSR streaming. When JSON.stringify'd, Promise becomes
+    // {}. On restoration, tryResolveSync() fails calling .then() on this plain object.
+    shouldDehydrateQuery: ({queryKey, state}) =>
+      state.status === 'success' &&
       cacheKeyIndicator.includes(String(queryKey[0])),
   }
 


### PR DESCRIPTION
The fix adds `state.status === 'success'` to `shouldDehydrateQuery` so that only completed queries are persisted to storage. Since React Query `5.40+`, pending queries include a promise property for SSR streaming, but when serialized via `JSON.stringify `this Promise becomes an empty object `{}`, and on app restart the hydration process tries to call `.then()` on this plain object causing the error message.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents hydration crashes by filtering which queries are persisted.
> 
> - Updates `dehydrateOptions.shouldDehydrateQuery` in `ConnectionProvider.tsx` to require `state.status === 'success'` and the `persist` prefix before persisting
> - Adds detailed comments explaining React Query 5.40+ pending Promise serialization issue; removes minor redundant comments in `safeAsyncStorage`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b0974d65837f60f5de8953d314ba17d6a5e7801. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->