### PR TITLE
chore: merge develop into preview

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoroi-v2",
-  "version": "7.0.5",
+  "version": "7.0.8",
   "main": "index.ts",
   "scripts": {
     "postinstall": "patch-package",

--- a/mobile/packages/explorers/explorer-manager.test.ts
+++ b/mobile/packages/explorers/explorer-manager.test.ts
@@ -12,6 +12,7 @@ describe('explorerManager', () => {
           tx: expect.any(Function),
           pool: expect.any(Function),
           stake: expect.any(Function),
+          drep: expect.any(Function),
         },
         [Explorers.Explorer.Cexplorer]: {
           token: expect.any(Function),
@@ -19,6 +20,7 @@ describe('explorerManager', () => {
           tx: expect.any(Function),
           pool: expect.any(Function),
           stake: expect.any(Function),
+          drep: expect.any(Function),
         },
       },
       [Chain.Network.Preprod]: {
@@ -28,6 +30,7 @@ describe('explorerManager', () => {
           tx: expect.any(Function),
           pool: expect.any(Function),
           stake: expect.any(Function),
+          drep: expect.any(Function),
         },
         [Explorers.Explorer.Cexplorer]: {
           token: expect.any(Function),
@@ -35,6 +38,7 @@ describe('explorerManager', () => {
           tx: expect.any(Function),
           pool: expect.any(Function),
           stake: expect.any(Function),
+          drep: expect.any(Function),
         },
       },
     })
@@ -57,6 +61,9 @@ describe('explorerManager', () => {
     expect(
       mainnetExplorer[Explorers.Explorer.Cardanoscan].stake('stakeAddress'),
     ).toBe('https://cardanoscan.io/stakeKey/stakeAddress')
+    expect(mainnetExplorer[Explorers.Explorer.Cardanoscan].drep('drepId')).toBe(
+      'https://cardanoscan.io/dRep/drepId',
+    )
 
     expect(
       mainnetExplorer[Explorers.Explorer.Cexplorer].token('fingerprint'),
@@ -73,6 +80,9 @@ describe('explorerManager', () => {
     expect(
       mainnetExplorer[Explorers.Explorer.Cexplorer].stake('stakeAddress'),
     ).toBe('https://cexplorer.io/stake/stakeAddress')
+    expect(mainnetExplorer[Explorers.Explorer.Cexplorer].drep('drepId')).toBe(
+      'https://cexplorer.io/drep/drepId',
+    )
   })
 
   it('should generate the correct URLs for Preprod', () => {
@@ -92,6 +102,9 @@ describe('explorerManager', () => {
     expect(
       preprodExplorer[Explorers.Explorer.Cardanoscan].stake('stakeAddress'),
     ).toBe('https://preprod.cardanoscan.io/stakeKey/stakeAddress')
+    expect(preprodExplorer[Explorers.Explorer.Cardanoscan].drep('drepId')).toBe(
+      'https://preprod.cardanoscan.io/dRep/drepId',
+    )
 
     expect(
       preprodExplorer[Explorers.Explorer.Cexplorer].token('fingerprint'),
@@ -108,5 +121,8 @@ describe('explorerManager', () => {
     expect(
       preprodExplorer[Explorers.Explorer.Cexplorer].stake('stakeAddress'),
     ).toBe('https://preprod.cexplorer.io/stake/stakeAddress')
+    expect(preprodExplorer[Explorers.Explorer.Cexplorer].drep('drepId')).toBe(
+      'https://preprod.cexplorer.io/drep/drepId',
+    )
   })
 })

--- a/mobile/packages/explorers/explorer-manager.ts
+++ b/mobile/packages/explorers/explorer-manager.ts
@@ -17,6 +17,7 @@ export const explorerManager: Readonly<
       pool: (poolId: string) => `https://cardanoscan.io/pool/${poolId}`,
       stake: (stakeAddress: string) =>
         `https://cardanoscan.io/stakeKey/${stakeAddress}`,
+      drep: (drepId: string) => `https://cardanoscan.io/dRep/${drepId}`,
     },
     [Explorers.Explorer.Cexplorer]: {
       token: (fingerprint: string) =>
@@ -26,6 +27,7 @@ export const explorerManager: Readonly<
       pool: (poolId: string) => `https://cexplorer.io/pool/${poolId}`,
       stake: (stakeAddress: string) =>
         `https://cexplorer.io/stake/${stakeAddress}`,
+      drep: (drepId: string) => `https://cexplorer.io/drep/${drepId}`,
     },
   },
   [Chain.Network.Preprod]: {
@@ -39,6 +41,7 @@ export const explorerManager: Readonly<
       pool: (poolId: string) => `https://preprod.cardanoscan.io/pool/${poolId}`,
       stake: (stakeAddress: string) =>
         `https://preprod.cardanoscan.io/stakeKey/${stakeAddress}`,
+      drep: (drepId: string) => `https://preprod.cardanoscan.io/dRep/${drepId}`,
     },
     [Explorers.Explorer.Cexplorer]: {
       token: (fingerprint: string) =>
@@ -49,6 +52,7 @@ export const explorerManager: Readonly<
       pool: (poolId: string) => `https://preprod.cexplorer.io/pool/${poolId}`,
       stake: (stakeAddress: string) =>
         `https://preprod.cexplorer.io/stake/${stakeAddress}`,
+      drep: (drepId: string) => `https://preprod.cexplorer.io/drep/${drepId}`,
     },
   },
 })

--- a/mobile/packages/types/explorers/manager.ts
+++ b/mobile/packages/types/explorers/manager.ts
@@ -4,4 +4,5 @@ export type ExplorersManager = Readonly<{
   tx: (txHash: string) => string
   pool: (poolId: string) => string
   stake: (stakeAddress: string) => string
+  drep: (drepId: string) => string
 }>

--- a/mobile/src/features/Staking/Governance/useCases/DrepDetail/DrepDetailScreen.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/DrepDetail/DrepDetailScreen.tsx
@@ -89,7 +89,7 @@ export const DrepDetailScreen = () => {
     <View style={[a.flex_1, ta.bg_color_max]}>
       <ScrollView
         style={[a.flex_1]}
-        contentContainerStyle={[a.px_lg, a.pt_sm, {paddingBottom: 120}]}
+        contentContainerStyle={[a.px_lg, a.pt_lg, {paddingBottom: 120}]}
       >
         {/* Connection details */}
         <IdRow label="DRep ID" value={params.bech32Id} />
@@ -278,7 +278,7 @@ const UnverifiedSection = () => {
           Unverified DRep metadata
         </Text>
 
-        <Icon.Info size={24} color={p.text_gray_medium} />
+        <Icon.Warning size={24} color={p.text_gray_medium} />
       </View>
 
       <Text style={[a.body_1_lg_regular, {color: p.text_gray_medium}]}>

--- a/mobile/src/features/Staking/Governance/useCases/DrepDetail/DrepDetailScreen.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/DrepDetail/DrepDetailScreen.tsx
@@ -1,11 +1,15 @@
-import {useDelegationCertificate, useGovernance} from '@yoroi/staking'
+import {
+  useDelegationCertificate,
+  useGovernance,
+  useStakingKeyState,
+} from '@yoroi/staking'
 import {atoms as a, useTheme} from '@yoroi/theme'
 import {NotEnoughMoneyToSendError} from '@yoroi/tx'
 import {useSelectedWallet} from '@yoroi/wallet-manager'
 
 import {RouteProp, useRoute} from '@react-navigation/native'
 import * as React from 'react'
-import {Image, Linking, Pressable, ScrollView, Text, View} from 'react-native'
+import {Linking, Pressable, ScrollView, Text, View} from 'react-native'
 
 import {useCopy} from '~/features/Copy/context/CopyProvider'
 import {formatDrepHashToCIP105Format} from '~/features/Staking/Governance/common/drep'
@@ -15,6 +19,7 @@ import {
 } from '~/features/Staking/Governance/common/navigation'
 import {useGovernanceVoteFlow} from '~/features/Staking/Governance/common/useGovernanceVoteFlow'
 import {useStakingInfo} from '~/features/Staking/hooks/useStakingInfo'
+import {useStakingKey} from '~/features/Staking/hooks/useStakingKey'
 import {Button} from '~/ui/Button/Button'
 import {Icon} from '~/ui/Icon'
 import {Space} from '~/ui/Space/Space'
@@ -27,6 +32,14 @@ export const DrepDetailScreen = () => {
   const {wallet, meta} = useSelectedWallet()
   const {manager} = useGovernance()
   const navigateTo = useNavigateTo()
+
+  const stakingKeyHash = useStakingKey(wallet)
+  const {data: stakingStatus} = useStakingKeyState(stakingKeyHash)
+  const currentDelegatedId =
+    stakingStatus?.drepDelegation?.action === 'drep'
+      ? stakingStatus.drepDelegation.hash
+      : null
+  const isCurrentlyDelegated = params.hexId === currentDelegatedId
 
   const stakingInfo = useStakingInfo(wallet)
   const needsToRegisterStakingKey =
@@ -78,22 +91,6 @@ export const DrepDetailScreen = () => {
         style={[a.flex_1]}
         contentContainerStyle={[a.px_lg, a.pt_sm, {paddingBottom: 120}]}
       >
-        {/* Avatar + Name header */}
-        <View
-          style={[a.flex_row, a.align_center, a.gap_sm, {marginBottom: 16}]}
-        >
-          <AvatarImage imageUrl={params.imageUrl} />
-
-          <View style={[a.flex_1]}>
-            <Text
-              style={[a.heading_3_medium, {color: p.text_gray_medium}]}
-              numberOfLines={2}
-            >
-              {params.name}
-            </Text>
-          </View>
-        </View>
-
         {/* Connection details */}
         <IdRow label="DRep ID" value={params.bech32Id} />
         <Space.Height.sm />
@@ -138,7 +135,7 @@ export const DrepDetailScreen = () => {
         <Button
           title="DELEGATE"
           onPress={handleDelegate}
-          disabled={isPending}
+          disabled={isPending || isCurrentlyDelegated}
         />
       </View>
     </View>
@@ -146,38 +143,6 @@ export const DrepDetailScreen = () => {
 }
 
 // ── Sub-components ────────────────────────────────────────────────────────────
-
-const AvatarImage = ({imageUrl}: {imageUrl: string}) => {
-  const {palette: p} = useTheme()
-  const [imageError, setImageError] = React.useState(false)
-  const showImage = Boolean(imageUrl) && !imageError
-
-  return (
-    <View
-      style={[
-        a.align_center,
-        a.justify_center,
-        a.rounded_full,
-        {
-          width: 56,
-          height: 56,
-          backgroundColor: p.bg_color_min,
-          overflow: 'hidden',
-        },
-      ]}
-    >
-      {showImage ? (
-        <Image
-          source={{uri: imageUrl}}
-          style={{width: 56, height: 56, borderRadius: 28}}
-          onError={() => setImageError(true)}
-        />
-      ) : (
-        <Icon.OtherDreps size={28} color={p.el_gray_medium} />
-      )}
-    </View>
-  )
-}
 
 type IdRowProps = {label: string; value: string}
 

--- a/mobile/src/features/Staking/Governance/useCases/DrepList/DrepListScreen.tsx
+++ b/mobile/src/features/Staking/Governance/useCases/DrepList/DrepListScreen.tsx
@@ -1,4 +1,5 @@
 import {isLeft} from '@yoroi/common'
+import {explorerManager} from '@yoroi/explorers'
 import {
   ActiveDRepEntry,
   governanceApiMaker,
@@ -6,8 +7,9 @@ import {
   useGovernance,
   useStakingKeyState,
 } from '@yoroi/staking'
-import {atoms as a, useTheme} from '@yoroi/theme'
+import {atoms as a, fontSize, useTheme} from '@yoroi/theme'
 import {NotEnoughMoneyToSendError} from '@yoroi/tx'
+import {Chain, Explorers} from '@yoroi/types'
 import {useSelectedWallet} from '@yoroi/wallet-manager'
 
 import {useQuery} from '@tanstack/react-query'
@@ -17,6 +19,7 @@ import {
   ActivityIndicator,
   FlatList,
   Image,
+  Linking,
   Modal,
   Pressable,
   Text,
@@ -261,6 +264,7 @@ type DRepCardProps = {
   onDetails: (drep: DRepDisplay) => void
   isPending: boolean
   isCurrentlyDelegated?: boolean
+  network: Chain.SupportedNetworks
 }
 
 const DRepCard = ({
@@ -269,6 +273,7 @@ const DRepCard = ({
   onDetails,
   isPending,
   isCurrentlyDelegated = false,
+  network,
 }: DRepCardProps) => {
   const {palette: p} = useTheme()
   const strings = useDrepListStrings()
@@ -312,15 +317,26 @@ const DRepCard = ({
           )}
         </View>
 
-        <Text
-          style={[
-            a.heading_4_medium,
-            {color: p.primary_600, textDecorationLine: 'underline', flex: 1},
-          ]}
-          numberOfLines={1}
+        <Pressable
+          onPress={() =>
+            Linking.openURL(
+              explorerManager[network][Explorers.Explorer.Cexplorer].drep(
+                drep.bech32Id,
+              ),
+            )
+          }
+          style={{flex: 1}}
         >
-          {drep.name}
-        </Text>
+          <Text
+            style={[
+              a.heading_4_medium,
+              {color: p.primary_600, textDecorationLine: 'underline'},
+            ]}
+            numberOfLines={1}
+          >
+            {drep.name}
+          </Text>
+        </Pressable>
       </View>
 
       <Space.Height.sm />
@@ -402,6 +418,7 @@ const DRepCard = ({
 export const DrepListScreen = () => {
   const {atoms: ta, palette: p} = useTheme()
   const {wallet, meta} = useSelectedWallet()
+  const network = wallet.networkManager.network
   const {manager} = useGovernance()
   const navigateTo = useNavigateTo()
   const strings = useDrepListStrings()
@@ -570,8 +587,8 @@ export const DrepListScreen = () => {
             placeholderTextColor={p.text_gray_low}
             style={[
               a.flex_1,
-              a.body_2_md_regular,
-              {color: p.text_gray_medium, paddingVertical: 0},
+              a.font_normal,
+              {color: p.text_gray_medium, fontSize: fontSize.sm},
             ]}
             autoCapitalize="none"
             autoCorrect={false}
@@ -605,6 +622,7 @@ export const DrepListScreen = () => {
             onDetails={handleDetails}
             isPending={isPending}
             isCurrentlyDelegated={item.id === currentDelegatedId}
+            network={network}
           />
         )}
         ListEmptyComponent={


### PR DESCRIPTION
## Summary
- Merge develop into preview
- Includes governance UI updates (SF-1236)
- Version bump to 7.0.8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches governance delegation UI and expands the `explorerManager` interface with a new `drep` URL builder, which could affect any downstream code expecting the old explorer type shape. Functionality is mostly UI/linking, but it changes typed APIs and delegation button enablement logic.
> 
> **Overview**
> **Governance DRep UX updates:** `DrepListScreen` now makes the DRep name open the selected explorer’s DRep page (network-aware) and tweaks search input styling. `DrepDetailScreen` disables the **DELEGATE** button when the wallet is already delegated to that DRep, removes the header avatar block, and switches the unverified-metadata icon from `Info` to `Warning`.
> 
> **Explorer support:** Extends `explorerManager`/`ExplorersManager` with a `drep(drepId)` URL builder for Cardanoscan and Cexplorer on Mainnet/Preprod, with updated unit tests.
> 
> **Release:** Bumps `mobile/package.json` version to `7.0.8`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9914b7d20ad2fc19ca6f1d937c5464bb97a78ae5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->