### PR TITLE
fix: Cexplorer links to DReps

### DIFF
--- a/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
@@ -28,7 +28,7 @@ export type Props = {
 
 const FIND_DREPS_LINKS: Record<Chain.SupportedNetworks, string> = {
   [Chain.Network.Preprod]: 'https://preprod.cexplorer.io/drep',
-  [Chain.Network.Mainnet]: 'https://beta.cexplorer.io/drep',
+  [Chain.Network.Mainnet]: 'https://cexplorer.io/drep',
 }
 
 export const HEIGHT_DEFAULT = 420


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes a single external URL used when opening the “Find DRep” link, with no impact to staking logic or data handling.
> 
> **Overview**
> Updates the mainnet “Find DRep” link in `EnterDrepIdModal` to point from `https://beta.cexplorer.io/drep` to the production `https://cexplorer.io/drep` (preprod link unchanged).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 634f879a31face914f2d58daa90c4bcd72492671. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->