### PR TITLE
feat(mobile): add dappsPreprod configuration and improve dapp list ha…

### DIFF
--- a/mobile/packages/types/index.ts
+++ b/mobile/packages/types/index.ts
@@ -382,6 +382,16 @@ export namespace App {
         Community?: ReadonlyArray<string>
       }>
     }>
+    dappsPreprod?: Readonly<{
+      banned?: ReadonlyArray<string>
+      recommended?: ReadonlyArray<App.ConfigRecommendedDapp>
+      filters?: Readonly<{
+        Media?: ReadonlyArray<string>
+        Investment?: ReadonlyArray<string>
+        Trading?: ReadonlyArray<string>
+        Community?: ReadonlyArray<string>
+      }>
+    }>
     swap?: Readonly<{
       initialPair?: Readonly<{
         tokenIn?: Portfolio.Token.Id

--- a/mobile/src/features/Discover/common/helpers.ts
+++ b/mobile/src/features/Discover/common/helpers.ts
@@ -57,7 +57,7 @@ export type DAppItem = {
 const googleDappId = 'google_search'
 const directUrlId = 'direct_url'
 
-/**
+/**c
  * Checks if a string looks like a URL
  * Matches patterns like:
  * - example.com

--- a/mobile/src/features/Discover/common/helpers.ts
+++ b/mobile/src/features/Discover/common/helpers.ts
@@ -57,7 +57,7 @@ export type DAppItem = {
 const googleDappId = 'google_search'
 const directUrlId = 'direct_url'
 
-/**c
+/**s
  * Checks if a string looks like a URL
  * Matches patterns like:
  * - example.com

--- a/mobile/src/features/Discover/common/useDappList.ts
+++ b/mobile/src/features/Discover/common/useDappList.ts
@@ -1,3 +1,6 @@
+import {Chain} from '@yoroi/types'
+import {useSelectedWallet} from '@yoroi/wallet-manager'
+
 import {useEffect, useState} from 'react'
 
 import {useRemoteConfig} from '~/common/hooks/useRemoteConfig'
@@ -21,8 +24,11 @@ type DappResponse = {
 }
 
 export const useDappList = () => {
+  const {wallet} = useSelectedWallet()
+  const isPreprod = wallet.networkManager.network === Chain.Network.Preprod
+
   const {
-    config,
+    config: remoteConfig,
     isLoading: configLoading,
     error: configError,
   } = useRemoteConfig()
@@ -36,18 +42,23 @@ export const useDappList = () => {
       return
     }
 
+    if (configError) {
+      setError(configError as Error)
+      setData(null)
+      setIsLoading(false)
+      return
+    }
+
     try {
       setIsLoading(true)
       setError(null)
 
-      if (configError) {
-        setError(configError as Error)
-        setData(null)
-        return
-      }
+      const config = isPreprod
+        ? remoteConfig?.dappsPreprod
+        : remoteConfig?.dapps
 
-      if (config?.dapps?.recommended) {
-        const dapps = config.dapps.recommended.map((dapp) => ({
+      if (config?.recommended) {
+        const dapps = config.recommended.map((dapp) => ({
           id: dapp.id,
           name: dapp.name,
           description: dapp.description,
@@ -58,11 +69,11 @@ export const useDappList = () => {
           isSingleAddress: dapp.isSingleAddress ?? false,
         }))
 
-        const filters = config.dapps.filters
+        const filters = config.filters
           ? Object.fromEntries(
-              Object.entries(config.dapps.filters).map(([key, value]) => [
+              Object.entries(config.filters).map(([key, value]) => [
                 key,
-                [...value],
+                [...(value as string[])],
               ]),
             )
           : {}
@@ -79,7 +90,7 @@ export const useDappList = () => {
     } finally {
       setIsLoading(false)
     }
-  }, [config, configLoading, configError])
+  }, [remoteConfig, configLoading, configError, isPreprod])
 
   return {
     data,

--- a/mobile/src/features/Discover/common/useDappList.ts
+++ b/mobile/src/features/Discover/common/useDappList.ts
@@ -73,7 +73,7 @@ export const useDappList = () => {
           ? Object.fromEntries(
               Object.entries(config.filters).map(([key, value]) => [
                 key,
-                [...(value as string[])],
+                [...value],
               ]),
             )
           : {}


### PR DESCRIPTION

- Introduced dappsPreprod configuration with banned and recommended dapps.
- Updated useDappList to handle preprod network and improved error handling.
- Refactored dapp filtering logic to accommodate new configuration structure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds preprod support for Discover dapps and makes the list selection network-aware.
> 
> - Introduces `App.Config.dappsPreprod` (with `banned`, `recommended`, `filters`) alongside existing `dapps`
> - Updates `useDappList` to read `remoteConfig.dappsPreprod` when `wallet.networkManager.network === Chain.Network.Preprod`, otherwise `remoteConfig.dapps`
> - Improves error handling (early return on `configError`), updates dependencies, and maps `recommended`/`filters` from the selected config
> - Minor comment typo in `helpers` (no functional impact)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f18bf275f6d6638410182d89e17541f0c1b168e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->