### PR TITLE
fix(mobile): add keyboard auto-resize to tx history filter modal

### DIFF
--- a/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
@@ -46,24 +46,26 @@ const shortenDRepId = (id: string) => {
 export const EnterDrepIdModal = ({onSubmit, initialDrepId}: Props) => {
   const strings = useStrings()
   const {atoms: ta, palette: p} = useTheme()
-  const {closeModal, setHeight} = useModal()
+  const {closeModal} = useModal()
   const {wallet} = useSelectedWallet()
   const network = wallet.networkManager.network
 
   const [showCard, setShowCard] = React.useState(true)
   const [drepId, setDrepId] = React.useState(initialDrepId ?? '')
 
-  const timeoutRef = React.useRef<ReturnType<typeof setTimeout>>(undefined)
   const showCardRef = React.useRef(showCard)
   const isInputFocusedRef = React.useRef(false)
   // Track if we've already set initialDrepId to prevent overriding user input
   const hasSetInitialDrepIdRef = React.useRef(false)
 
-  React.useEffect(() => {
-    return () => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current)
-    }
-  }, [])
+  const {
+    handleInputFocus: defaultHandleInputFocus,
+    handleInputBlur: defaultHandleInputBlur,
+    scheduleHeightChange,
+  } = useModalKeyboardResize({
+    defaultHeight: HEIGHT_WITH_CARD,
+    focusedHeight: HEIGHT_INPUT_FOCUSED,
+  })
 
   const handleDrepIdChange = React.useCallback(
     (text: string) => {
@@ -71,36 +73,17 @@ export const EnterDrepIdModal = ({onSubmit, initialDrepId}: Props) => {
       if (text.length > 0 && showCardRef.current) {
         showCardRef.current = false
         setShowCard(false)
-        if (timeoutRef.current) clearTimeout(timeoutRef.current)
-        timeoutRef.current = setTimeout(
-          () => setHeight(HEIGHT_WITHOUT_CARD),
-          150,
-        )
+        scheduleHeightChange(HEIGHT_WITHOUT_CARD)
       } else if (text.length === 0 && !showCardRef.current) {
         showCardRef.current = true
         setShowCard(true)
-        if (timeoutRef.current) clearTimeout(timeoutRef.current)
-        timeoutRef.current = setTimeout(
-          () =>
-            setHeight(
-              isInputFocusedRef.current
-                ? HEIGHT_INPUT_FOCUSED
-                : HEIGHT_WITH_CARD,
-            ),
-          150,
+        scheduleHeightChange(
+          isInputFocusedRef.current ? HEIGHT_INPUT_FOCUSED : HEIGHT_WITH_CARD,
         )
       }
     },
-    [setHeight],
+    [scheduleHeightChange],
   )
-
-  const {
-    handleInputFocus: defaultHandleInputFocus,
-    handleInputBlur: defaultHandleInputBlur,
-  } = useModalKeyboardResize({
-    defaultHeight: HEIGHT_WITH_CARD,
-    focusedHeight: HEIGHT_INPUT_FOCUSED,
-  })
 
   const handleInputFocus = React.useCallback(() => {
     isInputFocusedRef.current = true

--- a/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
@@ -13,6 +13,7 @@ import {YoroiDrepCard} from '~/features/Staking/Governance/common/YoroiDrepCard/
 import {useStrings} from '~/kernel/i18n/useStrings'
 import {Button} from '~/ui/Button/Button'
 import {useModal} from '~/ui/Modal/context/ModalContext'
+import {useModalKeyboardResize} from '~/ui/Modal/hooks/useModalKeyboardResize'
 import {Modal} from '~/ui/Modal/ui/screens/Modal/Modal'
 import {Space} from '~/ui/Space/Space'
 import {TextInput} from '~/ui/TextInput/TextInput'
@@ -93,24 +94,27 @@ export const EnterDrepIdModal = ({onSubmit, initialDrepId}: Props) => {
     [setHeight],
   )
 
+  const {
+    handleInputFocus: defaultHandleInputFocus,
+    handleInputBlur: defaultHandleInputBlur,
+  } = useModalKeyboardResize({
+    defaultHeight: HEIGHT_WITH_CARD,
+    focusedHeight: HEIGHT_INPUT_FOCUSED,
+  })
+
   const handleInputFocus = React.useCallback(() => {
     isInputFocusedRef.current = true
     if (showCardRef.current) {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current)
-      timeoutRef.current = setTimeout(
-        () => setHeight(HEIGHT_INPUT_FOCUSED),
-        150,
-      )
+      defaultHandleInputFocus()
     }
-  }, [setHeight])
+  }, [defaultHandleInputFocus])
 
   const handleInputBlur = React.useCallback(() => {
     isInputFocusedRef.current = false
     if (showCardRef.current) {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current)
-      timeoutRef.current = setTimeout(() => setHeight(HEIGHT_WITH_CARD), 150)
+      defaultHandleInputBlur()
     }
-  }, [setHeight])
+  }, [defaultHandleInputBlur])
 
   // Trim whitespace from input, ensure drepId is always a string
   const trimmedDrepId = (drepId ?? '').trim()

--- a/mobile/src/features/Transactions/useCases/TxHistory/TxFilterModal.tsx
+++ b/mobile/src/features/Transactions/useCases/TxHistory/TxFilterModal.tsx
@@ -7,6 +7,7 @@ import {useStrings} from '~/kernel/i18n/useStrings'
 import {Button} from '~/ui/Button/Button'
 import {Icon} from '~/ui/Icon'
 import {useModal} from '~/ui/Modal/context/ModalContext'
+import {useModalKeyboardResize} from '~/ui/Modal/hooks/useModalKeyboardResize'
 import {Modal} from '~/ui/Modal/ui/screens/Modal/Modal'
 import {Space} from '~/ui/Space/Space'
 import {TextInput} from '~/ui/TextInput/TextInput'
@@ -154,6 +155,9 @@ type Props = {
   }
 }
 
+const HEIGHT_DEFAULT = 600
+const HEIGHT_INPUT_FOCUSED = 400
+
 export const TxFilterModal = ({
   onApply,
   onClear,
@@ -167,6 +171,11 @@ export const TxFilterModal = ({
   const strings = useStrings()
   const {palette: p} = useTheme()
   const {closeModal} = useModal()
+
+  const {handleInputFocus, handleInputBlur} = useModalKeyboardResize({
+    defaultHeight: HEIGHT_DEFAULT,
+    focusedHeight: HEIGHT_INPUT_FOCUSED,
+  })
 
   const [selectedOperations, setSelectedOperations] = React.useState<string[]>(
     initialFilters?.selectedOperations ?? [],
@@ -273,6 +282,8 @@ export const TxFilterModal = ({
         value={metadataMemoSearch}
         onChangeText={setMetadataMemoSearch}
         placeholder={strings.transactions.filterMetadataMemoPlaceholder}
+        onFocus={handleInputFocus}
+        onBlur={handleInputBlur}
       />
 
       <Space.Height.lg />
@@ -292,6 +303,8 @@ export const TxFilterModal = ({
             onChangeText={handleMinAdaChange}
             placeholder="0"
             keyboardType="decimal-pad"
+            onFocus={handleInputFocus}
+            onBlur={handleInputBlur}
           />
         </View>
         <View style={[a.flex_1]}>
@@ -305,6 +318,8 @@ export const TxFilterModal = ({
             onChangeText={handleMaxAdaChange}
             placeholder="0"
             keyboardType="decimal-pad"
+            onFocus={handleInputFocus}
+            onBlur={handleInputBlur}
           />
         </View>
       </View>

--- a/mobile/src/ui/Modal/hooks/index.ts
+++ b/mobile/src/ui/Modal/hooks/index.ts
@@ -1,0 +1,1 @@
+export {useModalKeyboardResize} from './useModalKeyboardResize'

--- a/mobile/src/ui/Modal/hooks/index.ts
+++ b/mobile/src/ui/Modal/hooks/index.ts
@@ -1,1 +1,0 @@
-export {useModalKeyboardResize} from './useModalKeyboardResize'

--- a/mobile/src/ui/Modal/hooks/useModalKeyboardResize.tsx
+++ b/mobile/src/ui/Modal/hooks/useModalKeyboardResize.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react'
+
+import {useModal} from '../context/ModalContext'
+
+type UseModalKeyboardResizeOptions = {
+  defaultHeight: number
+  focusedHeight: number
+}
+
+export const useModalKeyboardResize = ({
+  defaultHeight,
+  focusedHeight,
+}: UseModalKeyboardResizeOptions) => {
+  const {setHeight} = useModal()
+  const timeoutRef = React.useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  React.useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    }
+  }, [])
+
+  const handleInputFocus = React.useCallback(() => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    timeoutRef.current = setTimeout(() => setHeight(focusedHeight), 150)
+  }, [setHeight, focusedHeight])
+
+  const handleInputBlur = React.useCallback(() => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    timeoutRef.current = setTimeout(() => setHeight(defaultHeight), 150)
+  }, [setHeight, defaultHeight])
+
+  return {
+    handleInputFocus,
+    handleInputBlur,
+  }
+}

--- a/mobile/src/ui/Modal/hooks/useModalKeyboardResize.tsx
+++ b/mobile/src/ui/Modal/hooks/useModalKeyboardResize.tsx
@@ -12,7 +12,9 @@ export const useModalKeyboardResize = ({
   focusedHeight,
 }: UseModalKeyboardResizeOptions) => {
   const {setHeight} = useModal()
-  const timeoutRef = React.useRef<ReturnType<typeof setTimeout>>(undefined)
+  const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  )
 
   React.useEffect(() => {
     return () => {
@@ -20,18 +22,25 @@ export const useModalKeyboardResize = ({
     }
   }, [])
 
+  const scheduleHeightChange = React.useCallback(
+    (targetHeight: number, delay: number = 150) => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+      timeoutRef.current = setTimeout(() => setHeight(targetHeight), delay)
+    },
+    [setHeight],
+  )
+
   const handleInputFocus = React.useCallback(() => {
-    if (timeoutRef.current) clearTimeout(timeoutRef.current)
-    timeoutRef.current = setTimeout(() => setHeight(focusedHeight), 150)
-  }, [setHeight, focusedHeight])
+    scheduleHeightChange(focusedHeight)
+  }, [scheduleHeightChange, focusedHeight])
 
   const handleInputBlur = React.useCallback(() => {
-    if (timeoutRef.current) clearTimeout(timeoutRef.current)
-    timeoutRef.current = setTimeout(() => setHeight(defaultHeight), 150)
-  }, [setHeight, defaultHeight])
+    scheduleHeightChange(defaultHeight)
+  }, [scheduleHeightChange, defaultHeight])
 
   return {
     handleInputFocus,
     handleInputBlur,
+    scheduleHeightChange,
   }
 }


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YW-199

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a reusable hook to standardize modal height adjustments when the keyboard appears and applies it to key modals.
> 
> - New `useModalKeyboardResize` hook encapsulates delayed `setHeight` scheduling for focus/blur in `ui/Modal/hooks`
> - `TxFilterModal` uses the hook with defined heights and adds `onFocus`/`onBlur` to text inputs (metadata, min/max ADA)
> - `EnterDrepIdModal` refactored to use the hook: removes internal timers and direct `setHeight`, and schedules height changes on input changes and focus/blur
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9a945d95d47d82b51eee549d9c0a241ea96bcb3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->