### PR TITLE
feature(mobile): drop 'delete collateral' option

### DIFF
--- a/mobile/src/features/Settings/ui/screens/ChangeWalletSettingsScreen/ManageCollateralScreen/ManageCollateralScreen.tsx
+++ b/mobile/src/features/Settings/ui/screens/ChangeWalletSettingsScreen/ManageCollateralScreen/ManageCollateralScreen.tsx
@@ -10,7 +10,7 @@ import {
 } from '@yoroi/cardano-wallet'
 import {atoms as a, useTheme} from '@yoroi/theme'
 import {TransactionOutput} from '@yoroi/tx'
-import {Branded, Portfolio, UtxoId} from '@yoroi/types'
+import {Branded, Portfolio} from '@yoroi/types'
 import {useCollateralInfo, useSelectedWallet} from '@yoroi/wallet-manager'
 
 import * as CSL from '@emurgo/cross-csl-core'
@@ -21,8 +21,6 @@ import {
   Alert,
   LayoutAnimation,
   ScrollView,
-  TouchableOpacity,
-  TouchableOpacityProps,
   View,
   ViewProps,
   useWindowDimensions,
@@ -37,7 +35,6 @@ import {SettingsStackRoutes} from '~/kernel/navigation/types'
 import {Button, ButtonType} from '~/ui/Button/Button'
 import {Copiable} from '~/ui/Copiable/Copiable'
 import {ErrorPanel} from '~/ui/ErrorPanel/ErrorPanel'
-import {Icon} from '~/ui/Icon'
 import {useModal} from '~/ui/Modal/context/ModalContext'
 import {SafeArea} from '~/ui/SafeArea/SafeArea'
 import {Space} from '~/ui/Space/Space'
@@ -76,10 +73,6 @@ export const ManageCollateralScreen = () => {
 
   const {isPending: isLoadingCollateral, setCollateralId} =
     useSetCollateralId(wallet)
-  const handleRemoveCollateral = () => {
-    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
-    setCollateralId('' as UtxoId)
-  }
   const handleSetCollateralId = (collateralId: RawUtxo['utxo_id']) => {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
     setCollateralId(collateralId)
@@ -200,12 +193,7 @@ export const ManageCollateralScreen = () => {
           {strings.manageCollateral.lockedAsCollateral}
         </Text>
         <Space.Height.sm />
-        <ActionableAmount
-          amount={amount}
-          onRemove={handleRemoveCollateral}
-          collateralId={collateralId}
-          disabled={isLoading}
-        />
+        <ActionableAmount amount={amount} />
         {hasCollateral && (
           <>
             <Space.Height.lg />
@@ -224,10 +212,6 @@ export const ManageCollateralScreen = () => {
                 </Text>
               </Copiable>
             </Row>
-
-            <Space.Height.lg />
-
-            <Text>{strings.manageCollateral.removeCollateral}</Text>
           </>
         )}
         <Space.Height.lg fill />
@@ -262,19 +246,9 @@ export const ManageCollateralScreen = () => {
 }
 
 type ActionableAmountProps = {
-  collateralId: RawUtxo['utxo_id']
   amount: Portfolio.Token.Amount
-  onRemove(): void
-  disabled?: boolean
 }
-const ActionableAmount = ({
-  onRemove,
-  collateralId,
-  amount,
-  disabled,
-}: ActionableAmountProps) => {
-  const handleRemove = () => onRemove()
-
+const ActionableAmount = ({amount}: ActionableAmountProps) => {
   return (
     <View
       style={[a.flex_row, a.justify_between, a.align_center]}
@@ -283,12 +257,6 @@ const ActionableAmount = ({
       <Left>
         <TokenAmountItem amount={amount} />
       </Left>
-
-      {collateralId !== '' && (
-        <Right>
-          <RemoveAmountButton onPress={handleRemove} disabled={disabled} />
-        </Right>
-      )}
     </View>
   )
 }
@@ -296,24 +264,6 @@ const ActionableAmount = ({
 const Left = ({style, ...props}: ViewProps) => (
   <View style={[style, a.flex_1]} {...props} />
 )
-const Right = ({style, ...props}: ViewProps) => (
-  <View style={[style, a.pl_lg]} {...props} />
-)
 const Row = ({style, ...props}: ViewProps) => (
   <View style={[style, a.flex_row, a.align_center]} {...props} />
 )
-
-const RemoveAmountButton = ({disabled, ...props}: TouchableOpacityProps) => {
-  const {palette: p} = useTheme()
-
-  return (
-    <TouchableOpacity
-      testID="removeAmountButton"
-      {...props}
-      disabled={disabled}
-      style={{opacity: disabled ? 0.5 : 1}}
-    >
-      <Icon.CrossCircle size={26} color={p.gray_900} />
-    </TouchableOpacity>
-  )
-}

--- a/mobile/src/kernel/i18n/locales/en-US.json
+++ b/mobile/src/kernel/i18n/locales/en-US.json
@@ -529,7 +529,6 @@
   "components.settings.collateral.notEnoughFundsAlertMessage": "We could not find enough funds in this wallet to create collateral.",
   "components.settings.collateral.notEnoughFundsAlertOK": "OK",
   "components.settings.collateral.notEnoughFundsAlertTitle": "Not enough funds",
-  "components.settings.collateral.removeCollateral": "If you want to return the amount locked as collateral to your balance press the remove icon",
   "components.settings.collateral.collateralInfoModalLabel": "Collateral creation",
   "components.settings.collateral.collateralInfoModalTitle": "What is collateral?",
   "components.settings.collateral.collateralInfoModalText": "The collateral mechanism is an important feature that has been designed to ensure successful smart contract execution. It is used to guarantee that Cardano nodes are compensated for their work in case phase-2 validation fails.",

--- a/mobile/src/kernel/i18n/messages/manage-collateral.ts
+++ b/mobile/src/kernel/i18n/messages/manage-collateral.ts
@@ -5,10 +5,6 @@ export const manageCollateralMessages = defineMessages({
     id: 'components.settings.collateral.lockedAsCollateral',
     defaultMessage: '!!!Locked as Collateral',
   },
-  removeCollateral: {
-    id: 'components.settings.collateral.removeCollateral',
-    defaultMessage: '!!!Remove Collateral',
-  },
   collateralSpent: {
     id: 'components.settings.collateral.collateralSpent',
     defaultMessage: '!!!Collateral Spent',

--- a/mobile/src/kernel/i18n/messages/ui.ts
+++ b/mobile/src/kernel/i18n/messages/ui.ts
@@ -69,10 +69,6 @@ export const uiMessages = defineMessages({
     id: 'analytics.noip',
     defaultMessage: '!!!Add',
   },
-  remove: {
-    id: 'components.settings.collateral.removeCollateral',
-    defaultMessage: '!!!Remove',
-  },
   search: {
     id: 'nft.navigation.search',
     defaultMessage: '!!!Search',

--- a/mobile/src/kernel/i18n/useStrings.ts
+++ b/mobile/src/kernel/i18n/useStrings.ts
@@ -2173,7 +2173,6 @@ export const useStrings = () => {
       // ManageCollateral strings
       manageCollateral: {
         lockedAsCollateral: f(manageCollateralMessages.lockedAsCollateral),
-        removeCollateral: f(manageCollateralMessages.removeCollateral),
         collateralSpent: f(manageCollateralMessages.collateralSpent),
         generateCollateral: f(manageCollateralMessages.generateCollateral),
         notEnoughFundsAlertTitle: f(


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YW-435

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the option to delete collateral from Manage Collateral and cleans up related UI and i18n.
> 
> - Simplifies `ManageCollateralScreen`: drops remove-collateral handler/button and collateral removal text; `ActionableAmount` now displays amount only
> - Cleans up unused imports/props (e.g., `UtxoId`, touchable/icon components) and layout helpers
> - Deletes i18n messages/keys for remove-collateral in `en-US.json`, `manage-collateral.ts`, and `ui.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 423b1051939ac35adc7ce6c61e5ec4e74ac41992. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->