### PR TITLE
feat: Add separate governance warning modal for undelegation

### DIFF
--- a/mobile/src/features/Dashboard/ui/screens/DashboardScreen.tsx
+++ b/mobile/src/features/Dashboard/ui/screens/DashboardScreen.tsx
@@ -23,6 +23,7 @@ import {
 import {useBalances} from '~/features/Portfolio/common/hooks/useBalances'
 import {StakeRewardsWithdrawalOperation} from '~/features/ReviewTx/common/operations'
 import {useGovernanceParticipation} from '~/features/Staking/Governance/common/helpers'
+import {UndelegateGovernanceWarningModal} from '~/features/Staking/Governance/useCases/UndelegateGovernanceWarningModal/UndelegateGovernanceWarningModal'
 import {WithdrawGovernanceWarningModal} from '~/features/Staking/Governance/useCases/WithdrawGovernanceWarningModal/WithdrawGovernanceWarningModal'
 import {usePrefetchPoolList} from '~/features/Staking/Staking/PoolList/usePoolList'
 import {PoolTransitionNotice} from '~/features/Staking/Staking/PoolTransition/PoolTransitionNotice'
@@ -113,10 +114,13 @@ export const DashboardScreen = () => {
         return
       }
       if (!isParticipating) {
+        const WarningModal = shouldDeregister
+          ? UndelegateGovernanceWarningModal
+          : WithdrawGovernanceWarningModal
         openModal({
           title: strings.staking.governanceRequiredTitle,
-          content: React.createElement(WithdrawGovernanceWarningModal.Content),
-          footer: React.createElement(WithdrawGovernanceWarningModal.Footer),
+          content: React.createElement(WarningModal.Content),
+          footer: React.createElement(WarningModal.Footer),
           height: screenHeight * 0.7,
         })
         return

--- a/mobile/src/features/Staking/Governance/useCases/UndelegateGovernanceWarningModal/UndelegateGovernanceWarningModal.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/UndelegateGovernanceWarningModal/UndelegateGovernanceWarningModal.tsx
@@ -10,9 +10,7 @@ import GovernanceIllustration from '~/ui/GovernanceIllustration/GovernanceIllust
 import {useModal} from '~/ui/Modal/context/ModalContext'
 import {Modal} from '~/ui/Modal/ui/screens/Modal/Modal'
 
-export const withdrawGovernanceWarningModalHeight = 1200
-
-const WithdrawGovernanceWarningModalContent = () => {
+const UndelegateGovernanceWarningModalContent = () => {
   const strings = useStrings()
   const {atoms: ta} = useTheme()
 
@@ -30,7 +28,7 @@ const WithdrawGovernanceWarningModalContent = () => {
           a.pb_sm,
         ]}
       >
-        {strings.staking.withdrawWarningTitle}
+        {strings.staking.undelegateWarningTitle}
       </Text>
       <Text
         style={[
@@ -40,13 +38,13 @@ const WithdrawGovernanceWarningModalContent = () => {
           ta.text_gray_medium,
         ]}
       >
-        {strings.staking.withdrawWarningDescription}
+        {strings.staking.undelegateWarningDescription}
       </Text>
     </Modal.Content>
   )
 }
 
-const WithdrawGovernanceWarningModalFooter = () => {
+const UndelegateGovernanceWarningModalFooter = () => {
   const walletNavigateTo = useWalletNavigation()
   const strings = useStrings()
   const {closeModal} = useModal()
@@ -67,7 +65,7 @@ const WithdrawGovernanceWarningModalFooter = () => {
   )
 }
 
-export const WithdrawGovernanceWarningModal = {
-  Content: WithdrawGovernanceWarningModalContent,
-  Footer: WithdrawGovernanceWarningModalFooter,
+export const UndelegateGovernanceWarningModal = {
+  Content: UndelegateGovernanceWarningModalContent,
+  Footer: UndelegateGovernanceWarningModalFooter,
 }

--- a/mobile/src/kernel/i18n/locales/en-US.json
+++ b/mobile/src/kernel/i18n/locales/en-US.json
@@ -191,6 +191,8 @@
   "components.governance.withdrawWarningButton": "Participate on governance",
   "components.governance.withdrawWarningDescription": "Participating in governance is required to withdraw rewards on Cardano. First, delegate your ADA in the Governance Center. Once your delegation is confirmed, you can then withdraw your rewards.",
   "components.governance.withdrawWarningTitle": "Keep your rewards accessible",
+  "components.governance.undelegateWarningTitle": "One step left to make the change",
+  "components.governance.undelegateWarningDescription": "Undelegating causes any pending staking rewards to be withdrawn and participating in governance is required to withdraw rewards on Cardano. First, delegate your ADA in the governance center. Once your delegation is confirmed, you will then be able to undelegate.",
   "components.governance.delegateAndWithdraw": "Delegate and withdraw",
   "components.governance.goToGovernanceCenter": "Go to governance center",
   "components.governance.workingOnHardwareWalletSupport": "We are currently working on integrating hardware wallet support for Governance",

--- a/mobile/src/kernel/i18n/messages/staking.ts
+++ b/mobile/src/kernel/i18n/messages/staking.ts
@@ -435,6 +435,14 @@ export const stakingMessages = defineMessages({
     id: 'components.governance.withdrawWarningDescription',
     defaultMessage: '!!!Withdraw Warning Description',
   },
+  undelegateWarningTitle: {
+    id: 'components.governance.undelegateWarningTitle',
+    defaultMessage: '!!!One step left to make the change',
+  },
+  undelegateWarningDescription: {
+    id: 'components.governance.undelegateWarningDescription',
+    defaultMessage: '!!!Undelegate Warning Description',
+  },
   withdrawWarningButton: {
     id: 'components.governance.withdrawWarningButton',
     defaultMessage: '!!!Withdraw Warning Button',

--- a/mobile/src/kernel/i18n/useStrings.ts
+++ b/mobile/src/kernel/i18n/useStrings.ts
@@ -1525,6 +1525,10 @@ export const useStrings = () => {
         withdrawWarningDescription: f(
           stakingMessages.withdrawWarningDescription,
         ),
+        undelegateWarningTitle: f(stakingMessages.undelegateWarningTitle),
+        undelegateWarningDescription: f(
+          stakingMessages.undelegateWarningDescription,
+        ),
         withdrawWarningButton: f(stakingMessages.withdrawWarningButton),
         delegateAndWithdraw: f(stakingMessages.delegateAndWithdraw),
         goToGovernanceCenter: f(stakingMessages.goToGovernanceCenter),


### PR DESCRIPTION
## Summary
- Add `UndelegateGovernanceWarningModal` with specific messaging for undelegation flow
- Update `DashboardScreen` to show different modal based on action:
  - **Withdraw Rewards**: Shows "Keep your rewards accessible" message
  - **Undelegate**: Shows "One step left to make the change" message (matching extension design)
- Add i18n strings for undelegation warning
- Add consistent button padding to both governance warning modals

## Test plan
- [ ] Trigger withdraw rewards without governance participation → should show "Keep your rewards accessible" modal
- [ ] Trigger undelegate without governance participation → should show "One step left to make the change" modal
- [ ] Verify both modals navigate to Governance Center on button tap
- [ ] Verify button padding is consistent on both modals

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/i18n change that only affects which warning modal is shown before withdraw/undelegate when governance participation is missing; no transaction building logic is modified.
> 
> **Overview**
> Adds a new `UndelegateGovernanceWarningModal` with dedicated copy for the undelegation (deregister) flow, and updates `DashboardScreen` to choose between the undelegation vs withdrawal governance warning based on `shouldDeregister`.
> 
> Extends staking i18n with `undelegateWarningTitle`/`undelegateWarningDescription`, and aligns both governance warning modals’ footer button padding for consistent layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39a2e6cd652c37b1d44cd4f3c5608f9805f2a9bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->