### PR TITLE
chore: disable delegating voting power to Yoroi DRep

### DIFF
--- a/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
@@ -26,7 +26,6 @@ export type Props = {
     hash: string
     CIP105: boolean
   }) => void
-  initialDrepId?: string
 }
 
 const FIND_DREPS_LINKS: Record<Chain.SupportedNetworks, string> = {
@@ -35,10 +34,14 @@ const FIND_DREPS_LINKS: Record<Chain.SupportedNetworks, string> = {
 }
 
 const GOVTOOLS_URL = 'https://gov.tools/'
+const YOROI_DREP = [
+  'drep1ygr9tuapcanc3kpeyy4dc3vmrz9cfe5q7v9wj3x9j0ap3tswtre9j',
+  'drep1qe2l8gw8v7ydswfp9twytxcc3wzwdq8npt55f3vnlgv2u8sx3nt',
+]
 
-export const HEIGHT_DEFAULT = 420
-export const HEIGHT_PREFILLED = 340
-export const HEIGHT_INPUT_FOCUSED = 400
+export const HEIGHT_DEFAULT = 460
+export const HEIGHT_PREFILLED = 380
+export const HEIGHT_INPUT_FOCUSED = 440
 
 const shortenDRepId = (id: string) => {
   if (id.length > 20) {
@@ -47,7 +50,7 @@ const shortenDRepId = (id: string) => {
   return id
 }
 
-export const EnterDrepIdModal = ({onSubmit, initialDrepId}: Props) => {
+export const EnterDrepIdModal = ({onSubmit}: Props) => {
   const strings = useStrings()
   const {atoms: ta, palette: p} = useTheme()
   const {closeModal} = useModal()
@@ -56,24 +59,20 @@ export const EnterDrepIdModal = ({onSubmit, initialDrepId}: Props) => {
   const {addTabAndSetActive} = useBrowser()
   const walletNavigation = useWalletNavigation()
 
-  const [drepId, setDrepId] = React.useState(initialDrepId ?? '')
-
-  // Track if we've already set initialDrepId to prevent overriding user input
-  const hasSetInitialDrepIdRef = React.useRef(false)
+  const [drepId, setDrepId] = React.useState('')
+  const [isYoroiDrep, setIsYoroiDrep] = React.useState<boolean>(false)
 
   const {
     handleInputFocus: defaultHandleInputFocus,
     handleInputBlur: defaultHandleInputBlur,
   } = useModalKeyboardResize({
-    defaultHeight:
-      initialDrepId != null && initialDrepId.length > 0
-        ? HEIGHT_PREFILLED
-        : HEIGHT_DEFAULT,
+    defaultHeight: HEIGHT_DEFAULT,
     focusedHeight: HEIGHT_INPUT_FOCUSED,
   })
 
   const handleDrepIdChange = React.useCallback((text: string) => {
     setDrepId(text)
+    setIsYoroiDrep(YOROI_DREP.includes(text))
   }, [])
 
   const handleInputFocus = React.useCallback(() => {
@@ -123,18 +122,6 @@ export const EnterDrepIdModal = ({onSubmit, initialDrepId}: Props) => {
     refetchOnMount: 'always',
   })
 
-  // Update drepId when initialDrepId is provided (only once).
-  React.useEffect(() => {
-    if (
-      initialDrepId !== undefined &&
-      initialDrepId !== null &&
-      !hasSetInitialDrepIdRef.current
-    ) {
-      hasSetInitialDrepIdRef.current = true
-      handleDrepIdChange(initialDrepId)
-    }
-  }, [initialDrepId, handleDrepIdChange])
-
   // Ensure validation runs when resolvedDrepId changes (including when initialDrepId is set)
   // React Query should automatically run when enabled becomes true, but we ensure it runs
   React.useEffect(() => {
@@ -181,9 +168,11 @@ export const EnterDrepIdModal = ({onSubmit, initialDrepId}: Props) => {
     !isResolvingHandle &&
     drepInfo === null &&
     !handleResolutionError
-  const displayError = noDrepForHandle
-    ? 'This ADA handle does not have a DRep associated with it'
-    : handleResolutionError?.message || error?.message
+  const displayError = isYoroiDrep
+    ? strings.staking.delegationFailedYoroi
+    : noDrepForHandle
+      ? strings.staking.noDrepForHandle
+      : handleResolutionError?.message || error?.message
   const isLoading = isResolvingHandle || isFetching
 
   // Button is enabled when:
@@ -199,7 +188,8 @@ export const EnterDrepIdModal = ({onSubmit, initialDrepId}: Props) => {
     isLoading ||
     isNonNullable(error) ||
     !(isSuccess && isValidDRep === true) ||
-    (isHandle && drepInfo === null)
+    (isHandle && drepInfo === null) ||
+    isYoroiDrep
 
   const handleSubmit = () => {
     try {

--- a/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
@@ -26,6 +26,7 @@ export type Props = {
     hash: string
     CIP105: boolean
   }) => void
+  initialDrepId?: string
 }
 
 const FIND_DREPS_LINKS: Record<Chain.SupportedNetworks, string> = {
@@ -50,7 +51,7 @@ const shortenDRepId = (id: string) => {
   return id
 }
 
-export const EnterDrepIdModal = ({onSubmit}: Props) => {
+export const EnterDrepIdModal = ({onSubmit, initialDrepId}: Props) => {
   const strings = useStrings()
   const {atoms: ta, palette: p} = useTheme()
   const {closeModal} = useModal()
@@ -59,8 +60,13 @@ export const EnterDrepIdModal = ({onSubmit}: Props) => {
   const {addTabAndSetActive} = useBrowser()
   const walletNavigation = useWalletNavigation()
 
-  const [drepId, setDrepId] = React.useState('')
-  const [isYoroiDrep, setIsYoroiDrep] = React.useState<boolean>(false)
+  const [drepId, setDrepId] = React.useState(initialDrepId ?? '')
+  const [isYoroiDrep, setIsYoroiDrep] = React.useState<boolean>(
+    initialDrepId != null && YOROI_DREP.includes(initialDrepId),
+  )
+
+  // Track if we've already set initialDrepId to prevent overriding user input
+  const hasSetInitialDrepIdRef = React.useRef(false)
 
   const {
     handleInputFocus: defaultHandleInputFocus,
@@ -82,6 +88,18 @@ export const EnterDrepIdModal = ({onSubmit}: Props) => {
   const handleInputBlur = React.useCallback(() => {
     defaultHandleInputBlur()
   }, [defaultHandleInputBlur])
+
+  // Update drepId when initialDrepId is provided (only once).
+  React.useEffect(() => {
+    if (
+      initialDrepId !== undefined &&
+      initialDrepId !== null &&
+      !hasSetInitialDrepIdRef.current
+    ) {
+      hasSetInitialDrepIdRef.current = true
+      handleDrepIdChange(initialDrepId)
+    }
+  }, [initialDrepId, handleDrepIdChange])
 
   // Trim whitespace from input, ensure drepId is always a string
   const trimmedDrepId = (drepId ?? '').trim()

--- a/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
@@ -38,6 +38,7 @@ const GOVTOOLS_URL = 'https://gov.tools/'
 const YOROI_DREP = [
   'drep1ygr9tuapcanc3kpeyy4dc3vmrz9cfe5q7v9wj3x9j0ap3tswtre9j',
   'drep1qe2l8gw8v7ydswfp9twytxcc3wzwdq8npt55f3vnlgv2u8sx3nt',
+  '220655f3a1c76788d839212adc459b188b84e680f30ae944c593fa18ae',
 ]
 
 export const HEIGHT_DEFAULT = 460

--- a/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
@@ -62,7 +62,7 @@ export const EnterDrepIdModal = ({onSubmit, initialDrepId}: Props) => {
 
   const [drepId, setDrepId] = React.useState(initialDrepId ?? '')
   const [isYoroiDrep, setIsYoroiDrep] = React.useState<boolean>(
-    initialDrepId != null && YOROI_DREP.includes(initialDrepId),
+    initialDrepId != null && YOROI_DREP.includes(initialDrepId.trim()),
   )
 
   // Track if we've already set initialDrepId to prevent overriding user input
@@ -78,7 +78,7 @@ export const EnterDrepIdModal = ({onSubmit, initialDrepId}: Props) => {
 
   const handleDrepIdChange = React.useCallback((text: string) => {
     setDrepId(text)
-    setIsYoroiDrep(YOROI_DREP.includes(text))
+    setIsYoroiDrep(YOROI_DREP.includes(text.trim()))
   }, [])
 
   const handleInputFocus = React.useCallback(() => {

--- a/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/EnterDrepIdModal/EnterDrepIdModal.tsx
@@ -1,7 +1,7 @@
 import {CardanoMobile} from '@yoroi/cardano-wallet'
 import {isNonNullable} from '@yoroi/common'
 import {isAdaHandleDomain, useResolverDRepId} from '@yoroi/resolver'
-import {parseDrepId, useIsValidDRepID} from '@yoroi/staking'
+import {getYoroiDrepIdHex, parseDrepId, useIsValidDRepID} from '@yoroi/staking'
 import {atoms as a, useTheme} from '@yoroi/theme'
 import {Chain} from '@yoroi/types'
 import {useSelectedWallet} from '@yoroi/wallet-manager'
@@ -222,6 +222,11 @@ export const EnterDrepIdModal = ({onSubmit, initialDrepId}: Props) => {
         const parsed = parseDrepId(resolvedDrepId, CardanoMobile)
         hash = parsed.hash
         type = parsed.type
+      }
+
+      if (hash === getYoroiDrepIdHex(network)) {
+        setIsYoroiDrep(true)
+        return
       }
 
       // CIP105 flag indicates if user entered deprecated CIP-105 format (58-char hex starting with 22/23)

--- a/mobile/src/kernel/i18n/locales/en-US.json
+++ b/mobile/src/kernel/i18n/locales/en-US.json
@@ -1240,6 +1240,8 @@
   "components.staking.poweredBy": "Powered by",
   "components.staking.poolROA": "Pool ROA",
   "components.staking.poolSaturation": "Pool Saturation",
+  "components.staking.delegationFailedYoroi": "Drep delegation to Yoroi is currently paused. Please select another Drep ID.",
+  "components.staking.noDrepForHandle": "This ADA handle does not have a DRep associated with it",
   "components.governance.resolvedDrepId": "Resolved DRep ID:",
   "nft.navigation.title": "Gallery",
   "scan.cameraPermissionDenied.help": "It looks the app doesn't have access to your device camera, if you are no longer asked to grant camera permission, please go to your device settings, search for Yoroi and allow access to the camera",

--- a/mobile/src/kernel/i18n/locales/en-US.json
+++ b/mobile/src/kernel/i18n/locales/en-US.json
@@ -190,7 +190,7 @@
   "components.governance.txFees": "Transaction fee",
   "components.governance.withdrawWarningButton": "Participate on governance",
   "components.governance.withdrawWarningDescription": "Participating in governance is required to withdraw rewards on Cardano. First, delegate your ADA in the Governance Center. Once your delegation is confirmed, you can then withdraw your rewards.",
-  "components.governance.withdrawWarningTitle": "Governance is required to withdraw",
+  "components.governance.withdrawWarningTitle": "Keep your rewards accessible",
   "components.governance.delegateAndWithdraw": "Delegate and withdraw",
   "components.governance.goToGovernanceCenter": "Go to governance center",
   "components.governance.workingOnHardwareWalletSupport": "We are currently working on integrating hardware wallet support for Governance",

--- a/mobile/src/kernel/i18n/messages/staking.ts
+++ b/mobile/src/kernel/i18n/messages/staking.ts
@@ -258,6 +258,14 @@ export const stakingMessages = defineMessages({
     id: 'components.staking.cardanoCardAnnouncementTitle',
     defaultMessage: '!!!Physical Cardano Card Now Available',
   },
+  delegationFailedYoroi: {
+    id: 'components.staking.delegationFailedYoroi',
+    defaultMessage: '!!!Delegation Failed Yoroi',
+  },
+  noDrepForHandle: {
+    id: 'components.staking.noDrepForHandle',
+    defaultMessage: '!!!No DRep For Handle',
+  },
   cardanoCardAnnouncementDescription: {
     id: 'components.staking.cardanoCardAnnouncementDescription',
     defaultMessage:

--- a/mobile/src/kernel/i18n/useStrings.ts
+++ b/mobile/src/kernel/i18n/useStrings.ts
@@ -1593,6 +1593,8 @@ export const useStrings = () => {
         delegationSuccess: f(stakingMessages.delegationSuccess),
         delegationFailed: f(stakingMessages.delegationFailed),
         delegationFailedMessage: f(stakingMessages.delegationFailed),
+        delegationFailedYoroi: f(stakingMessages.delegationFailedYoroi),
+        noDrepForHandle: f(stakingMessages.noDrepForHandle),
         retry: f(stakingMessages.retry),
         poolWarningCensoring: f(stakingMessages.warning),
         poolWarningMultiBlock: f(stakingMessages.warning),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI/flow change that prevents submitting a specific DRep delegation and adjusts user-facing copy; no wallet security, signing, or network logic is modified beyond the client-side guard.
> 
> **Overview**
> Disables delegating voting power to the **Yoroi DRep** from the `EnterDrepIdModal` by detecting known Yoroi DRep identifiers (including when prefilled) and blocking submission with a localized error message.
> 
> Updates i18n to add new staking error strings (`delegationFailedYoroi`, `noDrepForHandle`) and tweaks the governance rewards-withdrawal warning title copy; modal height constants were increased and keyboard-resize now uses a fixed default height.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c53ec92dde68fd0c7532ab6ada343e5b9ffba613. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->