### PR TITLE
fix(mobile): posthog missing events

### DIFF
--- a/mobile/PlatformShell.tsx
+++ b/mobile/PlatformShell.tsx
@@ -51,20 +51,54 @@ export function PlatformShell({children}: React.PropsWithChildren) {
 
 function usePosthogClient(enabled: boolean) {
   const installationId = React.useMemo(() => initInstallationId(), [])
-  const [initialEnabled] = React.useState(enabled)
+  const hasIdentifiedRef = React.useRef(false)
+  const previousEnabledRef = React.useRef<boolean | null>(null)
 
+  // Create SDK once
   const {sdk, client} = React.useMemo(() => {
     const apiKey = process.env.EXPO_PUBLIC_POSTHOG_KEY
     const host = process.env.EXPO_PUBLIC_POSTHOG_HOST
     if (!apiKey || !host) throw new Error('Analytics client is not configured')
-    const sdk = new PostHog(apiKey, {host, defaultOptIn: initialEnabled})
+    // Type definitions may be incomplete - these options are documented
+    const devOptions = __DEV__ ? {flushAt: 1, flushInterval: 1000} : {}
+    const sdk = new PostHog(apiKey, {
+      host,
+      defaultOptIn: true,
+      ...(devOptions as Record<string, unknown>),
+    })
     return {sdk, client: createPosthogClient({sdk})}
-  }, [initialEnabled])
+  }, [])
 
+  // Sync opt-in/opt-out state with enabled
   React.useEffect(() => {
-    enabled ? sdk.optIn() : sdk.optOut()
-    if (enabled && installationId) client.identify(installationId)
-  }, [sdk, client, installationId, enabled])
+    const prevEnabled = previousEnabledRef.current
+    previousEnabledRef.current = enabled
+
+    // On initial mount, sync SDK state if user is opted out
+    if (prevEnabled === null) {
+      if (!enabled) {
+        sdk.optOut()
+      }
+      return
+    }
+
+    // Only call when state actually changes
+    if (prevEnabled !== enabled) {
+      if (enabled) {
+        sdk.optIn()
+      } else {
+        sdk.optOut()
+      }
+    }
+  }, [sdk, enabled])
+
+  // Identify only once when enabled
+  React.useEffect(() => {
+    if (enabled && installationId && !hasIdentifiedRef.current) {
+      hasIdentifiedRef.current = true
+      client.identify(installationId)
+    }
+  }, [client, installationId, enabled])
 
   return client
 }

--- a/mobile/PlatformShell.tsx
+++ b/mobile/PlatformShell.tsx
@@ -52,7 +52,6 @@ export function PlatformShell({children}: React.PropsWithChildren) {
 function usePosthogClient(enabled: boolean) {
   const installationId = React.useMemo(() => initInstallationId(), [])
   const hasIdentifiedRef = React.useRef(false)
-  const previousEnabledRef = React.useRef<boolean | null>(null)
 
   // Create SDK once
   const {sdk, client} = React.useMemo(() => {
@@ -71,24 +70,10 @@ function usePosthogClient(enabled: boolean) {
 
   // Sync opt-in/opt-out state with enabled
   React.useEffect(() => {
-    const prevEnabled = previousEnabledRef.current
-    previousEnabledRef.current = enabled
-
-    // On initial mount, sync SDK state if user is opted out
-    if (prevEnabled === null) {
-      if (!enabled) {
-        sdk.optOut()
-      }
-      return
-    }
-
-    // Only call when state actually changes
-    if (prevEnabled !== enabled) {
-      if (enabled) {
-        sdk.optIn()
-      } else {
-        sdk.optOut()
-      }
+    if (enabled) {
+      sdk.optIn()
+    } else {
+      sdk.optOut()
     }
   }, [sdk, enabled])
 

--- a/mobile/PlatformShell.tsx
+++ b/mobile/PlatformShell.tsx
@@ -51,18 +51,20 @@ export function PlatformShell({children}: React.PropsWithChildren) {
 
 function usePosthogClient(enabled: boolean) {
   const installationId = React.useMemo(() => initInstallationId(), [])
+  const [initialEnabled] = React.useState(enabled)
 
-  const client = React.useMemo(() => {
+  const {sdk, client} = React.useMemo(() => {
     const apiKey = process.env.EXPO_PUBLIC_POSTHOG_KEY
     const host = process.env.EXPO_PUBLIC_POSTHOG_HOST
     if (!apiKey || !host) throw new Error('Analytics client is not configured')
-    const sdk = new PostHog(apiKey, {host, disabled: !enabled})
-    return createPosthogClient({sdk})
-  }, [enabled])
+    const sdk = new PostHog(apiKey, {host, defaultOptIn: initialEnabled})
+    return {sdk, client: createPosthogClient({sdk})}
+  }, [initialEnabled])
 
   React.useEffect(() => {
-    if (installationId && enabled) client.identify(installationId)
-  }, [client, installationId, enabled])
+    enabled ? sdk.optIn() : sdk.optOut()
+    if (enabled && installationId) client.identify(installationId)
+  }, [sdk, client, installationId, enabled])
 
   return client
 }

--- a/mobile/src/features/Analytics/helpers/createPosthogClient.ts
+++ b/mobile/src/features/Analytics/helpers/createPosthogClient.ts
@@ -25,7 +25,10 @@ export function createPosthogClient({sdk}: {sdk: SDK}): AnalyticsProvider {
       sdk.flush?.()
     },
     install: (campaign, source) => {
-      if (currentUserId) sdk.identify(currentUserId, {campaign, source})
+      if (currentUserId) {
+        sdk.identify(currentUserId, {campaign, source})
+        sdk.flush?.()
+      }
     },
     identify: (userId, traits) => {
       const hasValidUserId = userId && userId.length > 0

--- a/mobile/src/features/Analytics/helpers/createPosthogClient.ts
+++ b/mobile/src/features/Analytics/helpers/createPosthogClient.ts
@@ -10,13 +10,20 @@ type SDK = {
     event: string,
     properties?: Record<string, string | number | boolean | null | string[]>,
   ) => void
+  flush?: () => Promise<void>
 }
 
 export function createPosthogClient({sdk}: {sdk: SDK}): AnalyticsProvider {
   let currentUserId: string | undefined
   return {
-    navigate: (to) => sdk.capture('navigate', {to}),
-    capture: (event, properties) => sdk.capture(event, properties),
+    navigate: (to) => {
+      sdk.capture('navigate', {to})
+      sdk.flush?.()
+    },
+    capture: (event, properties) => {
+      sdk.capture(event, properties)
+      sdk.flush?.()
+    },
     install: (campaign, source) => {
       if (currentUserId) sdk.identify(currentUserId, {campaign, source})
     },
@@ -25,6 +32,7 @@ export function createPosthogClient({sdk}: {sdk: SDK}): AnalyticsProvider {
       if (hasValidUserId) {
         currentUserId = userId
         sdk.identify(userId, traits)
+        sdk.flush?.()
         return
       }
       currentUserId = undefined

--- a/mobile/src/kernel/navigation/RouterContainer.tsx
+++ b/mobile/src/kernel/navigation/RouterContainer.tsx
@@ -30,8 +30,8 @@ export function RouterContainer({children, onRouteChange}: Props) {
     isDarkRef.current = isDark
   }, [palette, isDark])
 
-  // Debounce navigation state changes to prevent rapid-fire status bar updates
-  const stateChangeRef = React.useRef(0)
+  // Use state to trigger re-renders for debounced callback
+  const [stateChangeCount, setStateChangeCount] = React.useState(0)
 
   const handleStateChangeDebounced = React.useCallback(() => {
     const routeName = navRef.current?.getCurrentRoute()?.name
@@ -42,15 +42,15 @@ export function RouterContainer({children, onRouteChange}: Props) {
 
   const handleStateChange = React.useCallback(
     (_state: NavigationState | undefined) => {
-      // Increment ref to trigger debounced callback
-      stateChangeRef.current += 1
+      // Increment state to trigger re-render and debounced callback
+      setStateChangeCount((prev) => prev + 1)
     },
     [],
   )
 
   useDebouncedCallback(
     handleStateChangeDebounced,
-    stateChangeRef.current,
+    stateChangeCount,
     100,
     false, // Don't skip first render - we want initial route to be processed
   )


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YW-450

**Fix: PostHog analytics events not sending**

**Problem**

After merge 828b5b66, that included problematic commit 32a3af23, PostHog stopped sending analytics events. Only the identify call worked - all other events (page views, transactions, etc.) were silently lost.

**Cause**

The analytics opt-in fix (32a3af23) made the PostHog SDK recreate on every enable/disable toggle. New SDK instances require async initialization, causing events to be lost.

**Solution**

- Create the PostHog SDK once on app start
- Use optIn()/optOut() methods to toggle tracking dynamically
- SDK connection remains stable, no events lost


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix PostHog event delivery and stability**
> 
> - Create PostHog SDK once in `usePosthogClient` and toggle tracking via `sdk.optIn()`/`sdk.optOut()`; identify only once per install
> - Add dev flush options and call `sdk.flush()` after `navigate`, `capture`, `install`, and `identify` in `createPosthogClient`
> - Update `RouterContainer` to use state-driven debouncing for navigation state changes to reliably trigger status bar updates and route-change callbacks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 861e82d8c599a066b8e1e88dff020daef5737603. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->