### PR TITLE
fix(wallet): Send max adjustments

### DIFF
--- a/mobile/packages/cardano-wallet/transaction-recipes/wallet-helpers.ts
+++ b/mobile/packages/cardano-wallet/transaction-recipes/wallet-helpers.ts
@@ -37,10 +37,16 @@ async function getAbsoluteSlotNumberFromWallet(
 /**
  * Helper to get modern UTXOs from wallet
  * Excludes collateral UTXO to prevent it from being used in regular transactions
+ * However, when sending MAX (subtractFeeFromAmount=true), includes collateral
+ * since it's not locked by assets and should be included in MAX sends
  */
-function getModernUtxosFromWallet(wallet: YoroiWallet) {
+function getModernUtxosFromWallet(
+  wallet: YoroiWallet,
+  includeCollateral = false,
+) {
+  const rawUtxos = includeCollateral ? wallet.allUtxos() : wallet.utxos()
   return convertRawUtxosToModernUtxos(
-    wallet.utxos(), // Use wallet.utxos instead of allUtxos to exclude collateral
+    rawUtxos,
     (address) => wallet.getAddressing(address),
     wallet.portfolioPrimaryTokenInfo.id,
   )
@@ -288,11 +294,15 @@ export async function createSendTxFromWallet(
      * If true, subtract transaction fee from the primary token amount in the first output.
      * This is useful when sending MAX amount - the output will be automatically adjusted
      * to account for fees, ensuring the transaction can be built successfully.
+     * When true, also includes collateral UTXO in the selection since it's not locked by assets.
      */
     subtractFeeFromAmount?: boolean
   },
 ): Promise<{cbor: string}> {
-  const modernUtxos = getModernUtxosFromWallet(wallet)
+  // When sending MAX (subtractFeeFromAmount=true), include collateral UTXO
+  // Collateral is not locked by assets, so it should be included in MAX sends
+  const includeCollateral = params.subtractFeeFromAmount === true
+  const modernUtxos = getModernUtxosFromWallet(wallet, includeCollateral)
 
   return createSendTx({
     utxos: modernUtxos,

--- a/mobile/src/features/Send/useCases/ListAmountsToSend/EditAmount/EditAmountScreen.tsx
+++ b/mobile/src/features/Send/useCases/ListAmountsToSend/EditAmount/EditAmountScreen.tsx
@@ -17,6 +17,7 @@ import {
 } from 'react-native'
 
 import {usePortfolioBalances} from '~/features/Portfolio/common/hooks/usePortfolioBalances'
+import {usePortfolioPrimaryBreakdown} from '~/features/Portfolio/common/hooks/usePortfolioPrimaryBreakdown'
 import {useDynamicLockedDeposit} from '~/features/Send/common/hooks/useDynamicLockedDeposit'
 import {useNavigateTo} from '~/features/Send/common/navigation'
 import {useLanguage} from '~/kernel/i18n/LanguageProvider'
@@ -46,6 +47,7 @@ export const EditAmountScreen = () => {
 
   const {wallet} = useSelectedWallet()
   const balances = usePortfolioBalances({wallet})
+  const primaryBreakdown = usePortfolioPrimaryBreakdown({wallet})
 
   const {
     amountRemoved,
@@ -78,10 +80,31 @@ export const EditAmountScreen = () => {
     isCalculating,
   } = useDynamicLockedDeposit({tokensBeingSent})
 
-  const available =
-    (balances.records.get(selectedTokenId)?.quantity ?? BigInt(0)) -
-    (allocated.get(selectedTargetIndex)?.get(selectedTokenId) ?? BigInt(0))
   const isPrimary = isPrimaryToken(amount.info)
+
+  // Calculate available balance excluding staking rewards
+  // Staking rewards are not in UTXOs and require withdrawal first
+  const available = React.useMemo(() => {
+    const balanceWithRewards =
+      (balances.records.get(selectedTokenId)?.quantity ?? BigInt(0)) -
+      (allocated.get(selectedTargetIndex)?.get(selectedTokenId) ?? BigInt(0))
+
+    // For primary token, exclude staking rewards from available balance
+    // Staking rewards are not spendable without withdrawal transaction
+    if (isPrimary) {
+      const availableRewards = primaryBreakdown.availableRewards ?? BigInt(0)
+      return balanceWithRewards - availableRewards
+    }
+
+    return balanceWithRewards
+  }, [
+    balances,
+    selectedTokenId,
+    allocated,
+    selectedTargetIndex,
+    isPrimary,
+    primaryBreakdown.availableRewards,
+  ])
 
   // Calculate spendable amount accounting for locked deposit
   // Use dynamic locked if tokens are being sent, otherwise use current locked

--- a/mobile/src/features/Send/useCases/ListAmountsToSend/ListAmountsToSendScreen.tsx
+++ b/mobile/src/features/Send/useCases/ListAmountsToSend/ListAmountsToSendScreen.tsx
@@ -14,6 +14,7 @@ import {FlatList} from 'react-native-gesture-handler'
 
 import {usePromise} from '~/common/hooks/usePromise'
 import {usePortfolioBalances} from '~/features/Portfolio/common/hooks/usePortfolioBalances'
+import {usePortfolioPrimaryBreakdown} from '~/features/Portfolio/common/hooks/usePortfolioPrimaryBreakdown'
 import {useSearch} from '~/features/Search/SearchContext'
 import {useDynamicLockedDeposit} from '~/features/Send/common/hooks/useDynamicLockedDeposit'
 import {useNavigateTo} from '~/features/Send/common/navigation'
@@ -60,6 +61,7 @@ export const ListAmountsToSendScreen = () => {
 
   // Check if MAX amount is being sent for primary token
   const balances = usePortfolioBalances({wallet})
+  const primaryBreakdown = usePortfolioPrimaryBreakdown({wallet})
   const primaryTokenId = wallet.portfolioPrimaryTokenInfo.id
   const primaryAmount = amounts[primaryTokenId]
 
@@ -82,9 +84,13 @@ export const ListAmountsToSendScreen = () => {
   const isSendingMaxAda = React.useMemo(() => {
     if (!primaryAmount || !isPrimaryToken(primaryAmount.info)) return false
 
-    const available =
+    // Calculate available balance excluding staking rewards
+    // Staking rewards are not in UTXOs and require withdrawal first
+    const balanceWithRewards =
       (balances.records.get(primaryTokenId)?.quantity ?? BigInt(0)) -
       (allocated.get(selectedTargetIndex)?.get(primaryTokenId) ?? BigInt(0))
+    const availableRewards = primaryBreakdown.availableRewards ?? BigInt(0)
+    const available = balanceWithRewards - availableRewards
 
     // Use dynamic locked if tokens are being sent, otherwise use current locked
     const lockedToUse =
@@ -96,6 +102,8 @@ export const ListAmountsToSendScreen = () => {
 
     logger.info('ListAmountsToSendScreen: MAX detection', {
       primaryAmount: primaryAmount.quantity.toString(),
+      balanceWithRewards: balanceWithRewards.toString(),
+      availableRewards: availableRewards.toString(),
       available: available.toString(),
       currentLocked: currentLocked.toString(),
       dynamicLocked: dynamicLocked.toString(),
@@ -109,6 +117,7 @@ export const ListAmountsToSendScreen = () => {
   }, [
     primaryAmount,
     balances,
+    primaryBreakdown.availableRewards,
     currentLocked,
     dynamicLocked,
     tokensBeingSent,


### PR DESCRIPTION
https://emurgo.atlassian.net/browse/YW-472
https://emurgo.atlassian.net/browse/YW-473

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts MAX send and spendable balance logic to better reflect actually spendable ADA.
> 
> - Updates `getModernUtxosFromWallet` to accept `includeCollateral` and uses `wallet.allUtxos()` when `subtractFeeFromAmount` is true; `createSendTxFromWallet` now includes collateral for MAX sends
> - In `EditAmountScreen` and `ListAmountsToSendScreen`, calculates available balance for the primary token excluding staking rewards via `usePortfolioPrimaryBreakdown`, and derives spendable using dynamic/current locked deposit; improves MAX detection and logging
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91eeb265978393b801c1f76b8157423cf144d6b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->