### PR TITLE
fix(mobile): format DRep delegator count with en-US locale

### DIFF
--- a/mobile/src/features/Staking/Governance/useCases/DrepList/DrepListScreen.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/DrepList/DrepListScreen.tsx
@@ -359,7 +359,7 @@ const DRepCard = ({
       {/* Stats row values */}
       <View style={[a.flex_row]}>
         <Text style={[a.body_2_md_regular, {color: p.text_gray_low, flex: 1}]}>
-          {drep.delegatorCount.toLocaleString()}
+          {drep.delegatorCount.toLocaleString('en-US')}
         </Text>
 
         <Text style={[a.body_2_md_regular, {color: p.text_gray_low, flex: 1}]}>


### PR DESCRIPTION
Use toLocaleString('en-US') so delegator counts always show digits and match other numeric fields 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that just forces a consistent number formatting locale for DRep delegator counts.
> 
> **Overview**
> DRep delegator counts in `DrepListScreen` are now formatted with `toLocaleString('en-US')` instead of the device default locale, ensuring consistent digit/grouping display across devices.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d085df32311cd1e547e6903039018af2e7315fb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->