### PR TITLE
Fix cases were offline default value gets persisted

### DIFF
--- a/mobile/src/common/hooks/useRemoteConfig.ts
+++ b/mobile/src/common/hooks/useRemoteConfig.ts
@@ -15,7 +15,7 @@ const url = `${basePath}${isDev ? 'dev.json' : 'prod.json'}`
 export const useRemoteConfig = () => {
   const query = useQuery({
     queryKey,
-    queryFn: async (): Promise<App.Config> => {
+    queryFn: async (): Promise<App.Config | undefined> => {
       const response = await fetchData<App.Config>({
         url,
       })
@@ -25,7 +25,7 @@ export const useRemoteConfig = () => {
           origin: 'useRemoteConfig',
           response: response,
         })
-        return {} as App.Config
+        return undefined
       }
 
       return response.value.data

--- a/mobile/src/features/Airdrop/common/useAirdropEligibility.ts
+++ b/mobile/src/features/Airdrop/common/useAirdropEligibility.ts
@@ -42,7 +42,7 @@ export const useAirdropEligibility = () => {
       !isByronWallet,
     staleTime: time.fiveMinutes,
     retry: false,
-    queryFn: async (): Promise<AddressAllocation[]> => {
+    queryFn: async (): Promise<AddressAllocation[] | undefined> => {
       if (!wallet || !wallet.isMainnet) {
         return []
       }
@@ -57,7 +57,7 @@ export const useAirdropEligibility = () => {
         addresses = wallet.receiveAddresses() || []
       } catch (error) {
         logger.warn('Failed to get receive addresses', {error})
-        return []
+        return undefined
       }
 
       if (addresses.length === 0) {

--- a/mobile/src/features/Pairing/hooks/usePrimaryTokenActivity.tsx
+++ b/mobile/src/features/Pairing/hooks/usePrimaryTokenActivity.tsx
@@ -11,16 +11,16 @@ export const usePrimaryTokenActivity = ({
   options,
 }: {
   to: Portfolio.Currency.Symbol
-  options?: UseQueryOptions<PrimaryTokenActivity, Error>
+  options?: UseQueryOptions<PrimaryTokenActivity | undefined, Error>
 }) => {
-  const query = useQuery({
+  const query = useQuery<PrimaryTokenActivity | undefined, Error>({
     enabled: to !== ptTicker,
     staleTime: time.oneMinute,
     retryDelay: time.oneSecond,
     refetchInterval: time.oneMinute,
     queryKey: [persistPrefixKeyword, 'usePrimaryTokenActivity', to],
     ...options,
-    queryFn: async () => {
+    queryFn: async (): Promise<PrimaryTokenActivity | undefined> => {
       const response = await fetchPtPriceActivity([
         Date.now(),
         Date.now() - time.oneDay,
@@ -39,7 +39,7 @@ export const usePrimaryTokenActivity = ({
         }
       }
 
-      return defaultPrimaryTokenActivity
+      return undefined
     },
   })
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prevents placeholder defaults from being cached/persisted when network requests fail.
> 
> - `useRemoteConfig`: `queryFn` now returns `undefined` on fetch errors instead of an empty `App.Config`
> - `useAirdropEligibility`: `queryFn` returns `AddressAllocation[] | undefined`; address-fetch failures now yield `undefined` (not `[]`) in certain cases to avoid persisting empty data
> - `usePrimaryTokenActivity`: types and `queryFn` updated to allow `undefined` (on failure) instead of defaulting; hook still exposes `defaultPrimaryTokenActivity` at usage layer
> 
> These changes reduce the risk of stale/offline defaults being stored by React Query caches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ed0e7c30fdfaff591be6e9b27201694039805c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->