### PR TITLE
fix(mobile): update DRep detail screen UI

### DIFF
--- a/mobile/src/features/Staking/Governance/useCases/DrepDetail/DrepDetailScreen.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/DrepDetail/DrepDetailScreen.tsx
@@ -89,7 +89,7 @@ export const DrepDetailScreen = () => {
     <View style={[a.flex_1, ta.bg_color_max]}>
       <ScrollView
         style={[a.flex_1]}
-        contentContainerStyle={[a.px_lg, a.pt_sm, {paddingBottom: 120}]}
+        contentContainerStyle={[a.px_lg, a.pt_lg, {paddingBottom: 120}]}
       >
         {/* Connection details */}
         <IdRow label="DRep ID" value={params.bech32Id} />
@@ -278,7 +278,7 @@ const UnverifiedSection = () => {
           Unverified DRep metadata
         </Text>
 
-        <Icon.Info size={24} color={p.text_gray_medium} />
+        <Icon.Warning size={24} color={p.text_gray_medium} />
       </View>
 
       <Text style={[a.body_1_lg_regular, {color: p.text_gray_medium}]}>


### PR DESCRIPTION
## Summary
- Increase top padding for better spacing between header and content
- Change info icon to warning triangle for unverified metadata section

## Test plan
- [ ] Verify increased spacing between header and DRep ID row
- [ ] Verify warning triangle icon appears for unverified DRep metadata

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only adjustments that do not affect delegation logic or data handling.
> 
> **Overview**
> Improves the `DrepDetailScreen` layout by increasing the top padding of the scroll content for better spacing under the header.
> 
> Updates the unverified metadata callout to use `Icon.Warning` instead of `Icon.Info` to better signal risk to the user.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e67742e3976406170bfddae6929fcb3e6217fa7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->