### PR TITLE
chore: merge develop to preview

### DIFF
--- a/mobile/src/features/Dashboard/ui/screens/DashboardScreen.tsx
+++ b/mobile/src/features/Dashboard/ui/screens/DashboardScreen.tsx
@@ -23,6 +23,7 @@ import {
 import {useBalances} from '~/features/Portfolio/common/hooks/useBalances'
 import {StakeRewardsWithdrawalOperation} from '~/features/ReviewTx/common/operations'
 import {useGovernanceParticipation} from '~/features/Staking/Governance/common/helpers'
+import {UndelegateGovernanceWarningModal} from '~/features/Staking/Governance/useCases/UndelegateGovernanceWarningModal/UndelegateGovernanceWarningModal'
 import {WithdrawGovernanceWarningModal} from '~/features/Staking/Governance/useCases/WithdrawGovernanceWarningModal/WithdrawGovernanceWarningModal'
 import {usePrefetchPoolList} from '~/features/Staking/Staking/PoolList/usePoolList'
 import {PoolTransitionNotice} from '~/features/Staking/Staking/PoolTransition/PoolTransitionNotice'
@@ -113,10 +114,13 @@ export const DashboardScreen = () => {
         return
       }
       if (!isParticipating) {
+        const WarningModal = shouldDeregister
+          ? UndelegateGovernanceWarningModal
+          : WithdrawGovernanceWarningModal
         openModal({
           title: strings.staking.governanceRequiredTitle,
-          content: React.createElement(WithdrawGovernanceWarningModal.Content),
-          footer: React.createElement(WithdrawGovernanceWarningModal.Footer),
+          content: React.createElement(WarningModal.Content),
+          footer: React.createElement(WarningModal.Footer),
           height: screenHeight * 0.7,
         })
         return

--- a/mobile/src/features/Staking/Governance/useCases/UndelegateGovernanceWarningModal/UndelegateGovernanceWarningModal.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/UndelegateGovernanceWarningModal/UndelegateGovernanceWarningModal.tsx
@@ -10,9 +10,7 @@ import GovernanceIllustration from '~/ui/GovernanceIllustration/GovernanceIllust
 import {useModal} from '~/ui/Modal/context/ModalContext'
 import {Modal} from '~/ui/Modal/ui/screens/Modal/Modal'
 
-export const withdrawGovernanceWarningModalHeight = 1200
-
-const WithdrawGovernanceWarningModalContent = () => {
+const UndelegateGovernanceWarningModalContent = () => {
   const strings = useStrings()
   const {atoms: ta} = useTheme()
 
@@ -30,7 +28,7 @@ const WithdrawGovernanceWarningModalContent = () => {
           a.pb_sm,
         ]}
       >
-        {strings.staking.withdrawWarningTitle}
+        {strings.staking.undelegateWarningTitle}
       </Text>
       <Text
         style={[
@@ -40,13 +38,13 @@ const WithdrawGovernanceWarningModalContent = () => {
           ta.text_gray_medium,
         ]}
       >
-        {strings.staking.withdrawWarningDescription}
+        {strings.staking.undelegateWarningDescription}
       </Text>
     </Modal.Content>
   )
 }
 
-const WithdrawGovernanceWarningModalFooter = () => {
+const UndelegateGovernanceWarningModalFooter = () => {
   const walletNavigateTo = useWalletNavigation()
   const strings = useStrings()
   const {closeModal} = useModal()
@@ -67,7 +65,7 @@ const WithdrawGovernanceWarningModalFooter = () => {
   )
 }
 
-export const WithdrawGovernanceWarningModal = {
-  Content: WithdrawGovernanceWarningModalContent,
-  Footer: WithdrawGovernanceWarningModalFooter,
+export const UndelegateGovernanceWarningModal = {
+  Content: UndelegateGovernanceWarningModalContent,
+  Footer: UndelegateGovernanceWarningModalFooter,
 }

--- a/mobile/src/kernel/i18n/locales/en-US.json
+++ b/mobile/src/kernel/i18n/locales/en-US.json
@@ -191,6 +191,8 @@
   "components.governance.withdrawWarningButton": "Participate on governance",
   "components.governance.withdrawWarningDescription": "Participating in governance is required to withdraw rewards on Cardano. First, delegate your ADA in the Governance Center. Once your delegation is confirmed, you can then withdraw your rewards.",
   "components.governance.withdrawWarningTitle": "Keep your rewards accessible",
+  "components.governance.undelegateWarningTitle": "One step left to make the change",
+  "components.governance.undelegateWarningDescription": "Undelegating causes any pending staking rewards to be withdrawn and participating in governance is required to withdraw rewards on Cardano. First, delegate your ADA in the governance center. Once your delegation is confirmed, you will then be able to undelegate.",
   "components.governance.delegateAndWithdraw": "Delegate and withdraw",
   "components.governance.goToGovernanceCenter": "Go to governance center",
   "components.governance.workingOnHardwareWalletSupport": "We are currently working on integrating hardware wallet support for Governance",

--- a/mobile/src/kernel/i18n/messages/staking.ts
+++ b/mobile/src/kernel/i18n/messages/staking.ts
@@ -435,6 +435,14 @@ export const stakingMessages = defineMessages({
     id: 'components.governance.withdrawWarningDescription',
     defaultMessage: '!!!Withdraw Warning Description',
   },
+  undelegateWarningTitle: {
+    id: 'components.governance.undelegateWarningTitle',
+    defaultMessage: '!!!One step left to make the change',
+  },
+  undelegateWarningDescription: {
+    id: 'components.governance.undelegateWarningDescription',
+    defaultMessage: '!!!Undelegate Warning Description',
+  },
   withdrawWarningButton: {
     id: 'components.governance.withdrawWarningButton',
     defaultMessage: '!!!Withdraw Warning Button',

--- a/mobile/src/kernel/i18n/useStrings.ts
+++ b/mobile/src/kernel/i18n/useStrings.ts
@@ -1525,6 +1525,10 @@ export const useStrings = () => {
         withdrawWarningDescription: f(
           stakingMessages.withdrawWarningDescription,
         ),
+        undelegateWarningTitle: f(stakingMessages.undelegateWarningTitle),
+        undelegateWarningDescription: f(
+          stakingMessages.undelegateWarningDescription,
+        ),
         withdrawWarningButton: f(stakingMessages.withdrawWarningButton),
         delegateAndWithdraw: f(stakingMessages.delegateAndWithdraw),
         goToGovernanceCenter: f(stakingMessages.goToGovernanceCenter),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI/UX change: it only alters which informational modal is shown (and adds copy) when users attempt to withdraw/undelegate without governance participation; transaction creation logic remains unchanged.
> 
> **Overview**
> Updates the Dashboard withdraw/undelegate CTA gating so that **users not participating in governance see an action-specific warning**: withdrawals keep using `WithdrawGovernanceWarningModal`, while undelegation now shows the new `UndelegateGovernanceWarningModal`.
> 
> Adds the new undelegation warning modal UI and strings (`undelegateWarningTitle`/`undelegateWarningDescription`), and slightly adjusts modal footer padding styling for consistency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9bc124152b01fe9311c7a75a7fea10c8da677990. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->