### PR TITLE
chore: merge preview from develop

### DIFF
--- a/mobile/src/features/Staking/Governance/useCases/DrepList/DrepListScreen.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/DrepList/DrepListScreen.tsx
@@ -359,7 +359,7 @@ const DRepCard = ({
       {/* Stats row values */}
       <View style={[a.flex_row]}>
         <Text style={[a.body_2_md_regular, {color: p.text_gray_low, flex: 1}]}>
-          {drep.delegatorCount.toLocaleString()}
+          {drep.delegatorCount.toLocaleString('en-US')}
         </Text>
 
         <Text style={[a.body_2_md_regular, {color: p.text_gray_low, flex: 1}]}>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only change that just forces a specific locale for number formatting; no business logic or data flow changes.
> 
> **Overview**
> Forces the DRep list’s delegator count display to use `toLocaleString('en-US')` instead of the device default, making thousands separators consistent across locales.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98b8134c4a00cc45d758970219648ef1bf288c83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->