### PR TITLE
fix(mobile): guard against null certificate entries causing crash

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Yoroi",
     "slug": "yoroi",
     "owner": "emurgo",
-    "version": "7.0.3",
+    "version": "7.0.4",
     "orientation": "portrait",
     "icon": "./assets/yoroi/icon.png",
     "userInterfaceStyle": "automatic",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yoroi-v2",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yoroi-v2",
-      "version": "7.0.3",
+      "version": "7.0.4",
       "hasInstallScript": true,
       "dependencies": {
         "@cardano-foundation/ledgerjs-hw-app-cardano": "7.1.4",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi-v2",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "main": "index.ts",
   "scripts": {
     "postinstall": "patch-package",

--- a/mobile/packages/cardano-wallet/transactionManager/transactionManager.ts
+++ b/mobile/packages/cardano-wallet/transactionManager/transactionManager.ts
@@ -942,7 +942,9 @@ const parseTx = (
   }
 
   const tx = parseSafe(data)
-  return isTx(tx) ? tx : undefined
+  if (!isTx(tx)) return undefined
+  tx.certificates = tx.certificates.filter((cert) => cert != null)
+  return tx
 }
 
 const exists = <T>(data: unknown): data is NonNullable<T> => !!data

--- a/mobile/src/features/ReviewTx/common/hooks/useFormattedTxFromWalletTransaction.tsx
+++ b/mobile/src/features/ReviewTx/common/hooks/useFormattedTxFromWalletTransaction.tsx
@@ -426,6 +426,7 @@ const formatCertificatesFromWalletTransaction = (
   // We only have the certificate kind and limited fields, so we create minimal certificates
   // that can still be displayed in the UI (operations only need the type for most cases)
   return certificates
+    .filter((cert) => cert != null)
     .map((cert): FormattedCertificate | null => {
       const kind = cert.kind
       if (!kind) return null

--- a/mobile/src/features/Transactions/common/getOperationTypeKey.ts
+++ b/mobile/src/features/Transactions/common/getOperationTypeKey.ts
@@ -73,7 +73,7 @@ export const getOperationTypeKey = (
 
   // 2. Certificate logic
   const hasWithdrawals = withdrawals.length > 0
-  const certificateKinds = certificates.map((cert) => cert.kind as string)
+  const certificateKinds = certificates.filter((cert) => cert != null).map((cert) => cert.kind as string)
   const hasStakeRegistration =
     certificateKinds.includes(CertificateKind.StakeRegistration) ||
     certificateKinds.includes(CertificateKind.StakeRegistrationAndDelegation) ||

--- a/mobile/src/features/Transactions/common/getOperationTypeKey.ts
+++ b/mobile/src/features/Transactions/common/getOperationTypeKey.ts
@@ -30,7 +30,9 @@ export const getOperationTypeKey = (
     return null
   }
 
-  const certificates = walletTransaction.certificates || []
+  const certificates = (walletTransaction.certificates || []).filter(
+    (cert) => cert != null,
+  )
   const withdrawals = walletTransaction.withdrawals || []
 
   // 1. Check for withdrawal
@@ -73,7 +75,7 @@ export const getOperationTypeKey = (
 
   // 2. Certificate logic
   const hasWithdrawals = withdrawals.length > 0
-  const certificateKinds = certificates.filter((cert) => cert != null).map((cert) => cert.kind as string)
+  const certificateKinds = certificates.map((cert) => cert.kind as string)
   const hasStakeRegistration =
     certificateKinds.includes(CertificateKind.StakeRegistration) ||
     certificateKinds.includes(CertificateKind.StakeRegistrationAndDelegation) ||

--- a/mobile/src/features/Transactions/common/operationDisplay.ts
+++ b/mobile/src/features/Transactions/common/operationDisplay.ts
@@ -176,7 +176,7 @@ export const getOperationDisplayText = (
   const hasWithdrawals = withdrawals.length > 0
 
   // Extract certificate kinds as strings to handle all certificate types
-  const certificateKinds = certificates.map((cert) => cert.kind as string)
+  const certificateKinds = certificates.filter((cert) => cert != null).map((cert) => cert.kind as string)
   const hasStakeRegistration =
     certificateKinds.includes(CertificateKind.StakeRegistration) ||
     certificateKinds.includes(CertificateKind.StakeRegistrationAndDelegation) ||

--- a/mobile/src/features/Transactions/common/operationDisplay.ts
+++ b/mobile/src/features/Transactions/common/operationDisplay.ts
@@ -116,7 +116,9 @@ export const getOperationDisplayText = (
     return null
   }
 
-  const certificates = walletTransaction.certificates || []
+  const certificates = (walletTransaction.certificates || []).filter(
+    (cert) => cert != null,
+  )
   const withdrawals = walletTransaction.withdrawals || []
 
   // 1. Check for withdrawal (no certs, SELF direction, withdrawals present)
@@ -176,7 +178,7 @@ export const getOperationDisplayText = (
   const hasWithdrawals = withdrawals.length > 0
 
   // Extract certificate kinds as strings to handle all certificate types
-  const certificateKinds = certificates.filter((cert) => cert != null).map((cert) => cert.kind as string)
+  const certificateKinds = certificates.map((cert) => cert.kind as string)
   const hasStakeRegistration =
     certificateKinds.includes(CertificateKind.StakeRegistration) ||
     certificateKinds.includes(CertificateKind.StakeRegistrationAndDelegation) ||

--- a/mobile/src/features/Transactions/common/transactionSummary.ts
+++ b/mobile/src/features/Transactions/common/transactionSummary.ts
@@ -104,7 +104,7 @@ const calculateImplicitOutput = (
   let totalRewards = Quantities.zero
 
   for (const cert of tx.certificates) {
-    if (cert.kind !== CertificateKind.MoveInstantaneousRewardsCert) {
+    if (cert == null || cert.kind !== CertificateKind.MoveInstantaneousRewardsCert) {
       continue
     }
 

--- a/mobile/src/features/Transactions/common/transactionSummary.ts
+++ b/mobile/src/features/Transactions/common/transactionSummary.ts
@@ -104,7 +104,10 @@ const calculateImplicitOutput = (
   let totalRewards = Quantities.zero
 
   for (const cert of tx.certificates) {
-    if (cert == null || cert.kind !== CertificateKind.MoveInstantaneousRewardsCert) {
+    if (
+      cert == null ||
+      cert.kind !== CertificateKind.MoveInstantaneousRewardsCert
+    ) {
       continue
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "mobile": {
       "name": "yoroi-v2",
-      "version": "7.0.3",
+      "version": "7.0.4",
       "extraneous": true,
       "hasInstallScript": true,
       "dependencies": {


### PR DESCRIPTION
## Summary
- Fixes unhandled `cannot read property 'kind' of null` crash when viewing transaction history
- After failed storage migrations (introduced in 7.0.3 hardening), the transaction cache can contain corrupted certificate arrays with null entries
- Adds null guards at 4 consumer sites (`transactionSummary.ts`, `operationDisplay.ts`, `getOperationTypeKey.ts`, `useFormattedTxFromWalletTransaction.tsx`)
- Also filters null certificates at the storage deserialization layer in `transactionManager.ts` to prevent the issue at the source

## Test plan
- [ ] Open app with a wallet that has staking/governance transactions in history
- [ ] Verify transaction list renders without crash
- [ ] Verify transaction details screen renders certificates correctly
- [ ] Simulate corrupted storage by manually inserting a null entry in a transaction's certificates array in MMKV, verify no crash


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive filtering/guards around corrupted cached transaction data; behavior change is limited to ignoring `null` certificate entries and bumping app/package versions.
> 
> **Overview**
> Prevents crashes when rendering transaction history/details by **filtering out `null` entries in transaction `certificates`** both at persistence boundaries (`parseTx` in `transactionManager.ts`) and at key UI/logic consumers (formatted tx hook, operation display/type key, and MIR reward summary).
> 
> Also bumps the mobile app/package version from `7.0.3` to `7.0.4` (including lockfiles) for the release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fe41c329cd1928531eddd7a0c95d2e80158caa6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->