### PR TITLE
chore: develop to preview

### DIFF
--- a/mobile/src/features/Links/components/ActionHandler.tsx
+++ b/mobile/src/features/Links/components/ActionHandler.tsx
@@ -139,18 +139,7 @@ export const ActionHandler = () => {
   // Update observables when React state changes
   React.useEffect(() => {
     if (pendingAction) {
-      const newActionId = createActionId(pendingAction)
-      // If this actionId was processed before, check if it's a new instance
-      if (newActionId && processedActionsRef.current.has(newActionId)) {
-        const previousAction = processedActionsRef.current.get(newActionId)
-        // If the action object reference is different, it's a new trigger
-        if (previousAction !== pendingAction) {
-          // Same actionId but new instance - clear to allow reprocessing
-          processedActionsRef.current.delete(newActionId)
-          isProcessingRef.current = false
-        }
-      }
-      currentActionIdRef.current = newActionId
+      currentActionIdRef.current = createActionId(pendingAction)
     } else {
       currentActionIdRef.current = null
     }
@@ -168,10 +157,8 @@ export const ActionHandler = () => {
   }, [wallet])
 
   // Track processing state
-  // Map actionId -> pendingAction object reference to detect new triggers
-  const processedActionsRef = React.useRef<Map<string, PendingAction | null>>(
-    new Map(),
-  )
+  // Set of actionIds that have been processed
+  const processedActionsRef = React.useRef<Set<string>>(new Set())
   const isProcessingRef = React.useRef(false)
   const hasShownModalRef = React.useRef(false)
   const prevWalletRef = React.useRef<typeof wallet>(wallet)
@@ -319,19 +306,8 @@ export const ActionHandler = () => {
             return
           }
 
-          // Check if we've already processed this exact action instance
-          if (actionId && processedActionsRef.current.has(actionId)) {
-            const processedAction = processedActionsRef.current.get(actionId)
-            // If it's the same action object reference, skip (already processing)
-            if (processedAction === action) {
-              return
-            }
-            // Different action object with same actionId - new trigger, allow it
-            processedActionsRef.current.delete(actionId)
-            isProcessingRef.current = false
-          }
-
-          if (!actionId) {
+          // Check if we've already processed this action
+          if (!actionId || processedActionsRef.current.has(actionId)) {
             return
           }
 
@@ -340,8 +316,7 @@ export const ActionHandler = () => {
           }
 
           isProcessingRef.current = true
-          // Store action object reference, not just actionId
-          processedActionsRef.current.set(actionId, action)
+          processedActionsRef.current.add(actionId)
 
           InteractionManager.runAfterInteractions(() => {
             try {

--- a/mobile/src/features/Links/components/ClaimActionHandler.tsx
+++ b/mobile/src/features/Links/components/ClaimActionHandler.tsx
@@ -18,7 +18,8 @@ import {logger} from '~/kernel/logger/logger'
 export const ClaimActionHandler = () => {
   const {pendingAction} = useLinks()
   const {reset: resetClaimState, scanActionClaimChanged, address} = useClaim()
-  const processedActionRef = React.useRef<Links.CardanoActionClaim | null>(null)
+  // Track processed claim URLs to prevent re-processing
+  const processedClaimUrlsRef = React.useRef<Set<string>>(new Set())
 
   // Handle claim action from pendingAction context
   // Use useFocusEffect to ensure we process when screen is focused
@@ -48,12 +49,9 @@ export const ClaimActionHandler = () => {
       ) {
         const cardanoAction = pendingAction.action as Links.CardanoActionClaim
 
-        // Check if we've already processed this action
-        if (
-          processedActionRef.current &&
-          processedActionRef.current.url === cardanoAction.url &&
-          processedActionRef.current.code === cardanoAction.code
-        ) {
+        // Check if we've already processed this claim URL
+        const claimKey = `${cardanoAction.url}:${cardanoAction.code}`
+        if (processedClaimUrlsRef.current.has(claimKey)) {
           logger.info(
             'ClaimActionHandler: action already processed, skipping',
             {
@@ -75,7 +73,7 @@ export const ClaimActionHandler = () => {
         scanActionClaimChanged(cardanoAction)
 
         // Mark as processed to prevent re-processing if screen refocuses
-        processedActionRef.current = cardanoAction
+        processedClaimUrlsRef.current.add(claimKey)
       } else {
         logger.info('ClaimActionHandler: conditions not met', {
           hasPendingAction: !!pendingAction,

--- a/mobile/src/features/Links/hooks/useDeepLinkWatcher.tsx
+++ b/mobile/src/features/Links/hooks/useDeepLinkWatcher.tsx
@@ -12,6 +12,10 @@ export const useDeepLinkWatcher = () => {
   const {isLoggedIn} = useAuth()
   const {pendingAction, setPendingAction} = useLinks()
 
+  // Track URLs that have already been processed to prevent re-processing
+  // when processLink callback reference changes
+  const processedUrlsRef = React.useRef<Set<string>>(new Set())
+
   const processLink = React.useCallback(
     (url: string) => {
       // Try Yoroi links first (yoroi://)
@@ -70,7 +74,8 @@ export const useDeepLinkWatcher = () => {
   React.useEffect(() => {
     const getInitialURL = async () => {
       const url = await Linking.getInitialURL()
-      if (url !== null) {
+      if (url !== null && !processedUrlsRef.current.has(url)) {
+        processedUrlsRef.current.add(url)
         processLink(url)
       }
     }
@@ -92,40 +97,42 @@ export const useDeepLinkWatcher = () => {
     const checkInitialUrlAfterLogin = async () => {
       const url = await Linking.getInitialURL()
 
-      if (url !== null) {
-        // Try both Yoroi and Cardano links
-        const parsedYoroiAction = linksYoroiParser(url)
-        if (parsedYoroiAction != null) {
-          if (
-            parsedYoroiAction.params?.isSandbox === true &&
-            __DEV__ === false
-          ) {
-            return
-          }
-          const pendingAction: PendingAction = {
-            source: 'yoroi',
-            action: {info: parsedYoroiAction, isTrusted: false},
-          }
-          setPendingAction(pendingAction)
+      // Skip if URL was already processed
+      if (url === null || processedUrlsRef.current.has(url)) {
+        return
+      }
+
+      // Try both Yoroi and Cardano links
+      const parsedYoroiAction = linksYoroiParser(url)
+      if (parsedYoroiAction != null) {
+        if (parsedYoroiAction.params?.isSandbox === true && __DEV__ === false) {
           return
         }
+        processedUrlsRef.current.add(url)
+        const pendingAction: PendingAction = {
+          source: 'yoroi',
+          action: {info: parsedYoroiAction, isTrusted: false},
+        }
+        setPendingAction(pendingAction)
+        return
+      }
 
-        if (isWebCardanoLink(url)) {
-          try {
-            const cardanoAction = parseCardanoLink(url)
-            const pendingAction: PendingAction = {
-              source: 'cardano',
-              action: cardanoAction,
-            }
-            setPendingAction(pendingAction)
-          } catch (error) {
-            logger.error('useDeepLinkWatcher: error parsing URL after login', {
-              error,
-              errorMessage:
-                error instanceof Error ? error.message : String(error),
-              url,
-            })
+      if (isWebCardanoLink(url)) {
+        try {
+          processedUrlsRef.current.add(url)
+          const cardanoAction = parseCardanoLink(url)
+          const pendingAction: PendingAction = {
+            source: 'cardano',
+            action: cardanoAction,
           }
+          setPendingAction(pendingAction)
+        } catch (error) {
+          logger.error('useDeepLinkWatcher: error parsing URL after login', {
+            error,
+            errorMessage:
+              error instanceof Error ? error.message : String(error),
+            url,
+          })
         }
       }
     }

--- a/mobile/src/ui/Counter/Counter.tsx
+++ b/mobile/src/ui/Counter/Counter.tsx
@@ -44,7 +44,7 @@ export const Counter = ({
 
         {unitsText !== undefined && (
           <Text style={[a.body_2_md_medium, {color: p.primary_600}]}>
-            {unitsText ?? ''}
+            {` ${unitsText}`}
           </Text>
         )}
 
@@ -56,7 +56,7 @@ export const Counter = ({
                 : [a.body_2_md_regular, {color: p.primary_600}],
             ]}
           >
-            {closingText ?? ''}
+            {` ${closingText}`}
           </Text>
         )}
       </Text>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the deduplication logic for deep-link ingestion and action execution, which can affect whether links/actions fire once or multiple times (especially across login/wallet-selection flows). Risk is moderate because it touches navigation-triggering behavior and state cleanup timing.
> 
> **Overview**
> Tightens deep-link/action deduplication to avoid repeated processing: `useDeepLinkWatcher` now tracks already-seen URLs and skips re-handling the same `getInitialURL` result (including the post-login re-check), and `ClaimActionHandler` tracks processed claim `url:code` pairs to avoid re-running claim setup on screen refocus.
> 
> Simplifies `ActionHandler`'s processing guard from an `actionId -> actionRef` map to an `actionId` set, relying on `markActionProcessed` cleanup to allow re-triggering later, while still preventing duplicate execution during a single processing cycle.
> 
> Minor UI tweak: `Counter` now inserts a leading space before `unitsText`/`closingText` when present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05347e773b5e9a1e8ab742d9c66d80e021a2247b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->